### PR TITLE
RHOAIENG-2417: Remove unnecessary cluster role binding's namespace

### DIFF
--- a/controllers/service_accounts.go
+++ b/controllers/service_accounts.go
@@ -99,8 +99,7 @@ func (r *TrustyAIServiceReconciler) createServiceAccount(ctx context.Context, in
 func (r *TrustyAIServiceReconciler) createClusterRoleBinding(ctx context.Context, instance *trustyaiopendatahubiov1alpha1.TrustyAIService, serviceAccountName string) error {
 	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      instance.Name + "-" + instance.Namespace + "-proxy-rolebinding",
-			Namespace: instance.Namespace,
+			Name: instance.Name + "-" + instance.Namespace + "-proxy-rolebinding",
 		},
 		Subjects: []rbacv1.Subject{
 			{


### PR DESCRIPTION
See https://github.com/trustyai-explainability/trustyai-service-operator/pull/185#discussion_r1464612407