### PR TITLE
[RHOAIENG-2135] Add unique ClusterRoleBinding names

### DIFF
--- a/config/crd/bases/trustyai.opendatahub.io_trustyaiservices.yaml
+++ b/config/crd/bases/trustyai.opendatahub.io_trustyaiservices.yaml
@@ -2,121 +2,121 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-    annotations:
-        controller-gen.kubebuilder.io/version: v0.11.1
-    creationTimestamp: null
-    name: trustyaiservices.trustyai.opendatahub.io
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.1
+  creationTimestamp: null
+  name: trustyaiservices.trustyai.opendatahub.io
 spec:
-    group: trustyai.opendatahub.io
-    names:
-        kind: TrustyAIService
-        listKind: TrustyAIServiceList
-        plural: trustyaiservices
-        singular: trustyaiservice
-    scope: Namespaced
-    versions:
-        -   name: v1alpha1
-            schema:
-                openAPIV3Schema:
-                    description: TrustyAIService is the Schema for the trustyaiservices API
-                    properties:
-                        apiVersion:
-                            description: 'APIVersion defines the versioned schema of this representation
+  group: trustyai.opendatahub.io
+  names:
+    kind: TrustyAIService
+    listKind: TrustyAIServiceList
+    plural: trustyaiservices
+    singular: trustyaiservice
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: TrustyAIService is the Schema for the trustyaiservices API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                            type: string
-                        kind:
-                            description: 'Kind is a string value representing the REST resource this
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                        metadata:
-                            type: object
-                        spec:
-                            description: TrustyAIServiceSpec defines the desired state of TrustyAIService
-                            properties:
-                                data:
-                                    properties:
-                                        filename:
-                                            type: string
-                                        format:
-                                            type: string
-                                    required:
-                                        - filename
-                                        - format
-                                    type: object
-                                metrics:
-                                    properties:
-                                        batchSize:
-                                            type: integer
-                                        schedule:
-                                            type: string
-                                    required:
-                                        - schedule
-                                    type: object
-                                replicas:
-                                    description: Number of replicas
-                                    format: int32
-                                    type: integer
-                                storage:
-                                    properties:
-                                        folder:
-                                            type: string
-                                        format:
-                                            type: string
-                                        size:
-                                            type: string
-                                    required:
-                                        - folder
-                                        - format
-                                        - size
-                                    type: object
-                            required:
-                                - data
-                                - metrics
-                                - storage
-                            type: object
-                        status:
-                            description: TrustyAIServiceStatus defines the observed state of TrustyAIService
-                            properties:
-                                conditions:
-                                    items:
-                                        description: Condition represents possible conditions of a TrustyAIServiceStatus
-                                        properties:
-                                            lastTransitionTime:
-                                                format: date-time
-                                                type: string
-                                            message:
-                                                type: string
-                                            reason:
-                                                type: string
-                                            status:
-                                                type: string
-                                            type:
-                                                type: string
-                                        required:
-                                            - lastTransitionTime
-                                            - message
-                                            - reason
-                                            - status
-                                            - type
-                                        type: object
-                                    type: array
-                                phase:
-                                    description: Define your status fields here
-                                    type: string
-                                ready:
-                                    type: string
-                                replicas:
-                                    format: int32
-                                    type: integer
-                            required:
-                                - conditions
-                                - phase
-                                - replicas
-                            type: object
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: TrustyAIServiceSpec defines the desired state of TrustyAIService
+              properties:
+                data:
+                  properties:
+                    filename:
+                      type: string
+                    format:
+                      type: string
+                  required:
+                    - filename
+                    - format
+                  type: object
+                metrics:
+                  properties:
+                    batchSize:
+                      type: integer
+                    schedule:
+                      type: string
+                  required:
+                    - schedule
+                  type: object
+                replicas:
+                  description: Number of replicas
+                  format: int32
+                  type: integer
+                storage:
+                  properties:
+                    folder:
+                      type: string
+                    format:
+                      type: string
+                    size:
+                      type: string
+                  required:
+                    - folder
+                    - format
+                    - size
+                  type: object
+              required:
+                - data
+                - metrics
+                - storage
+              type: object
+            status:
+              description: TrustyAIServiceStatus defines the observed state of TrustyAIService
+              properties:
+                conditions:
+                  items:
+                    description: Condition represents possible conditions of a TrustyAIServiceStatus
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
                     type: object
-            served: true
-            storage: true
-            subresources:
-                status: {}
+                  type: array
+                phase:
+                  description: Define your status fields here
+                  type: string
+                ready:
+                  type: string
+                replicas:
+                  format: int32
+                  type: integer
+              required:
+                - conditions
+                - phase
+                - replicas
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/controllers/service_accounts.go
+++ b/controllers/service_accounts.go
@@ -99,7 +99,7 @@ func (r *TrustyAIServiceReconciler) createServiceAccount(ctx context.Context, in
 func (r *TrustyAIServiceReconciler) createClusterRoleBinding(ctx context.Context, instance *trustyaiopendatahubiov1alpha1.TrustyAIService, serviceAccountName string) error {
 	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      instance.Name + "-proxy-rolebinding",
+			Name:      instance.Name + "-" + instance.Namespace + "-proxy-rolebinding",
 			Namespace: instance.Namespace,
 		},
 		Subjects: []rbacv1.Subject{
@@ -128,10 +128,9 @@ func (r *TrustyAIServiceReconciler) createClusterRoleBinding(ctx context.Context
 		log.FromContext(ctx).Info("Creating a new ClusterRoleBinding", "Name", clusterRoleBinding.Name)
 		err = r.Create(ctx, clusterRoleBinding)
 		if err != nil {
+			log.FromContext(ctx).Error(err, "Error creating a new ClusterRoleBinding")
 			return err
 		}
-	} else if err != nil {
-		return err
 	}
 
 	return nil

--- a/controllers/service_accounts_test.go
+++ b/controllers/service_accounts_test.go
@@ -1,0 +1,72 @@
+package controllers
+
+import (
+	"context"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+)
+
+var _ = Describe("Service Accounts", func() {
+
+	BeforeEach(func() {
+		recorder = record.NewFakeRecorder(10)
+		reconciler = &TrustyAIServiceReconciler{
+			Client:        k8sClient,
+			Scheme:        scheme.Scheme,
+			EventRecorder: recorder,
+		}
+		ctx = context.Background()
+	})
+
+	Context("When creating multiple services", func() {
+		It("Should create SAs, CRBs successfully", func() {
+
+			namespace1 := "sa-test-namespace-1"
+			instance1 := createDefaultCR(namespace1)
+
+			WaitFor(func() error {
+				return createNamespace(ctx, k8sClient, namespace1)
+			}, "failed to create namespace")
+
+			WaitFor(func() error { return reconciler.createServiceAccount(ctx, instance1) }, "failed to create service account")
+
+			namespace2 := "sa-test-namespace-2"
+
+			instance2 := createDefaultCR(namespace2)
+
+			WaitFor(func() error {
+				return createNamespace(ctx, k8sClient, namespace2)
+			}, "failed to create namespace")
+
+			WaitFor(func() error { return reconciler.createServiceAccount(ctx, instance2) }, "failed to create service account")
+
+			serviceAccount1 := &corev1.ServiceAccount{}
+			serviceAccountName1 := instance1.Name + "-proxy"
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: serviceAccountName1, Namespace: namespace1}, serviceAccount1)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(serviceAccount1).ToNot(BeNil())
+			Expect(serviceAccount1.Name).To(Equal(generateServiceAccountName(instance1)))
+			Expect(serviceAccountName1).To(Equal(generateServiceAccountName(instance1)))
+
+			serviceAccount2 := &corev1.ServiceAccount{}
+			serviceAccountName2 := instance2.Name + "-proxy"
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: serviceAccountName2, Namespace: namespace2}, serviceAccount2)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(serviceAccount2).ToNot(BeNil())
+			Expect(serviceAccount2.Name).To(Equal(generateServiceAccountName(instance2)))
+			Expect(serviceAccountName2).To(Equal(generateServiceAccountName(instance2)))
+
+			checkServiceAccountAnnotations(ctx, instance1, k8sClient)
+			checkServiceAccountAnnotations(ctx, instance2, k8sClient)
+
+			checkClusterRoleBinding(ctx, instance1, k8sClient)
+			checkClusterRoleBinding(ctx, instance2, k8sClient)
+
+		})
+	})
+
+})


### PR DESCRIPTION
Fixes [RHOAIENG-2135](https://issues.redhat.com/browse/RHOAIENG-2135)

### Problem

When creating multiple `TrustyAIServices`, endpoint authentication will fail.

### Steps to reproduce

Steps to reproduce using the CLI:

Assuming:
- A TrustyAI operator already deployed
- `$CLUSTER` is your cluster address.
- A `$TOKEN` as `export TOKEN=$(oc whoami -t)`
- No models are required to reproduce this

Create a namespace `test`. 
Add a first `TrustyAIService` in this namespace , using, for instance (`trustyai-test.yaml`)

```
apiVersion: trustyai.opendatahub.io/v1alpha1
kind: TrustyAIService
metadata:
  name: trustyai-service
spec:
  storage:
    format: "PVC"
    folder: "/inputs"
    size: "1Gi"
  data:
    filename: "data.csv"
    format: "CSV"
  metrics:
    schedule: "5s"
```
 and

```
oc apply -f trustyai-test.yaml -n test
```

Try the external endpoint:

```
curl -sk -H "Authorization: Bearer ${TOKEN}" https://trustyai-service-test.${CLUSTER}/info
```

This should provide a successful response (in terms of authentication, actual response might be `[]`).

Create a namespace `test2`. 
Add a `TrustyAIService` in this namespace , using, for instance the `trustyai-test.yaml` as before:

```
oc apply -f trustyai-test.yaml -n test2
```

Try the external endpoint:

```
curl -sk -H "Authorization: Bearer ${TOKEN}" https://trustyai-service-test2.${CLUSTER}/info
```

The request will now be unsuccessful in terms of authentication.

### Solution

For authentication, TrustyAI's proxy uses a `ServiceAccount` with a binding to a proxy role with `tokenreviews` and `subjectaccessreviews`. This binding was created for each service and with a name derived from the TrustyAI service name.
If more than one service with the same were deployed, this would create a conflict and cause the second role binding to not be created.

`ClusterRoleBinding` names are now unique, derived from the service's name and namespace.

### Validation

Re-run the entire "Steps to reproduce" section.
The final request should now be successful

```
curl -sk -H "Authorization: Bearer ${TOKEN}" https://trustyai-service-test2.${CLUSTER}/info
```


