### PR TITLE
Deploy TrustyAI editor and viewer roles

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -8,3 +8,5 @@ resources:
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
 - auth_proxy_client_clusterrole.yaml
+- trustyaiservice_editor_role.yaml
+- trustyaiservice_viewer_role.yaml


### PR DESCRIPTION
This PR adds the `TrustyAIService` viewer and editor roles to the operator's default deployments.