### PR TITLE
Operator reads inject CA ConfigMaps

### DIFF
--- a/controllers/certificates.go
+++ b/controllers/certificates.go
@@ -1,0 +1,25 @@
+package controllers
+
+import (
+	"context"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// getConfigMapNamesWithLabel retrieves the names of ConfigMaps that have the specified label
+func (r *TrustyAIServiceReconciler) getConfigMapNamesWithLabel(ctx context.Context, namespace string, labelSelector client.MatchingLabels) ([]string, error) {
+	configMapList := &corev1.ConfigMapList{}
+
+	// List ConfigMaps with the specified label selector
+	err := r.Client.List(ctx, configMapList, client.InNamespace(namespace), labelSelector)
+	if err != nil {
+		return nil, err
+	}
+
+	var names []string
+	for _, cm := range configMapList.Items {
+		names = append(names, cm.Name)
+	}
+
+	return names, nil
+}

--- a/controllers/deployment.go
+++ b/controllers/deployment.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"strconv"
 )
@@ -106,6 +107,53 @@ func (r *TrustyAIServiceReconciler) createDeploymentObject(ctx context.Context, 
 			},
 		},
 	}
+
+	// Check if the CA bundle ConfigMap exists
+	labelSelector := client.MatchingLabels{"config.openshift.io/inject-trusted-cabundle": "true"}
+	configMapNames, err := r.getConfigMapNamesWithLabel(ctx, cr.Namespace, labelSelector)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "Error checking for trusted CA bundle ConfigMap. Using no custom CA bundle.")
+	} else {
+		var selectedConfigMapName string
+		if len(configMapNames) > 0 {
+			selectedConfigMapName = configMapNames[0]
+
+			if selectedConfigMapName != "" {
+				volumeName := "trusted-ca"
+
+				// Create the ConfigMap volume object
+				configMapVolume := corev1.Volume{
+					Name: volumeName,
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: selectedConfigMapName,
+							},
+							Items: []corev1.KeyToPath{
+								{
+									Key:  "ca-bundle.crt",
+									Path: "tls-ca-bundle.pem",
+								},
+							},
+						},
+					},
+				}
+
+				deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, configMapVolume)
+
+				volumeMount := corev1.VolumeMount{
+					Name:      volumeName,
+					MountPath: "/etc/pki/ca-trust/extracted/pem",
+					ReadOnly:  true,
+				}
+
+				// Add the volume mount to the service's container
+				deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts, volumeMount)
+
+			}
+		}
+	}
+
 	return deployment
 }
 


### PR DESCRIPTION
This PR adds the ability to pass [custom certificates injected](https://docs.openshift.com/container-platform/4.14/networking/configuring-a-custom-pki.html#certificate-injection-using-operators_configuring-a-custom-pki) into the namespace via `ConfigMap` to the TrustyAI operator's deployments.

- If a `ConfigMap` with custom CAs (labelled `"config.openshift.io/inject-trusted-cabundle": "true"`) exist, they will be mounted in the service (and also in the OAuth container in the future).
- If it is not present, the deployment will stay as before the PR.