### PR TITLE
Added two level support for operator configmaps

### DIFF
--- a/controllers/config_maps.go
+++ b/controllers/config_maps.go
@@ -8,10 +8,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// getImageFromConfigMap gets a custom image value from a ConfigMap in the operator's namespace
-func (r *TrustyAIServiceReconciler) getImageFromConfigMap(ctx context.Context, key string, defaultImage string) (string, error) {
+// getImageFromConfigMapDefault gets "stock" image values from a ConfigMap in the operator's namespace
+func (r *TrustyAIServiceReconciler) getImageFromConfigMapStock(ctx context.Context, key string, defaultImage string) (string, error) {
 	if r.Namespace != "" {
-		// Define the key for the ConfigMap
+		// Define the key for the custom ConfigMap
 		configMapKey := types.NamespacedName{
 			Namespace: r.Namespace,
 			Name:      imageConfigMap,
@@ -36,6 +36,55 @@ func (r *TrustyAIServiceReconciler) getImageFromConfigMap(ctx context.Context, k
 		if !ok {
 			// One or both of the keys are not present in the ConfigMap, return error
 			return defaultImage, fmt.Errorf("configmap %s does not contain necessary keys", configMapKey)
+		}
+
+		// Return the image and tag
+		return image, nil
+	} else {
+		return defaultImage, nil
+	}
+}
+
+// getImageFromConfigMap gets a custom image value from a ConfigMap in the operator's namespace
+func (r *TrustyAIServiceReconciler) getImageFromConfigMap(ctx context.Context, key string, defaultImage string) (string, error) {
+	if r.Namespace != "" {
+		// Define the key for the custom ConfigMap
+		configMapKeyCustom := types.NamespacedName{
+			Namespace: r.Namespace,
+			Name:      imageConfigMapCustom,
+		}
+
+		// define the key for the stock ConfigMap
+		configMapKey := types.NamespacedName{
+			Namespace: r.Namespace,
+			Name:      imageConfigMap,
+		}
+
+		// Create an empty ConfigMap object
+		var cm corev1.ConfigMap
+
+		// Try to get the ConfigMap
+		if err := r.Get(ctx, configMapKeyCustom, &cm); err != nil {
+			if errors.IsNotFound(err) {
+				// ConfigMap not found, fallback to operator installed values
+				return r.getImageFromConfigMapStock(ctx, key, defaultImage)
+			}
+			// Other error occurred when trying to fetch the ConfigMap
+			return defaultImage, fmt.Errorf("error reading configmap %s", configMapKeyCustom)
+		}
+
+		// ConfigMap is found, extract the image and tag
+		image, ok := cm.Data[key]
+
+		if !ok {
+			// One or both of the keys are not present in the ConfigMap, return error
+			image, defaultErr := r.getImageFromConfigMapStock(ctx, key, defaultImage)
+			errInvalidKeys := fmt.Errorf("configmap %s does not contain necessary keys, failing back to %s", configMapKeyCustom, configMapKey)
+
+			if defaultErr != nil {
+				errInvalidKeys = fmt.Errorf("%w. While retrieving %s, another error occured: %w", errInvalidKeys, configMapKey, defaultErr)
+			}
+			return image, errInvalidKeys
 		}
 
 		// Return the image and tag

--- a/controllers/config_maps_test.go
+++ b/controllers/config_maps_test.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -43,9 +42,23 @@ var _ = Describe("ConfigMap tests", func() {
 		} else if !apierrors.IsNotFound(err) {
 			Fail(fmt.Sprintf("Unexpected error while getting ConfigMap: %s", err))
 		}
+
+		// Attempt to delete the custom ConfigMap
+		configMapCustom := &corev1.ConfigMap{}
+		errCustom := k8sClient.Get(ctx, types.NamespacedName{
+			Namespace: operatorNamespace,
+			Name:      imageConfigMapCustom,
+		}, configMapCustom)
+
+		// If the ConfigMap exists, delete it
+		if errCustom == nil {
+			Expect(k8sClient.Delete(ctx, configMapCustom)).To(Succeed())
+		} else if !apierrors.IsNotFound(errCustom) {
+			Fail(fmt.Sprintf("Unexpected error while getting custom ConfigMap: %s", err))
+		}
 	})
 
-	Context("When deploying a ConfigMap to the operator's namespace", func() {
+	Context("When deploying a stock ConfigMap to the operator's namespace", func() {
 
 		It("Should get back the correct values", func() {
 
@@ -53,7 +66,46 @@ var _ = Describe("ConfigMap tests", func() {
 			oauthImage := "custom-oauth-proxy:bar"
 
 			WaitFor(func() error {
-				configMap := createConfigMap(operatorNamespace, oauthImage, serviceImage)
+				configMap := createConfigMap(operatorNamespace, oauthImage, serviceImage, false)
+				return k8sClient.Create(ctx, configMap)
+			}, "failed to create ConfigMap")
+
+			var actualOAuthImage string
+			var actualServiceImage string
+
+			WaitFor(func() error {
+				var err error
+				actualOAuthImage, err = reconciler.getImageFromConfigMap(ctx, configMapOAuthProxyImageKey, defaultOAuthProxyImage)
+				return err
+			}, "failed to get oauth image from ConfigMap")
+
+			WaitFor(func() error {
+				var err error
+				actualServiceImage, err = reconciler.getImageFromConfigMap(ctx, configMapServiceImageKey, defaultImage)
+				return err
+			}, "failed to get service image from ConfigMap")
+
+			Expect(actualOAuthImage).Should(Equal(oauthImage))
+			Expect(actualServiceImage).Should(Equal(serviceImage))
+		})
+	})
+
+	Context("When deploying a Custom ConfigMap to the operator's namespace", func() {
+
+		It("Should get back the correct custom values, over the default values", func() {
+
+			serviceImage := "custom-service-image:foo_custom"
+			oauthImage := "custom-oauth-proxy:bar_custom"
+			serviceImageStock := "custom-service-image:foo"
+			oauthImageStock := "custom-oauth-proxy:bar"
+
+			WaitFor(func() error {
+				configMap := createConfigMap(operatorNamespace, oauthImage, serviceImage, true)
+				return k8sClient.Create(ctx, configMap)
+			}, "failed to create ConfigMap")
+
+			WaitFor(func() error {
+				configMap := createConfigMap(operatorNamespace, oauthImageStock, serviceImageStock, false)
 				return k8sClient.Create(ctx, configMap)
 			}, "failed to create ConfigMap")
 
@@ -101,13 +153,14 @@ var _ = Describe("ConfigMap tests", func() {
 		})
 	})
 
-	Context("When deploying a ConfigMap to the operator's namespace with the wrong keys", func() {
+	Context("When deploying a stock ConfigMap to the operator's namespace with the wrong keys", func() {
 
 		It("Should get back the default values", func() {
 
-			serviceImage := "custom-service-image:foo"
-			oauthImage := "custom-oauth-proxy:bar"
+			serviceImage := "custom-service-image:foo_custom"
+			oauthImage := "custom-oauth-proxy:bar_custom"
 
+			// create default CM
 			WaitFor(func() error {
 				configMap := &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
@@ -144,4 +197,118 @@ var _ = Describe("ConfigMap tests", func() {
 		})
 	})
 
+	Context("When deploying a custom ConfigMap to the operator's namespace with the wrong keys, and a valid stock CM", func() {
+
+		It("Should get back the stock CM values", func() {
+
+			serviceImage := "custom-service-image:foo"
+			oauthImage := "custom-oauth-proxy:bar"
+			stockServiceImage := "stock-service-image:foo"
+			stockOauthImage := "stock-oauth-proxy:bar"
+
+			// create invalid custom CM
+			WaitFor(func() error {
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      imageConfigMapCustom,
+						Namespace: operatorNamespace,
+					},
+					Data: map[string]string{
+						"foo-oauth-image": oauthImage,
+						"foo-image":       serviceImage,
+					},
+				}
+				return k8sClient.Create(ctx, configMap)
+			}, "failed to create ConfigMap")
+
+			// create valid stock CM
+			WaitFor(func() error {
+				configMap := createConfigMap(operatorNamespace, stockOauthImage, stockServiceImage, false)
+				return k8sClient.Create(ctx, configMap)
+			}, "failed to create ConfigMap")
+
+			var actualOAuthImage string
+			var actualServiceImage string
+
+			configMapPathCustom := operatorNamespace + "/" + imageConfigMapCustom
+			configMapPath := operatorNamespace + "/" + imageConfigMap
+
+			Eventually(func() error {
+				var err error
+				actualOAuthImage, err = reconciler.getImageFromConfigMap(ctx, configMapOAuthProxyImageKey, defaultOAuthProxyImage)
+				return err
+			}, defaultTimeout, defaultPolling).Should(MatchError(fmt.Sprintf("configmap %s does not contain necessary keys, failing back to %s", configMapPathCustom, configMapPath)), "failed to get oauth image from ConfigMap")
+
+			Eventually(func() error {
+				var err error
+				actualServiceImage, err = reconciler.getImageFromConfigMap(ctx, configMapServiceImageKey, defaultImage)
+				return err
+			}, defaultTimeout, defaultPolling).Should(MatchError(fmt.Sprintf("configmap %s does not contain necessary keys, failing back to %s", configMapPathCustom, configMapPath)), "failed to get oauth image from ConfigMap")
+
+			Expect(actualOAuthImage).Should(Equal(stockOauthImage))
+			Expect(actualServiceImage).Should(Equal(stockServiceImage))
+		})
+	})
+
+	Context("When neither the custom nor Stock ConfigMap in the operator's namespace has valid keys", func() {
+
+		It("Should get back the default values", func() {
+
+			serviceImage := "custom-service-image:foo"
+			oauthImage := "custom-oauth-proxy:bar"
+			stockServiceImage := "stock-service-image:foo"
+			stockOauthImage := "stock-oauth-proxy:bar"
+
+			// create invalid custom CM
+			WaitFor(func() error {
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      imageConfigMapCustom,
+						Namespace: operatorNamespace,
+					},
+					Data: map[string]string{
+						"foo-oauth-image": oauthImage,
+						"foo-image":       serviceImage,
+					},
+				}
+				return k8sClient.Create(ctx, configMap)
+			}, "failed to create ConfigMap")
+
+			// create invalid stock CM
+			WaitFor(func() error {
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      imageConfigMap,
+						Namespace: operatorNamespace,
+					},
+					Data: map[string]string{
+						"foo-oauth-image": stockOauthImage,
+						"foo-image":       stockServiceImage,
+					},
+				}
+				return k8sClient.Create(ctx, configMap)
+			}, "failed to create ConfigMap")
+
+			var actualOAuthImage string
+			var actualServiceImage string
+
+			configMapPathCustom := operatorNamespace + "/" + imageConfigMapCustom
+			configMapPath := operatorNamespace + "/" + imageConfigMap
+
+			Eventually(func() error {
+				var err error
+				actualOAuthImage, err = reconciler.getImageFromConfigMap(ctx, configMapOAuthProxyImageKey, defaultOAuthProxyImage)
+				return err
+			}, defaultTimeout, defaultPolling).Should(MatchError(fmt.Sprintf("configmap %s does not contain necessary keys, failing back to %s. While retrieving %s, another error occured: configmap %s does not contain necessary keys", configMapPathCustom, configMapPath, configMapPath, configMapPath)), "failed to get oauth image from ConfigMap")
+
+			Eventually(func() error {
+				var err error
+				actualServiceImage, err = reconciler.getImageFromConfigMap(ctx, configMapServiceImageKey, defaultImage)
+				return err
+			}, defaultTimeout, defaultPolling).Should(MatchError(fmt.Sprintf("configmap %s does not contain necessary keys, failing back to %s. While retrieving %s, another error occured: configmap %s does not contain necessary keys", configMapPathCustom, configMapPath, configMapPath, configMapPath)), "failed to get oauth image from ConfigMap")
+
+			Expect(actualOAuthImage).Should(Equal(defaultOAuthProxyImage))
+			Expect(actualServiceImage).Should(Equal(defaultImage))
+		})
+	})
 })

--- a/controllers/constants.go
+++ b/controllers/constants.go
@@ -18,6 +18,7 @@ const (
 // Configuration constants
 const (
 	imageConfigMap              = "trustyai-service-operator-config"
+	imageConfigMapCustom        = "trustyai-service-operator-config-custom"
 	configMapOAuthProxyImageKey = "oauthProxyImage"
 	configMapServiceImageKey    = "trustyaiServiceImage"
 )

--- a/controllers/deployment_test.go
+++ b/controllers/deployment_test.go
@@ -138,7 +138,7 @@ var _ = Describe("TrustyAI operator", func() {
 			Expect(createNamespace(ctx, k8sClient, namespace)).To(Succeed())
 
 			WaitFor(func() error {
-				configMap := createConfigMap(operatorNamespace, oauthImage, serviceImage)
+				configMap := createConfigMap(operatorNamespace, oauthImage, serviceImage, false)
 				return k8sClient.Create(ctx, configMap)
 			}, "failed to create ConfigMap")
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -134,11 +134,15 @@ func createNamespace(ctx context.Context, k8sClient client.Client, namespace str
 }
 
 // createConfigMap creates a configuration in the specified namespace
-func createConfigMap(namespace string, oauthImage string, trustyaiServiceImage string) *corev1.ConfigMap {
+func createConfigMap(namespace string, oauthImage string, trustyaiServiceImage string, isCustom bool) *corev1.ConfigMap {
 	// Define the ConfigMap with the necessary data
+	configMapName := imageConfigMap
+	if isCustom {
+		configMapName = imageConfigMapCustom
+	}
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      imageConfigMap,
+			Name:      configMapName,
 			Namespace: namespace,
 		},
 		Data: map[string]string{


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-3013

The operator config map that determines image values are now read with the following priority:
1) trustyai-service-operator-config-custom
2) trustyai-service-operator-config 
3) created from default image values