### PR TITLE
Refine conditionals in CI install script

### DIFF
--- a/tests/scripts/install.sh
+++ b/tests/scripts/install.sh
@@ -46,8 +46,8 @@ pushd ~/kfdef
 sed -i "s#value: serviceTagPlaceholder#value: latest#" $HOME/peak/operator-tests/trustyai-explainability/resources/trustyai/trustyai_operator_kfdef.yaml
 sed -i "s#value: serviceImagePlaceholder#value: quay.io/trustyai/trustyai-service#" $HOME/peak/operator-tests/trustyai-explainability/resources/trustyai/trustyai_operator_kfdef.yaml
 
-if [ -z "$PULL_NUMBER" ]; then
-  echo "No pull number, not modifying ${KFDEF_FILENAME}"
+if [ -z "$PULL_NUMBER" ] || [ $REPO_NAME -ne "trustyai-service-operator" ];; then
+  echo "No pull number/not correct repo, using default values for ${KFDEF_FILENAME}"
   sed -i "s#value: operatorTagPlaceholder#value: latest#" $HOME/peak/operator-tests/trustyai-explainability/resources/trustyai/trustyai_operator_kfdef.yaml
   sed -i "s#value: operatorImagePlaceholder#value: quay.io/trustyai/trustyai-service-operator#" $HOME/peak/operator-tests/trustyai-explainability/resources/trustyai/trustyai_operator_kfdef.yaml
 else


### PR DESCRIPTION
This will revert to default image values if triggered by a non-trustyai-service-operator PR (i.e., from the main Openshift CI repo)