### PR TITLE
RHOAIENG-2918: Remove /metrics from skip-auth

### DIFF
--- a/controllers/templates/service/deployment.tmpl.yaml
+++ b/controllers/templates/service/deployment.tmpl.yaml
@@ -105,7 +105,7 @@ spec:
             - '--tls-cert=/etc/tls/private/tls.crt'
             - '--tls-key=/etc/tls/private/tls.key'
             - '--upstream=http://localhost:8080'
-            - '--skip-auth-regex=''(^/metrics|^/apis/v1beta1/healthz)'''
+            - '--skip-auth-regex=''(^/apis/v1beta1/healthz)'''
             - >-
               --openshift-sar={"namespace":"{{ .Instance.Namespace }}","resource":"pods","verb":"get"}
             - >-


### PR DESCRIPTION
See [RHOAIENG-2918](https://issues.redhat.com/browse/RHOAIENG-2918).

This PR removes `/metrics` from the skip-auth.