### PR TITLE
Refactor image env format

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,10 +118,8 @@ spec:
         name: manifests
         path: config
       parameters:
-         - name: trustyaiServiceImageName
+         - name: trustyaiServiceImage
            value: NEW_IMAGE_NAME
-        - name: trustyaiServiceImageTag
-          value: NEW_IMAGE_TAG
     name: trustyai-service-operator
   repos:
   - name: manifests

--- a/artifacts/examples/example-config-map.yaml
+++ b/artifacts/examples/example-config-map.yaml
@@ -3,5 +3,4 @@ kind: ConfigMap
 metadata:
   name: trustyai-service-operator-config
 data:
-  trustyaiServiceImageName: "quay.io/trustyai/trustyai-service"
-  trustyaiServiceImageTag: "latest"
+  trustyaiServiceImage: "quay.io/trustyai/trustyai-service:latest"

--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -24,31 +24,17 @@ generatorOptions:
   disableNameSuffixHash: true
 
 vars:
-  - name: trustyaiServiceImageName
+  - name: trustyaiServiceImage
     objref:
       kind: ConfigMap
       name: config
       apiVersion: v1
     fieldref:
-      fieldpath: data.trustyaiServiceImageName
-  - name: trustyaiServiceImageTag
+      fieldpath: data.trustyaiServiceImage
+  - name: trustyaiOperatorImage
     objref:
       kind: ConfigMap
       name: config
       apiVersion: v1
     fieldref:
-      fieldpath: data.trustyaiServiceImageTag
-  - name: trustyaiOperatorImageName
-    objref:
-      kind: ConfigMap
-      name: config
-      apiVersion: v1
-    fieldref:
-      fieldpath: data.trustyaiOperatorImageName
-  - name: trustyaiOperatorImageTag
-    objref:
-      kind: ConfigMap
-      name: config
-      apiVersion: v1
-    fieldref:
-      fieldpath: data.trustyaiOperatorImageTag
+      fieldpath: data.trustyaiOperatorImage

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -1,4 +1,2 @@
-trustyaiServiceImageName=quay.io/trustyai/trustyai-service
-trustyaiServiceImageTag=latest
-trustyaiOperatorImageName=quay.io/trustyai/trustyai-service-operator
-trustyaiOperatorImageTag=latest
+trustyaiServiceImage=quay.io/trustyai/trustyai-service:latest
+trustyaiOperatorImage=quay.io/trustyai/trustyai-service-operator:latest

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
         - /manager
         args:
         - --leader-elect
-        image: $(trustyaiOperatorImageName):$(trustyaiOperatorImageTag)
+        image: $(trustyaiOperatorImage)
         name: manager
         securityContext:
           runAsNonRoot: true

--- a/controllers/constants.go
+++ b/controllers/constants.go
@@ -1,8 +1,7 @@
 package controllers
 
 const (
-	defaultImage         = string("quay.io/trustyai/trustyai-service")
-	defaultTag           = string("latest")
+	defaultImage         = string("quay.io/trustyai/trustyai-service:latest")
 	containerName        = "trustyai-service"
 	componentName        = "trustyai"
 	serviceMonitorName   = "trustyai-metrics"

--- a/controllers/trustyaiservice_controller.go
+++ b/controllers/trustyaiservice_controller.go
@@ -354,7 +354,7 @@ func (r *TrustyAIServiceReconciler) reconcileStatuses(instance *trustyaiopendata
 }
 
 // getTrustyAIImageAndTagFromConfigMap gets a custom TrustyAI image and tag from a ConfigMap in the operator's namespace
-func (r *TrustyAIServiceReconciler) getImageAndTagFromConfigMap(ctx context.Context) (string, string, error) {
+func (r *TrustyAIServiceReconciler) getImageFromConfigMap(ctx context.Context) (string, error) {
 	if r.Namespace != "" {
 		// Define the key for the ConfigMap
 		configMapKey := types.NamespacedName{
@@ -369,24 +369,23 @@ func (r *TrustyAIServiceReconciler) getImageAndTagFromConfigMap(ctx context.Cont
 		if err := r.Get(ctx, configMapKey, &cm); err != nil {
 			if errors.IsNotFound(err) {
 				// ConfigMap not found, fallback to default values
-				return defaultImage, defaultTag, nil
+				return defaultImage, nil
 			}
 			// Other error occurred when trying to fetch the ConfigMap
-			return defaultImage, defaultTag, fmt.Errorf("Error reading configmap %s", configMapKey)
+			return defaultImage, fmt.Errorf("Error reading configmap %s", configMapKey)
 		}
 
 		// ConfigMap is found, extract the image and tag
-		imageName, ok1 := cm.Data["trustyaiServiceImageName"]
-		imageTag, ok2 := cm.Data["trustyaiServiceImageTag"]
+		image, ok := cm.Data["trustyaiServiceImage"]
 
-		if !ok1 || !ok2 {
+		if !ok {
 			// One or both of the keys are not present in the ConfigMap, return error
-			return defaultImage, defaultTag, fmt.Errorf("configmap %s does not contain necessary keys", configMapKey)
+			return defaultImage, fmt.Errorf("configmap %s does not contain necessary keys", configMapKey)
 		}
 
 		// Return the image and tag
-		return imageName, imageTag, nil
+		return image, nil
 	} else {
-		return defaultImage, defaultTag, nil
+		return defaultImage, nil
 	}
 }


### PR DESCRIPTION
For compatibility with ODHv2, the param.env is now in the format:

```yaml
trustyaiOperatorImage: "quay.io/trustyai/trustyai-service-operator:latest"
trustyaiServiceImage: "quay.io/trustyai/trustyai-service:latest"
```

instead of

```yaml
trustyaiOperatorImageName: "quay.io/trustyai/trustyai-service-operator"
trustyaiOperatorImageTag: "latest"
trustyaiServiceImageName: "quay.io/trustyai/trustyai-service"
trustyaiServiceImageTag: "latest"
```
