### PR TITLE
Remove namespace from CR

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To deploy it on your cluster:
         spec:
           containers:
             - name: trustyai-operator
-              image: quay.io/ruimvieira/trustyai-service-operator:latest
+              image: quay.io/trustyai/trustyai-service-operator:latest
               command:
                 - /manager
               resources:
@@ -58,6 +58,12 @@ To deploy it on your cluster:
                   cpu: 100m
                   memory: 20Mi
     ```
+
+   or run
+
+   ```shell
+   kubectl apply -f https://raw.githubusercontent.com/trustyai-explainability/trustyai-service-operator/main/artifacts/examples/deploy-operator.yaml   
+   ```
 
 ## Usage
 
@@ -78,6 +84,8 @@ spec:
   storage:
     format: "PVC"
     folder: "/inputs"
+    pv: "mypv"
+    size: "1Gi"
   data:
     filename: "data.csv"
     format: "CSV"
@@ -85,12 +93,14 @@ spec:
     schedule: "5s"
 ```
 
+`mypv` must be an existing Persistent Volume (PV).
+
 You can apply this manifest with 
 
 ```shell
-kubectl apply -f <file-name.yaml> -n $NAMESPACE` to create a service,
+kubectl apply -f <file-name.yaml> -n $NAMESPACE
 ```
-where `$NAMESPACE` is the namespace where you want to deploy it.
+to create a service, where `$NAMESPACE` is the namespace where you want to deploy it.
 
 
 Additionally, in that namespace:

--- a/api/v1alpha1/trustyaiservice_types.go
+++ b/api/v1alpha1/trustyaiservice_types.go
@@ -41,11 +41,6 @@ type MetricsSpec struct {
 
 // TrustyAIServiceSpec defines the desired state of TrustyAIService
 type TrustyAIServiceSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-
-	// The namespace in which to deploy the image
-	Namespace string `json:"namespace"`
 	// The image to deploy
 	// +optional
 	Image string `json:"image,omitempty"`

--- a/artifacts/examples/deploy-operator.yaml
+++ b/artifacts/examples/deploy-operator.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: trustyai-operator
+  namespace: trustyai-operator-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: trustyai-operator
+  template:
+    metadata:
+      labels:
+        control-plane: trustyai-operator
+    spec:
+      containers:
+        - name: trustyai-operator
+          image: quay.io/trustyai/trustyai-service-operator:latest
+          command:
+            - /manager
+          resources:
+            limits:
+              cpu: 100m
+              memory: 30Mi
+            requests:
+              cpu: 100m
+              memory: 20Mi

--- a/artifacts/examples/example-trustyai.yaml
+++ b/artifacts/examples/example-trustyai.yaml
@@ -3,7 +3,6 @@ kind: TrustyAIService
 metadata:
   name: example-trustyai-service
 spec:
-  namespace: default
 #  image: quay.io/trustyai/trustyai-service
 #  tag: latest
   replicas: 1

--- a/config/crd/bases/trustyai.opendatahub.io.trustyai.opendatahub.io_trustyaiservices.yaml
+++ b/config/crd/bases/trustyai.opendatahub.io.trustyai.opendatahub.io_trustyaiservices.yaml
@@ -55,9 +55,6 @@ spec:
                 required:
                 - schedule
                 type: object
-              namespace:
-                description: The namespace in which to deploy the image
-                type: string
               replicas:
                 description: Number of replicas
                 format: int32
@@ -84,7 +81,6 @@ spec:
             required:
             - data
             - metrics
-            - namespace
             - storage
             type: object
           status:


### PR DESCRIPTION
Namespace no longer needed in the CR.
TrustyAI service namespace is taken from where the CR is deployed.
Closes #11 .