### PR TITLE
Use ConfigMap to customise TrustyAI operator's service image

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,36 @@ Additionally, in that namespace:
 * a `ServiceMonitor` will be created to allow Prometheus to scrape metrics from the service.
 * (if on OpenShift) a `Route` will be created to allow external access to the service.
 
+### Custom Image Configuration using ConfigMap
+
+You can configure the operator to use custom images by creating a `ConfigMap` in the operator's namespace. 
+The operator only checks the ConfigMap at deployment, so changes made afterward won't trigger a redeployment of services.
+
+Here's an example of a ConfigMap that specifies a custom image:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trustyai-service-operator-config
+data:
+  trustyaiServiceImageName: 'quay.io/mycustomrepo/mycustomimage'
+  trustyaiServiceImageTag: 'v1.0.0'
+```
+
+You can apply this manifest with the following command, replacing `<file-name.yaml>` with the name of your manifest file:
+
+```shell
+kubectl apply -f <file-name.yaml> -n $OPERATOR_NAMESPACE
+```
+
+Please ensure the namespace specified is the same as the namespace where you have deployed the operator.
+
+After the ConfigMap is applied, you can then proceed to deploy the TrustyAI service.
+The operator will use the image name and tag specified in the ConfigMap for the deployment.
+
+If you want to use a different image or tag in the future, you'll need to update the ConfigMap and redeploy the operator to have the changes take effect. The running TrustyAI services won't be redeployed automatically. To use the new image or tag, you'll need to delete and recreate the TrustyAIService resources.
+
 ## Contributing
 
 Please see the [CONTRIBUTING.md](./CONTRIBUTING.md) file for more details on how to contribute to this project.

--- a/api/v1alpha1/trustyaiservice_types.go
+++ b/api/v1alpha1/trustyaiservice_types.go
@@ -50,12 +50,6 @@ type MetricsSpec struct {
 
 // TrustyAIServiceSpec defines the desired state of TrustyAIService
 type TrustyAIServiceSpec struct {
-	// The image to deploy
-	// +optional
-	Image string `json:"image,omitempty"`
-	// The tag to deploy
-	// +optional
-	Tag string `json:"tag,omitempty"`
 	// Number of replicas
 	// +optional
 	Replicas *int32      `json:"replicas"`

--- a/artifacts/examples/example-config-map.yaml
+++ b/artifacts/examples/example-config-map.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trustyai-service-operator-config
+  namespace: trustyai
+data:
+  trustyaiServiceImageName: "quay.io/trustyai/trustyai-service"
+  trustyaiServiceImageTag: "alpha"

--- a/artifacts/examples/example-config-map.yaml
+++ b/artifacts/examples/example-config-map.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: trustyai-service-operator-config
-  namespace: trustyai
 data:
   trustyaiServiceImageName: "quay.io/trustyai/trustyai-service"
   trustyaiServiceImageTag: "alpha"

--- a/config/crd/bases/trustyai.opendatahub.io.trustyai.opendatahub.io_trustyaiservices.yaml
+++ b/config/crd/bases/trustyai.opendatahub.io.trustyai.opendatahub.io_trustyaiservices.yaml
@@ -45,9 +45,6 @@ spec:
                 - filename
                 - format
                 type: object
-              image:
-                description: The image to deploy
-                type: string
               metrics:
                 properties:
                   schedule:
@@ -75,9 +72,6 @@ spec:
                 - pv
                 - size
                 type: object
-              tag:
-                description: The tag to deploy
-                type: string
             required:
             - data
             - metrics

--- a/controllers/trustyaiservice_controller.go
+++ b/controllers/trustyaiservice_controller.go
@@ -56,8 +56,6 @@ type TrustyAIServiceReconciler struct {
 	client.Client
 	Scheme    *runtime.Scheme
 	Namespace string
-	ImageName string
-	ImageTag  string
 }
 
 //+kubebuilder:rbac:groups=trustyai.opendatahub.io.trustyai.opendatahub.io,resources=trustyaiservices,verbs=get;list;watch;create;update;patch;delete
@@ -221,13 +219,21 @@ func (r *TrustyAIServiceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 func (r *TrustyAIServiceReconciler) ensureDeployment(ctx context.Context, instance *trustyaiopendatahubiov1alpha1.TrustyAIService) (*appsv1.Deployment, error) {
 
+	// Get image and tag from ConfigMap
+	// If there's a ConfigMap with custom images, it is only applied when the operator is first deployed
+	// Changing (or creating) the ConfigMap after the operator is deployed will not have any effect
+	imageName, imageTag, err := r.getImageAndTagFromConfigMap(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	deploy := &appsv1.Deployment{}
-	err := r.Get(ctx, types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, deploy)
+	err = r.Get(ctx, types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, deploy)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Deployment does not exist, create it
 			log.FromContext(ctx).Info("Could not find deployment.")
-			return r.createDeployment(ctx, instance)
+			return r.createDeployment(ctx, instance, imageName, imageTag)
 		}
 
 		// Some other error occurred when trying to get the Deployment
@@ -326,7 +332,7 @@ func (r *TrustyAIServiceReconciler) createPVC(ctx context.Context, instance *tru
 }
 
 // reconcileDeployment returns a Deployment object with the same name/namespace as the cr
-func (r *TrustyAIServiceReconciler) createDeployment(ctx context.Context, cr *trustyaiopendatahubiov1alpha1.TrustyAIService) (*appsv1.Deployment, error) {
+func (r *TrustyAIServiceReconciler) createDeployment(ctx context.Context, cr *trustyaiopendatahubiov1alpha1.TrustyAIService, imageName string, imageTag string) (*appsv1.Deployment, error) {
 
 	labels := getCommonLabels(cr.Name)
 
@@ -338,7 +344,7 @@ func (r *TrustyAIServiceReconciler) createDeployment(ctx context.Context, cr *tr
 	containers := []corev1.Container{
 		{
 			Name:  containerName,
-			Image: fmt.Sprintf("%s:%s", r.ImageName, r.ImageTag),
+			Image: fmt.Sprintf("%s:%s", imageName, imageTag),
 			Env: []corev1.EnvVar{
 				{
 					Name:  "STORAGE_DATA_FILENAME",
@@ -622,14 +628,36 @@ func (r *TrustyAIServiceReconciler) reconcileStatuses(instance *trustyaiopendata
 	return nil
 }
 
-// GetConfigMapValues gets a custom TrustyAI image and tag from a ConfigMap in the operator's namespace
-func GetConfigMapValues(client client.Client, namespace string, configMapName string) (imageName string, imageTag string, err error) {
-	cm := &corev1.ConfigMap{}
-	err = client.Get(context.TODO(), types.NamespacedName{Name: configMapName, Namespace: namespace}, cm)
-	if err != nil {
-		return defaultImage, defaultTag, nil
+// getTrustyAIImageAndTagFromConfigMap gets a custom TrustyAI image and tag from a ConfigMap in the operator's namespace
+func (r *TrustyAIServiceReconciler) getImageAndTagFromConfigMap(ctx context.Context) (string, string, error) {
+	// Define the key for the ConfigMap
+	configMapKey := types.NamespacedName{
+		Namespace: r.Namespace,
+		Name:      "trustyai-service-operator-config",
 	}
-	imageName = cm.Data["trustyaiServiceImageName"]
-	imageTag = cm.Data["trustyaiServiceImageTag"]
+
+	// Create an empty ConfigMap object
+	var cm corev1.ConfigMap
+
+	// Try to get the ConfigMap
+	if err := r.Get(ctx, configMapKey, &cm); err != nil {
+		if errors.IsNotFound(err) {
+			// ConfigMap not found, fallback to default values
+			return defaultImage, defaultTag, nil
+		}
+		// Other error occurred when trying to fetch the ConfigMap
+		return defaultImage, defaultTag, fmt.Errorf("Error reading configmap %s", configMapKey)
+	}
+
+	// ConfigMap is found, extract the image and tag
+	imageName, ok1 := cm.Data["trustyaiServiceImageName"]
+	imageTag, ok2 := cm.Data["trustyaiServiceImageTag"]
+
+	if !ok1 || !ok2 {
+		// One or both of the keys are not present in the ConfigMap, return error
+		return defaultImage, defaultTag, fmt.Errorf("configmap %s does not contain necessary keys", configMapKey)
+	}
+
+	// Return the image and tag
 	return imageName, imageTag, nil
 }

--- a/controllers/trustyaiservice_controller.go
+++ b/controllers/trustyaiservice_controller.go
@@ -54,7 +54,8 @@ const (
 // TrustyAIServiceReconciler reconciles a TrustyAIService object
 type TrustyAIServiceReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme    *runtime.Scheme
+	Namespace string
 }
 
 //+kubebuilder:rbac:groups=trustyai.opendatahub.io.trustyai.opendatahub.io,resources=trustyaiservices,verbs=get;list;watch;create;update;patch;delete
@@ -217,13 +218,22 @@ func (r *TrustyAIServiceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 }
 
 func (r *TrustyAIServiceReconciler) ensureDeployment(ctx context.Context, instance *trustyaiopendatahubiov1alpha1.TrustyAIService) (*appsv1.Deployment, error) {
+
+	// Get image and tag from ConfigMap
+	// If there's a ConfigMap with custom images, it is only applied when the operator is first deployed
+	// Changing (or creating) the ConfigMap after the operator is deployed will not have any effect
+	imageName, imageTag, err := r.getImageAndTagFromConfigMap(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	deploy := &appsv1.Deployment{}
-	err := r.Get(ctx, types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, deploy)
+	err = r.Get(ctx, types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, deploy)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Deployment does not exist, create it
 			log.FromContext(ctx).Info("Could not find deployment.")
-			return r.createDeployment(ctx, instance)
+			return r.createDeployment(ctx, instance, imageName, imageTag)
 		}
 
 		// Some other error occurred when trying to get the Deployment
@@ -322,16 +332,9 @@ func (r *TrustyAIServiceReconciler) createPVC(ctx context.Context, instance *tru
 }
 
 // reconcileDeployment returns a Deployment object with the same name/namespace as the cr
-func (r *TrustyAIServiceReconciler) createDeployment(ctx context.Context, cr *trustyaiopendatahubiov1alpha1.TrustyAIService) (*appsv1.Deployment, error) {
+func (r *TrustyAIServiceReconciler) createDeployment(ctx context.Context, cr *trustyaiopendatahubiov1alpha1.TrustyAIService, imageName string, imageTag string) (*appsv1.Deployment, error) {
 
 	labels := getCommonLabels(cr.Name)
-
-	if cr.Spec.Image == "" {
-		cr.Spec.Image = defaultImage
-	}
-	if cr.Spec.Tag == "" {
-		cr.Spec.Tag = defaultTag
-	}
 
 	replicas := int32(1)
 	if cr.Spec.Replicas == nil {
@@ -341,7 +344,7 @@ func (r *TrustyAIServiceReconciler) createDeployment(ctx context.Context, cr *tr
 	containers := []corev1.Container{
 		{
 			Name:  containerName,
-			Image: fmt.Sprintf("%s:%s", cr.Spec.Image, cr.Spec.Tag),
+			Image: fmt.Sprintf("%s:%s", imageName, imageTag),
 			Env: []corev1.EnvVar{
 				{
 					Name:  "STORAGE_DATA_FILENAME",
@@ -623,4 +626,38 @@ func (r *TrustyAIServiceReconciler) reconcileStatuses(instance *trustyaiopendata
 	}
 
 	return nil
+}
+
+// getTrustyAIImageAndTagFromConfigMap gets a custom TrustyAI image and tag from a ConfigMap in the operator's namespace
+func (r *TrustyAIServiceReconciler) getImageAndTagFromConfigMap(ctx context.Context) (string, string, error) {
+	// Define the key for the ConfigMap
+	configMapKey := types.NamespacedName{
+		Namespace: r.Namespace,
+		Name:      "trustyai-service-operator-config",
+	}
+
+	// Create an empty ConfigMap object
+	var cm corev1.ConfigMap
+
+	// Try to get the ConfigMap
+	if err := r.Get(ctx, configMapKey, &cm); err != nil {
+		if errors.IsNotFound(err) {
+			// ConfigMap not found, fallback to default values
+			return defaultImage, defaultTag, nil
+		}
+		// Other error occurred when trying to fetch the ConfigMap
+		return defaultImage, defaultTag, fmt.Errorf("Error reading configmap %s", configMapKey)
+	}
+
+	// ConfigMap is found, extract the image and tag
+	imageName, ok1 := cm.Data["trustyaiServiceImageName"]
+	imageTag, ok2 := cm.Data["trustyaiServiceImageTag"]
+
+	if !ok1 || !ok2 {
+		// One or both of the keys are not present in the ConfigMap, return error
+		return defaultImage, defaultTag, fmt.Errorf("configmap %s does not contain necessary keys", configMapKey)
+	}
+
+	// Return the image and tag
+	return imageName, imageTag, nil
 }

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -31,6 +31,7 @@ func removeString(list []string, s string) []string {
 	return newList
 }
 
+// GetNamespace returns the namespace of a pod
 func GetNamespace() (string, error) {
 	ns, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err != nil {

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -1,6 +1,9 @@
 package controllers
 
-import appsv1 "k8s.io/api/apps/v1"
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	"os"
+)
 
 func isDeploymentReady(deployment *appsv1.Deployment) bool {
 	return deployment.Status.Replicas == deployment.Status.UpdatedReplicas &&
@@ -26,4 +29,12 @@ func removeString(list []string, s string) []string {
 		}
 	}
 	return newList
+}
+
+func GetNamespace() (string, error) {
+	ns, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		return "", err
+	}
+	return string(ns), nil
 }

--- a/main.go
+++ b/main.go
@@ -99,21 +99,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Get image and tag from ConfigMap
-	// If there's a ConfigMap with custom images, it is only applied when the operator is first deployed
-	// Changing (or creating) the ConfigMap after the operator is deployed will not have any effect
-	imageName, imageTag, err := controllers.GetConfigMapValues(mgr.GetClient(), ns, "trustyai-service-operator-config")
-	if err != nil {
-		setupLog.Error(err, "unable to read ConfigMap")
-		os.Exit(1)
-	}
-
 	if err = (&controllers.TrustyAIServiceReconciler{
 		Client:    mgr.GetClient(),
 		Scheme:    mgr.GetScheme(),
 		Namespace: ns,
-		ImageName: imageName,
-		ImageTag:  imageTag,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "TrustyAIService")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -93,9 +93,16 @@ func main() {
 		os.Exit(1)
 	}
 
+	ns, err := controllers.GetNamespace()
+	if err != nil {
+		setupLog.Error(err, "unable to operator's namespace")
+		os.Exit(1)
+	}
+
 	if err = (&controllers.TrustyAIServiceReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:    mgr.GetClient(),
+		Scheme:    mgr.GetScheme(),
+		Namespace: ns,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "TrustyAIService")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -96,7 +96,6 @@ func main() {
 	ns, err := controllers.GetNamespace()
 	if err != nil {
 		setupLog.Error(err, "unable to operator's namespace")
-		os.Exit(1)
 	}
 
 	if err = (&controllers.TrustyAIServiceReconciler{

--- a/main.go
+++ b/main.go
@@ -99,10 +99,21 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Get image and tag from ConfigMap
+	// If there's a ConfigMap with custom images, it is only applied when the operator is first deployed
+	// Changing (or creating) the ConfigMap after the operator is deployed will not have any effect
+	imageName, imageTag, err := controllers.GetConfigMapValues(mgr.GetClient(), ns, "trustyai-service-operator-config")
+	if err != nil {
+		setupLog.Error(err, "unable to read ConfigMap")
+		os.Exit(1)
+	}
+
 	if err = (&controllers.TrustyAIServiceReconciler{
 		Client:    mgr.GetClient(),
 		Scheme:    mgr.GetScheme(),
 		Namespace: ns,
+		ImageName: imageName,
+		ImageTag:  imageTag,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "TrustyAIService")
 		os.Exit(1)


### PR DESCRIPTION
[RHODS-9182](https://issues.redhat.com/browse/RHODS-9182) / #23 

Configure the operator to use custom images by creating a `ConfigMap` in the operator's namespace. 
The operator only checks the `ConfigMap` at deployment, so changes made afterward won't trigger a redeployment of services.

Example ConfigMap:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: trustyai-service-operator-config
data:
  trustyaiServiceImageName: 'quay.io/mycustomrepo/mycustomimage'
  trustyaiServiceImageTag: 'v1.0.0'
```