### PR TITLE
Add Available condition and checks

### DIFF
--- a/controllers/constants.go
+++ b/controllers/constants.go
@@ -20,6 +20,7 @@ const (
 	StatusTypeInferenceServicesPresent = "InferenceServicesPresent"
 	StatusTypePVCAvailable             = "PVCAvailable"
 	StatusTypeRouteAvailable           = "RouteAvailable"
+	StatusTypeAvailable                = "Available"
 )
 
 // Status reasons
@@ -30,6 +31,8 @@ const (
 	StatusReasonPVCFound                  = "PVCFound"
 	StatusReasonRouteNotFound             = "RouteNotFound"
 	StatusReasonRouteFound                = "RouteFound"
+	StatusAvailable                       = "AllComponentsReady"
+	StatusNotAvailable                    = "NotAllComponentsReady"
 )
 
 // Event reasons

--- a/controllers/inference_services.go
+++ b/controllers/inference_services.go
@@ -138,11 +138,6 @@ func (r *TrustyAIServiceReconciler) handleInferenceServices(ctx context.Context,
 	}
 
 	if len(inferenceServices.Items) == 0 {
-		_, updateErr := r.updateStatus(ctx, instance, UpdateInferenceServiceNotPresent)
-		if updateErr != nil {
-			log.FromContext(ctx).Error(updateErr, "Could not update status for InferenceService not present")
-			return false, updateErr
-		}
 		return true, nil
 	}
 
@@ -162,13 +157,6 @@ func (r *TrustyAIServiceReconciler) handleInferenceServices(ctx context.Context,
 				return false, err
 			}
 		}
-	}
-
-	instance.SetStatus("InferenceServicesPresent", "InferenceServicesFound", "InferenceServices found", corev1.ConditionTrue)
-	_, updateErr := r.updateStatus(ctx, instance, UpdateInferenceServicePresent)
-	if updateErr != nil {
-		log.FromContext(ctx).Error(updateErr, "Could not update status for InferenceService present")
-		return false, updateErr
 	}
 	return true, nil
 }
@@ -215,4 +203,13 @@ func (r *TrustyAIServiceReconciler) patchKServe(ctx context.Context, instance *t
 		return fmt.Errorf("failed to update InferenceService %s/%s: %v", infService.Namespace, infService.Name, err)
 	}
 	return nil
+}
+
+func (r *TrustyAIServiceReconciler) checkInferenceServicesPresent(ctx context.Context, namespace string) (bool, error) {
+	infServiceList := &kservev1beta1.InferenceServiceList{}
+	if err := r.List(ctx, infServiceList, client.InNamespace(namespace)); err != nil {
+		return false, err
+	}
+
+	return len(infServiceList.Items) > 0, nil
 }

--- a/controllers/route_test.go
+++ b/controllers/route_test.go
@@ -8,12 +8,14 @@ import (
 	trustyaiopendatahubiov1alpha1 "github.com/trustyai-explainability/trustyai-service-operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	"time"
 )
 
 var _ = Describe("Route Reconciliation", func() {
 
 	BeforeEach(func() {
+		recorder = record.NewFakeRecorder(10)
 		reconciler = &TrustyAIServiceReconciler{
 			Client:        k8sClient,
 			Scheme:        scheme.Scheme,

--- a/controllers/statuses.go
+++ b/controllers/statuses.go
@@ -5,9 +5,23 @@ import (
 	trustyaiopendatahubiov1alpha1 "github.com/trustyai-explainability/trustyai-service-operator/api/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+// IsAllReady checks if all the necessary readiness fields are true.
+func (rs *AvailabilityStatus) IsAllReady() bool {
+	return rs.PVCReady && rs.DeploymentReady && rs.RouteReady
+}
+
+// AvailabilityStatus holds the readiness status of various resources.
+type AvailabilityStatus struct {
+	PVCReady              bool
+	DeploymentReady       bool
+	RouteReady            bool
+	InferenceServiceReady bool
+}
 
 func (r *TrustyAIServiceReconciler) updateStatus(ctx context.Context, original *trustyaiopendatahubiov1alpha1.TrustyAIService, update func(saved *trustyaiopendatahubiov1alpha1.TrustyAIService),
 ) (*trustyaiopendatahubiov1alpha1.TrustyAIService, error) {
@@ -17,7 +31,7 @@ func (r *TrustyAIServiceReconciler) updateStatus(ctx context.Context, original *
 		if err != nil {
 			return err
 		}
-		// update status here
+		// Update status here
 		update(saved)
 
 		// Try to update
@@ -28,6 +42,85 @@ func (r *TrustyAIServiceReconciler) updateStatus(ctx context.Context, original *
 		log.FromContext(ctx).Error(err, "Failed to update TrustyAIService status")
 	}
 	return saved, err
+}
+
+// reconcileStatuses checks the readiness status of PVC, Deployment, Route and Inference Services
+func (r *TrustyAIServiceReconciler) reconcileStatuses(ctx context.Context, instance *trustyaiopendatahubiov1alpha1.TrustyAIService) (ctrl.Result, error) {
+	var err error
+	status := AvailabilityStatus{}
+
+	// Check for PVC readiness
+	status.PVCReady, err = r.checkPVCReady(ctx, instance)
+	if err != nil || !status.PVCReady {
+		// PVC not ready, requeue
+		return Requeue()
+	}
+
+	// Check for deployment readiness
+	status.DeploymentReady, err = r.checkDeploymentReady(ctx, instance)
+	if err != nil || !status.DeploymentReady {
+		// Deployment not ready, requeue
+		return Requeue()
+	}
+
+	// Check for route readiness
+	status.RouteReady, err = r.checkRouteReady(ctx, instance)
+	if err != nil || !status.RouteReady {
+		// Route not ready, requeue
+		return Requeue()
+	}
+
+	// Check if InferenceServices present
+	status.InferenceServiceReady, err = r.checkInferenceServicesPresent(ctx, instance.Namespace)
+
+	// All checks passed, resources are ready
+	if status.IsAllReady() {
+		_, updateErr := r.updateStatus(ctx, instance, func(saved *trustyaiopendatahubiov1alpha1.TrustyAIService) {
+
+			if status.InferenceServiceReady {
+				UpdateInferenceServicePresent(saved)
+			} else {
+				UpdateInferenceServiceNotPresent(saved)
+			}
+
+			UpdatePVCAvailable(saved)
+			UpdateRouteAvailable(saved)
+			UpdateTrustyAIServiceAvailable(saved)
+			saved.Status.Phase = "Ready"
+			saved.Status.Ready = v1.ConditionTrue
+		})
+		if updateErr != nil {
+			return RequeueWithErrorMessage(ctx, err, "Failed to update status")
+		}
+	} else {
+		_, updateErr := r.updateStatus(ctx, instance, func(saved *trustyaiopendatahubiov1alpha1.TrustyAIService) {
+
+			if status.InferenceServiceReady {
+				UpdateInferenceServicePresent(saved)
+			} else {
+				UpdateInferenceServiceNotPresent(saved)
+			}
+
+			if status.PVCReady {
+				UpdatePVCAvailable(saved)
+			} else {
+				UpdatePVCNotAvailable(saved)
+			}
+			if status.RouteReady {
+				UpdateRouteAvailable(saved)
+			} else {
+				UpdateRouteNotAvailable(saved)
+			}
+			UpdateTrustyAIServiceNotAvailable(saved)
+			saved.Status.Phase = "Ready"
+			saved.Status.Ready = v1.ConditionFalse
+		})
+		if updateErr != nil {
+			return RequeueWithErrorMessage(ctx, err, "Failed to update status")
+		}
+	}
+	// All resources are reconciled, return no error and do not requeue
+	return ctrl.Result{}, nil
 }
 
 func UpdateInferenceServiceNotPresent(saved *trustyaiopendatahubiov1alpha1.TrustyAIService) {
@@ -56,4 +149,12 @@ func UpdateRouteAvailable(saved *trustyaiopendatahubiov1alpha1.TrustyAIService) 
 
 func UpdateRouteNotAvailable(saved *trustyaiopendatahubiov1alpha1.TrustyAIService) {
 	saved.SetStatus(StatusTypeRouteAvailable, StatusReasonRouteNotFound, "Route not found", v1.ConditionFalse)
+}
+
+func UpdateTrustyAIServiceAvailable(saved *trustyaiopendatahubiov1alpha1.TrustyAIService) {
+	saved.SetStatus(StatusTypeAvailable, StatusAvailable, StatusAvailable, v1.ConditionTrue)
+}
+
+func UpdateTrustyAIServiceNotAvailable(saved *trustyaiopendatahubiov1alpha1.TrustyAIService) {
+	saved.SetStatus(StatusTypeAvailable, StatusNotAvailable, "Not all components available", v1.ConditionFalse)
 }

--- a/controllers/statuses_test.go
+++ b/controllers/statuses_test.go
@@ -1,0 +1,225 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	trustyaiopendatahubiov1alpha1 "github.com/trustyai-explainability/trustyai-service-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"time"
+)
+
+func checkCondition(conditions []trustyaiopendatahubiov1alpha1.Condition, conditionType string, expectedStatus corev1.ConditionStatus, allowMissing bool) (*trustyaiopendatahubiov1alpha1.Condition, bool, error) {
+	for _, cond := range conditions {
+		if cond.Type == conditionType {
+			isExpectedStatus := cond.Status == expectedStatus
+			return &cond, isExpectedStatus, nil
+		}
+	}
+	if allowMissing {
+		return nil, false, nil
+	}
+	return nil, false, fmt.Errorf("%s condition not found", conditionType)
+}
+
+var _ = Describe("Status and condition tests", func() {
+
+	BeforeEach(func() {
+		k8sClient = fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+		recorder = record.NewFakeRecorder(10)
+		reconciler = &TrustyAIServiceReconciler{
+			Client:        k8sClient,
+			Scheme:        scheme.Scheme,
+			EventRecorder: recorder,
+		}
+		ctx = context.Background()
+	})
+
+	Context("When no component exists", func() {
+		var instance *trustyaiopendatahubiov1alpha1.TrustyAIService
+		It("Should not be available", func() {
+			namespace := "statuses-test-namespace-1"
+			instance = createDefaultCR(namespace)
+
+			Eventually(func() error {
+				return createNamespace(ctx, k8sClient, namespace)
+			}, time.Second*10, time.Millisecond*250).Should(Succeed(), "failed to create namespace")
+
+			// Call the reconcileStatuses function
+			_, _ = reconciler.reconcileStatuses(ctx, instance)
+
+			readyCondition, statusMatch, err := checkCondition(instance.Status.Conditions, "Ready", corev1.ConditionTrue, true)
+			Expect(err).NotTo(HaveOccurred(), "Error checking Ready condition")
+			if readyCondition != nil {
+				Expect(statusMatch).To(Equal(corev1.ConditionFalse), "Ready condition should be true")
+			}
+
+			availableCondition, statusMatch, err := checkCondition(instance.Status.Conditions, StatusTypeAvailable, corev1.ConditionFalse, true)
+			Expect(err).NotTo(HaveOccurred(), "Error checking Available condition")
+			if availableCondition != nil {
+				Expect(statusMatch).To(Equal(corev1.ConditionFalse), "Available condition should be false")
+			}
+
+		})
+	})
+
+	Context("When route, deployment and PVC component, but not inference service, exist", func() {
+		var instance *trustyaiopendatahubiov1alpha1.TrustyAIService
+		It("Should be available", func() {
+			namespace := "statuses-test-namespace-2"
+			instance = createDefaultCR(namespace)
+			Eventually(func() error {
+				return createNamespace(ctx, k8sClient, namespace)
+			}, time.Second*10, time.Millisecond*250).Should(Succeed(), "failed to create namespace")
+			Eventually(func() error {
+				return reconciler.reconcileRoute(instance, ctx)
+			}, time.Second*10, time.Millisecond*250).Should(Succeed(), "failed to create route")
+			Eventually(func() error {
+				return makeRouteReady(ctx, k8sClient, instance)
+			}, time.Second*10, time.Millisecond*250).Should(Succeed(), "failed to make route ready")
+			Eventually(func() error {
+				return reconciler.ensurePVC(ctx, instance)
+			}, time.Second*10, time.Millisecond*250).Should(Succeed(), "failed to create PVC")
+			Eventually(func() error {
+				return makePVCReady(ctx, k8sClient, instance)
+			}, time.Second*10, time.Millisecond*250).Should(Succeed(), "failed to bind PVC")
+			Eventually(func() error {
+				return reconciler.ensureDeployment(ctx, instance)
+			}, time.Second*10, time.Millisecond*250).Should(Succeed(), "failed to create deployment")
+			Eventually(func() error {
+				return makeDeploymentReady(ctx, k8sClient, instance)
+			}, time.Second*10, time.Millisecond*250).Should(Succeed(), "failed to make deployment ready")
+
+			Eventually(func() error {
+				return k8sClient.Create(ctx, instance)
+			}, time.Second*10, time.Millisecond*250).Should(Succeed(), "failed to create TrustyAIService")
+
+			// Call the reconcileStatuses function
+			Eventually(func() error {
+				_, err := reconciler.reconcileStatuses(ctx, instance)
+				return err
+			}, time.Second*10, time.Millisecond*250).Should(Succeed(), "failed to update statuses")
+
+			// Fetch the updated instance
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name:      instance.Name,
+					Namespace: instance.Namespace,
+				}, instance)
+			}, time.Second*10, time.Millisecond*250).Should(Succeed(), "failed to get updated instance")
+
+			readyCondition, statusMatch, err := checkCondition(instance.Status.Conditions, "Ready", corev1.ConditionTrue, true)
+			Expect(err).NotTo(HaveOccurred(), "Error checking Ready condition")
+			if readyCondition != nil {
+				Expect(statusMatch).To(Equal(corev1.ConditionTrue), "Ready condition should be true")
+			}
+
+			availableCondition, statusMatch, err := checkCondition(instance.Status.Conditions, StatusTypeAvailable, corev1.ConditionTrue, false)
+			Expect(err).NotTo(HaveOccurred(), "Error checking Available condition")
+			Expect(availableCondition).NotTo(BeNil(), "Available condition should not be null")
+			Expect(statusMatch).To(Equal(true), "Ready condition should be true")
+
+			routeAvailableCondition, statusMatch, err := checkCondition(instance.Status.Conditions, StatusTypeRouteAvailable, corev1.ConditionTrue, false)
+			Expect(err).NotTo(HaveOccurred(), "Error checking RouteAvailable condition")
+			Expect(routeAvailableCondition).NotTo(BeNil(), "RouteAvailable condition should not be null")
+			Expect(statusMatch).To(Equal(true), "RouteAvailable condition should be true")
+
+			pvcAvailableCondition, statusMatch, err := checkCondition(instance.Status.Conditions, StatusTypePVCAvailable, corev1.ConditionTrue, false)
+			Expect(err).NotTo(HaveOccurred(), "Error checking PVCAvailable condition")
+			Expect(pvcAvailableCondition).NotTo(BeNil(), "PVCAvailable condition should not be null")
+			Expect(statusMatch).To(Equal(true), "PVCAvailable condition should be true")
+
+			ISPresentCondition, statusMatch, err := checkCondition(instance.Status.Conditions, StatusTypeInferenceServicesPresent, corev1.ConditionFalse, false)
+			Expect(err).NotTo(HaveOccurred(), "Error checking InferenceServicePresent condition")
+			Expect(ISPresentCondition).NotTo(BeNil(), "InferenceServicePresent condition should not be null")
+			Expect(statusMatch).To(Equal(true), "InferenceServicePresent condition should be false")
+		})
+	})
+
+	Context("When route, deployment, PVC and inference service components exist", func() {
+		var instance *trustyaiopendatahubiov1alpha1.TrustyAIService
+		It("Should be available", func() {
+			namespace := "statuses-test-namespace-2"
+			instance = createDefaultCR(namespace)
+			Eventually(func() error {
+				return createNamespace(ctx, k8sClient, namespace)
+			}, time.Second*10, time.Millisecond*250).Should(Succeed(), "failed to create namespace")
+			Eventually(func() error {
+				return reconciler.reconcileRoute(instance, ctx)
+			}, time.Second*10, time.Millisecond*250).Should(Succeed(), "failed to create route")
+			Eventually(func() error {
+				return makeRouteReady(ctx, k8sClient, instance)
+			}, time.Second*10, time.Millisecond*250).Should(Succeed(), "failed to make route ready")
+			Eventually(func() error {
+				return reconciler.ensurePVC(ctx, instance)
+			}, time.Second*10, time.Millisecond*250).Should(Succeed(), "failed to create PVC")
+			Eventually(func() error {
+				return makePVCReady(ctx, k8sClient, instance)
+			}, time.Second*10, time.Millisecond*250).Should(Succeed(), "failed to bind PVC")
+			Eventually(func() error {
+				return reconciler.ensureDeployment(ctx, instance)
+			}, time.Second*10, time.Millisecond*250).Should(Succeed(), "failed to create deployment")
+			Eventually(func() error {
+				return makeDeploymentReady(ctx, k8sClient, instance)
+			}, time.Second*10, time.Millisecond*250).Should(Succeed(), "failed to make deployment ready")
+
+			inferenceService := createInferenceService("my-model", namespace)
+			Eventually(func() error {
+				return k8sClient.Create(ctx, inferenceService)
+			}, time.Second*10, time.Millisecond*250).Should(Succeed(), "failed to create InferenceService")
+
+			Expect(reconciler.patchKServe(ctx, instance, *inferenceService, namespace, instance.Name, false)).ToNot(HaveOccurred())
+
+			Eventually(func() error {
+				return k8sClient.Create(ctx, instance)
+			}, time.Second*10, time.Millisecond*250).Should(Succeed(), "failed to create TrustyAIService")
+
+			// Call the reconcileStatuses function
+			Eventually(func() error {
+				_, err := reconciler.reconcileStatuses(ctx, instance)
+				return err
+			}, time.Second*10, time.Millisecond*250).Should(Succeed(), "failed to update statuses")
+
+			// Fetch the updated instance
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name:      instance.Name,
+					Namespace: instance.Namespace,
+				}, instance)
+			}, time.Second*10, time.Millisecond*250).Should(Succeed(), "failed to get updated instance")
+
+			readyCondition, statusMatch, err := checkCondition(instance.Status.Conditions, "Ready", corev1.ConditionTrue, true)
+			Expect(err).NotTo(HaveOccurred(), "Error checking Ready condition")
+			if readyCondition != nil {
+				Expect(statusMatch).To(Equal(corev1.ConditionTrue), "Ready condition should be true")
+			}
+
+			availableCondition, statusMatch, err := checkCondition(instance.Status.Conditions, StatusTypeAvailable, corev1.ConditionTrue, false)
+			Expect(err).NotTo(HaveOccurred(), "Error checking Available condition")
+			Expect(availableCondition).NotTo(BeNil(), "Available condition should not be null")
+			Expect(statusMatch).To(Equal(true), "Ready condition should be true")
+
+			routeAvailableCondition, statusMatch, err := checkCondition(instance.Status.Conditions, StatusTypeRouteAvailable, corev1.ConditionTrue, false)
+			Expect(err).NotTo(HaveOccurred(), "Error checking RouteAvailable condition")
+			Expect(routeAvailableCondition).NotTo(BeNil(), "RouteAvailable condition should not be null")
+			Expect(statusMatch).To(Equal(true), "RouteAvailable condition should be true")
+
+			pvcAvailableCondition, statusMatch, err := checkCondition(instance.Status.Conditions, StatusTypePVCAvailable, corev1.ConditionTrue, false)
+			Expect(err).NotTo(HaveOccurred(), "Error checking PVCAvailable condition")
+			Expect(pvcAvailableCondition).NotTo(BeNil(), "PVCAvailable condition should not be null")
+			Expect(statusMatch).To(Equal(true), "PVCAvailable condition should be true")
+
+			ISPresentCondition, statusMatch, err := checkCondition(instance.Status.Conditions, StatusTypeInferenceServicesPresent, corev1.ConditionTrue, false)
+			Expect(err).NotTo(HaveOccurred(), "Error checking InferenceServicePresent condition")
+			Expect(ISPresentCondition).NotTo(BeNil(), "InferenceServicePresent condition should not be null")
+			Expect(statusMatch).To(Equal(true), "InferenceServicePresent condition should be true")
+
+		})
+	})
+
+})

--- a/controllers/storage.go
+++ b/controllers/storage.go
@@ -67,3 +67,22 @@ func (r *TrustyAIServiceReconciler) createPVC(ctx context.Context, instance *tru
 
 	return r.Create(ctx, pvc)
 }
+
+func (r *TrustyAIServiceReconciler) checkPVCReady(ctx context.Context, instance *trustyaiopendatahubiov1alpha1.TrustyAIService) (bool, error) {
+	pvc := &corev1.PersistentVolumeClaim{}
+
+	err := r.Get(ctx, types.NamespacedName{Name: generatePVCName(instance), Namespace: instance.Namespace}, pvc)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	if pvc.Status.Phase == corev1.ClaimBound {
+		// The PVC is bound, so it's ready
+		return true, nil
+	}
+
+	return false, nil
+}


### PR DESCRIPTION
This PR introduces the `Available` condition.
This condition is set to `True` if the PVC, Route and Deployment are ready.
The definition of ready is:
- PVC bound
- Route is admitted
- Deployment is Available and with expected number of replicas
The `Available` condition would be `False` otherwise.

`InferenceServices` do not have a bearing in `Available` and whether they are present or not will be reflected in the `InferenceServicesPresent` condition.

The readiness status checks are moved to the `reconcileStatuses` method and performed together, rather than at each component's (PVC, Route, etc) check.