### PR TITLE
feat: Change `part-of` label to match ODH v2 component name

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -7,6 +7,9 @@ resources:
 - ../rbac
 - ../manager
 
+commonLabels:
+  app.kubernetes.io/part-of: trustyai
+
 patchesStrategicMerge:
 - manager_auth_proxy_patch.yaml
 

--- a/controllers/constants.go
+++ b/controllers/constants.go
@@ -1,0 +1,14 @@
+package controllers
+
+const (
+	defaultImage         = string("quay.io/trustyai/trustyai-service")
+	defaultTag           = string("latest")
+	containerName        = "trustyai-service"
+	componentName        = "trustyai"
+	serviceMonitorName   = "trustyai-metrics"
+	finalizerName        = "trustyai.opendatahub.io.trustyai.opendatahub.io/finalizer"
+	payloadProcessorName = "MM_PAYLOAD_PROCESSORS"
+	modelMeshLabelKey    = "modelmesh-service"
+	modelMeshLabelValue  = "modelmesh-serving"
+	volumeMountName      = "volume"
+)

--- a/controllers/monitor.go
+++ b/controllers/monitor.go
@@ -48,7 +48,7 @@ func generateServiceMonitorSpecCentral(deploymentNamespace string) *monitoringv1
 			},
 			Selector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app.kubernetes.io/part-of": serviceType,
+					"app.kubernetes.io/part-of": componentName,
 				},
 			},
 		},
@@ -117,7 +117,7 @@ func generateServiceMonitorSpecLocal(deploymentNamespace string, serviceName str
 			},
 			Selector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app.kubernetes.io/part-of": serviceType,
+					"app.kubernetes.io/part-of": componentName,
 				},
 			},
 		},

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -243,7 +243,7 @@ var _ = Describe("TrustyAI operator", func() {
 			Expect(deployment.Labels["app"]).Should(Equal(name))
 			Expect(deployment.Labels["app.kubernetes.io/name"]).Should(Equal(name))
 			Expect(deployment.Labels["app.kubernetes.io/instance"]).Should(Equal(name))
-			Expect(deployment.Labels["app.kubernetes.io/part-of"]).Should(Equal(serviceType))
+			Expect(deployment.Labels["app.kubernetes.io/part-of"]).Should(Equal(componentName))
 			Expect(deployment.Labels["app.kubernetes.io/version"]).Should(Equal("0.1.0"))
 
 			Expect(deployment.Spec.Template.Spec.Containers[0].Image).Should(Equal("quay.io/trustyai/trustyai-service:latest"))
@@ -298,7 +298,7 @@ var _ = Describe("TrustyAI operator", func() {
 				Expect(deployment.Labels["app"]).Should(Equal(name))
 				Expect(deployment.Labels["app.kubernetes.io/name"]).Should(Equal(name))
 				Expect(deployment.Labels["app.kubernetes.io/instance"]).Should(Equal(name))
-				Expect(deployment.Labels["app.kubernetes.io/part-of"]).Should(Equal(serviceType))
+				Expect(deployment.Labels["app.kubernetes.io/part-of"]).Should(Equal(componentName))
 				Expect(deployment.Labels["app.kubernetes.io/version"]).Should(Equal("0.1.0"))
 
 				Expect(deployment.Spec.Template.Spec.Containers[0].Image).Should(Equal("quay.io/trustyai/trustyai-service:latest"))

--- a/controllers/trustyaiservice_controller.go
+++ b/controllers/trustyaiservice_controller.go
@@ -38,19 +38,6 @@ import (
 
 var ErrPVCNotReady = goerrors.New("PVC is not ready")
 
-const (
-	defaultImage         = string("quay.io/trustyai/trustyai-service")
-	defaultTag           = string("latest")
-	containerName        = "trustyai-service"
-	serviceMonitorName   = "trustyai-metrics"
-	finalizerName        = "trustyai.opendatahub.io.trustyai.opendatahub.io/finalizer"
-	payloadProcessorName = "MM_PAYLOAD_PROCESSORS"
-	modelMeshLabelKey    = "modelmesh-service"
-	modelMeshLabelValue  = "modelmesh-serving"
-	volumeMountName      = "volume"
-	serviceType          = "trustyai-service"
-)
-
 // TrustyAIServiceReconciler reconciles a TrustyAIService object
 type TrustyAIServiceReconciler struct {
 	client.Client
@@ -80,7 +67,7 @@ func getCommonLabels(serviceName string) map[string]string {
 		"app":                        serviceName,
 		"app.kubernetes.io/name":     serviceName,
 		"app.kubernetes.io/instance": serviceName,
-		"app.kubernetes.io/part-of":  serviceType,
+		"app.kubernetes.io/part-of":  componentName,
 		"app.kubernetes.io/version":  "0.1.0",
 	}
 }


### PR DESCRIPTION
Change TrustyAI operator and resources `app.kubernetes.io/part-of` to `trustyai` in order to match the ODH v2 TrustyAI component name