### PR TITLE
Implement lifecycle events.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 VERSION ?= 0.0.1
 
+BUILD_TOOL ?= podman
+
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
 # To re-generate a bundle for other specific channels without changing the standard setup, you can:
@@ -120,11 +122,11 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} .
+	$(BUILD_TOOL) build -t ${IMG} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
-	docker push ${IMG}
+	$(BUILD_TOOL) push ${IMG}
 
 # PLATFORMS defines the target platforms for  the manager image be build to provide support to multiple
 # architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
@@ -212,7 +214,7 @@ bundle: manifests kustomize ## Generate bundle manifests and metadata, then vali
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
-	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+	$BUILD_TOOL build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -20,6 +20,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - create

--- a/controllers/constants.go
+++ b/controllers/constants.go
@@ -31,3 +31,10 @@ const (
 	StatusReasonRouteNotFound             = "RouteNotFound"
 	StatusReasonRouteFound                = "RouteFound"
 )
+
+// Event reasons
+const (
+	EventReasonPVCCreated                 = "PVCCreated"
+	EventReasonInferenceServiceConfigured = "InferenceServiceConfigured"
+	EventReasonServiceMonitorCreated      = "ServiceMonitorCreated"
+)

--- a/controllers/events.go
+++ b/controllers/events.go
@@ -1,0 +1,22 @@
+package controllers
+
+import (
+	trustyaiopendatahubiov1alpha1 "github.com/trustyai-explainability/trustyai-service-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func (r *TrustyAIServiceReconciler) eventModelMeshConfigured(instance *trustyaiopendatahubiov1alpha1.TrustyAIService) {
+	r.EventRecorder.Event(instance, corev1.EventTypeNormal, EventReasonInferenceServiceConfigured, "ModelMesh InferenceService configured")
+}
+
+func (r *TrustyAIServiceReconciler) eventKServeConfigured(instance *trustyaiopendatahubiov1alpha1.TrustyAIService) {
+	r.EventRecorder.Event(instance, corev1.EventTypeNormal, EventReasonInferenceServiceConfigured, "KServe InferenceService configured")
+}
+
+func (r *TrustyAIServiceReconciler) eventPVCCreated(instance *trustyaiopendatahubiov1alpha1.TrustyAIService) {
+	r.EventRecorder.Event(instance, corev1.EventTypeNormal, EventReasonPVCCreated, "PVC created")
+}
+
+func (r *TrustyAIServiceReconciler) eventLocalServiceMonitorCreated(instance *trustyaiopendatahubiov1alpha1.TrustyAIService) {
+	r.EventRecorder.Event(instance, corev1.EventTypeNormal, EventReasonServiceMonitorCreated, "Local ServiceMonitor created")
+}

--- a/controllers/finalizers.go
+++ b/controllers/finalizers.go
@@ -2,13 +2,21 @@ package controllers
 
 import (
 	"context"
+	trustyaiopendatahubiov1alpha1 "github.com/trustyai-explainability/trustyai-service-operator/api/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // deleteExternalDependency removes the payload processor from the ModelMesh deployment
-func (r *TrustyAIServiceReconciler) deleteExternalDependency(crName, namespace string, ctx context.Context) error {
+func (r *TrustyAIServiceReconciler) deleteExternalDependency(crName string, instance *trustyaiopendatahubiov1alpha1.TrustyAIService, namespace string, ctx context.Context) error {
 	// Call patchEnvVarsByLabelForDeployments with remove set to true
-	_, err := r.patchEnvVarsByLabelForDeployments(ctx, namespace, modelMeshLabelKey, modelMeshLabelValue, payloadProcessorName, crName, true)
+	_, err := r.patchEnvVarsByLabelForDeployments(ctx,
+		instance,
+		namespace,
+		modelMeshLabelKey,
+		modelMeshLabelValue,
+		payloadProcessorName,
+		crName,
+		true)
 	if err != nil {
 		log.FromContext(ctx).Error(err, "Could not remove environment variable from ModelMesh Deployment.")
 		// Do not return the error to avoid finalizer loop if the namespace or other resources are deleted

--- a/controllers/monitor.go
+++ b/controllers/monitor.go
@@ -145,6 +145,8 @@ func (r *TrustyAIServiceReconciler) ensureLocalServiceMonitor(cr *trustyaiopenda
 			if err != nil {
 				log.FromContext(ctx).Error(err, "Failed to create local ServiceMonitor", "ServiceMonitor.Namespace", serviceMonitor.Namespace, "ServiceMonitor.Name", serviceMonitor.Name)
 				return err
+			} else {
+				r.eventLocalServiceMonitorCreated(cr)
 			}
 		} else {
 			log.FromContext(ctx).Error(err, "Failed to get local ServiceMonitor", "ServiceMonitor.Namespace", serviceMonitor.Namespace, "ServiceMonitor.Name", serviceMonitor.Name)

--- a/controllers/statuses.go
+++ b/controllers/statuses.go
@@ -32,7 +32,6 @@ func (r *TrustyAIServiceReconciler) updateStatus(ctx context.Context, original *
 
 func UpdateInferenceServiceNotPresent(saved *trustyaiopendatahubiov1alpha1.TrustyAIService) {
 	saved.SetStatus(StatusTypeInferenceServicesPresent, StatusReasonInferenceServicesNotFound, "InferenceServices not found", v1.ConditionFalse)
-	saved.Status.Phase = "Not Ready"
 	saved.Status.Ready = v1.ConditionFalse
 
 }

--- a/controllers/storage.go
+++ b/controllers/storage.go
@@ -26,7 +26,14 @@ func (r *TrustyAIServiceReconciler) ensurePVC(ctx context.Context, instance *tru
 		if apierrors.IsNotFound(err) {
 			log.FromContext(ctx).Info("PVC not found. Creating.")
 			// The PVC doesn't exist, so we need to create it
-			return r.createPVC(ctx, instance)
+
+			creationErr := r.createPVC(ctx, instance)
+			if creationErr == nil {
+				// Creation successful, emit Event
+				log.FromContext(ctx).Info("Created PVC " + pvcName + ".")
+				r.eventPVCCreated(instance)
+			}
+			return creationErr
 		}
 		return err
 	}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -267,10 +267,13 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
+	recorder := k8sManager.GetEventRecorderFor("trustyai-service-operator")
+
 	err = (&TrustyAIServiceReconciler{
 		Client: k8sManager.GetClient(),
 		//Log:    ctrl.Log.WithName("controllers").WithName("YourController"),
-		Scheme: k8sManager.GetScheme(),
+		Scheme:        k8sManager.GetScheme(),
+		EventRecorder: recorder,
 	}).SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/main.go
+++ b/main.go
@@ -97,15 +97,18 @@ func main() {
 		os.Exit(1)
 	}
 
+	recorder := mgr.GetEventRecorderFor("trustyai-service-operator")
+
 	ns, err := controllers.GetNamespace()
 	if err != nil {
 		setupLog.Error(err, "unable to operator's namespace")
 	}
 
 	if err = (&controllers.TrustyAIServiceReconciler{
-		Client:    mgr.GetClient(),
-		Scheme:    mgr.GetScheme(),
-		Namespace: ns,
+		Client:        mgr.GetClient(),
+		Scheme:        mgr.GetScheme(),
+		Namespace:     ns,
+		EventRecorder: recorder,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "TrustyAIService")
 		os.Exit(1)


### PR DESCRIPTION
Add Kubernetes events to the `TrustyAIService`:

- `PVCCreated`
- `InferenceServiceConfigured`
- `ServiceMonitorCreated`

The Ready condition has also been refactored, in order to be set only at the end of a successful (for the Readiness criteria) reconcilition.

By moving the Readiness check as the last step of the reconciliation, this PR also addresses https://github.com/trustyai-explainability/trustyai-service-operator/issues/76.
