### PR TITLE
RHOAIENG-2419: Add version information to resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.1
+VERSION ?= 1.17.0
 
 BUILD_TOOL ?= podman
 

--- a/controllers/deployment.go
+++ b/controllers/deployment.go
@@ -27,6 +27,7 @@ type DeploymentConfig struct {
 	Schedule        string
 	VolumeMountName string
 	PVCClaimName    string
+	Version         string
 }
 
 // createDeploymentObject returns a Deployment for the TrustyAI Service instance
@@ -54,6 +55,7 @@ func (r *TrustyAIServiceReconciler) createDeploymentObject(ctx context.Context, 
 		Schedule:        strconv.Itoa(batchSize),
 		VolumeMountName: volumeMountName,
 		PVCClaimName:    pvcName,
+		Version:         Version,
 	}
 
 	var deployment *appsv1.Deployment

--- a/controllers/deployment_test.go
+++ b/controllers/deployment_test.go
@@ -82,7 +82,7 @@ var _ = Describe("TrustyAI operator", func() {
 			Expect(deployment.Labels["app.kubernetes.io/name"]).Should(Equal(defaultServiceName))
 			Expect(deployment.Labels["app.kubernetes.io/instance"]).Should(Equal(defaultServiceName))
 			Expect(deployment.Labels["app.kubernetes.io/part-of"]).Should(Equal(componentName))
-			Expect(deployment.Labels["app.kubernetes.io/version"]).Should(Equal("0.1.0"))
+			Expect(deployment.Labels["app.kubernetes.io/version"]).Should(Equal(Version))
 
 			Expect(len(deployment.Spec.Template.Spec.Containers)).Should(Equal(2))
 			Expect(deployment.Spec.Template.Spec.Containers[0].Image).Should(Equal("quay.io/trustyai/trustyai-service:latest"))
@@ -121,7 +121,7 @@ var _ = Describe("TrustyAI operator", func() {
 			Expect(oauthService.Labels["app.kubernetes.io/instance"]).Should(Equal(instance.Name))
 			Expect(oauthService.Labels["app.kubernetes.io/name"]).Should(Equal(instance.Name))
 			Expect(oauthService.Labels["app.kubernetes.io/part-of"]).Should(Equal("trustyai"))
-			Expect(oauthService.Labels["app.kubernetes.io/version"]).Should(Equal("0.1.0"))
+			Expect(oauthService.Labels["app.kubernetes.io/version"]).Should(Equal(Version))
 			Expect(oauthService.Labels["trustyai-service-name"]).Should(Equal(instance.Name))
 
 		})
@@ -163,7 +163,7 @@ var _ = Describe("TrustyAI operator", func() {
 			Expect(deployment.Labels["app.kubernetes.io/name"]).Should(Equal(defaultServiceName))
 			Expect(deployment.Labels["app.kubernetes.io/instance"]).Should(Equal(defaultServiceName))
 			Expect(deployment.Labels["app.kubernetes.io/part-of"]).Should(Equal(componentName))
-			Expect(deployment.Labels["app.kubernetes.io/version"]).Should(Equal("0.1.0"))
+			Expect(deployment.Labels["app.kubernetes.io/version"]).Should(Equal(Version))
 
 			Expect(len(deployment.Spec.Template.Spec.Containers)).Should(Equal(2))
 			Expect(deployment.Spec.Template.Spec.Containers[0].Image).Should(Equal(serviceImage))
@@ -202,7 +202,7 @@ var _ = Describe("TrustyAI operator", func() {
 			Expect(oauthService.Labels["app.kubernetes.io/instance"]).Should(Equal(instance.Name))
 			Expect(oauthService.Labels["app.kubernetes.io/name"]).Should(Equal(instance.Name))
 			Expect(oauthService.Labels["app.kubernetes.io/part-of"]).Should(Equal("trustyai"))
-			Expect(oauthService.Labels["app.kubernetes.io/version"]).Should(Equal("0.1.0"))
+			Expect(oauthService.Labels["app.kubernetes.io/version"]).Should(Equal(Version))
 			Expect(oauthService.Labels["trustyai-service-name"]).Should(Equal(instance.Name))
 
 		})
@@ -350,7 +350,7 @@ var _ = Describe("TrustyAI operator", func() {
 			Expect(deployment.Labels["app.kubernetes.io/name"]).Should(Equal(defaultServiceName))
 			Expect(deployment.Labels["app.kubernetes.io/instance"]).Should(Equal(defaultServiceName))
 			Expect(deployment.Labels["app.kubernetes.io/part-of"]).Should(Equal(componentName))
-			Expect(deployment.Labels["app.kubernetes.io/version"]).Should(Equal("0.1.0"))
+			Expect(deployment.Labels["app.kubernetes.io/version"]).Should(Equal(Version))
 
 			WaitFor(func() error {
 				err := reconciler.reconcileOAuthService(ctx, instance)
@@ -370,7 +370,7 @@ var _ = Describe("TrustyAI operator", func() {
 			Expect(oauthService.Labels["app.kubernetes.io/instance"]).Should(Equal(instance.Name))
 			Expect(oauthService.Labels["app.kubernetes.io/name"]).Should(Equal(instance.Name))
 			Expect(oauthService.Labels["app.kubernetes.io/part-of"]).Should(Equal("trustyai"))
-			Expect(oauthService.Labels["app.kubernetes.io/version"]).Should(Equal("0.1.0"))
+			Expect(oauthService.Labels["app.kubernetes.io/version"]).Should(Equal(Version))
 			Expect(oauthService.Labels["trustyai-service-name"]).Should(Equal(instance.Name))
 
 		})
@@ -431,7 +431,7 @@ var _ = Describe("TrustyAI operator", func() {
 				Expect(deployment.Labels["app.kubernetes.io/name"]).Should(Equal(defaultServiceName))
 				Expect(deployment.Labels["app.kubernetes.io/instance"]).Should(Equal(defaultServiceName))
 				Expect(deployment.Labels["app.kubernetes.io/part-of"]).Should(Equal(componentName))
-				Expect(deployment.Labels["app.kubernetes.io/version"]).Should(Equal("0.1.0"))
+				Expect(deployment.Labels["app.kubernetes.io/version"]).Should(Equal(Version))
 
 				Expect(len(deployment.Spec.Template.Spec.Containers)).Should(Equal(2))
 				Expect(deployment.Spec.Template.Spec.Containers[0].Image).Should(Equal("quay.io/trustyai/trustyai-service:latest"))
@@ -455,7 +455,7 @@ var _ = Describe("TrustyAI operator", func() {
 				Expect(oauthService.Labels["app.kubernetes.io/instance"]).Should(Equal(instance.Name))
 				Expect(oauthService.Labels["app.kubernetes.io/name"]).Should(Equal(instance.Name))
 				Expect(oauthService.Labels["app.kubernetes.io/part-of"]).Should(Equal("trustyai"))
-				Expect(oauthService.Labels["app.kubernetes.io/version"]).Should(Equal("0.1.0"))
+				Expect(oauthService.Labels["app.kubernetes.io/version"]).Should(Equal(Version))
 				Expect(oauthService.Labels["trustyai-service-name"]).Should(Equal(instance.Name))
 
 			}

--- a/controllers/oauth.go
+++ b/controllers/oauth.go
@@ -22,6 +22,7 @@ type OAuthConfig struct {
 
 type ServiceTLSConfig struct {
 	Instance *trustyaiopendatahubiov1alpha1.TrustyAIService
+	Version  string
 }
 
 // generateTrustyAIOAuthService defines the desired OAuth service object
@@ -29,6 +30,7 @@ func generateTrustyAIOAuthService(ctx context.Context, instance *trustyaiopendat
 
 	serviceTLSConfig := ServiceTLSConfig{
 		Instance: instance,
+		Version:  Version,
 	}
 
 	var serviceTLS *corev1.Service

--- a/controllers/service_accounts.go
+++ b/controllers/service_accounts.go
@@ -64,7 +64,7 @@ func (r *TrustyAIServiceReconciler) createServiceAccount(ctx context.Context, in
 				"app.kubernetes.io/name":     serviceAccountName,
 				"app.kubernetes.io/instance": instance.Name,
 				"app.kubernetes.io/part-of":  componentName,
-				"app.kubernetes.io/version":  "0.1.0",
+				"app.kubernetes.io/version":  Version,
 			},
 		},
 	}

--- a/controllers/services.go
+++ b/controllers/services.go
@@ -17,6 +17,7 @@ const (
 type ServiceConfig struct {
 	Name      string
 	Namespace string
+	Version   string
 }
 
 func (r *TrustyAIServiceReconciler) reconcileService(ctx context.Context, cr *trustyaiopendatahubiov1alpha1.TrustyAIService) (*corev1.Service, error) {
@@ -24,6 +25,7 @@ func (r *TrustyAIServiceReconciler) reconcileService(ctx context.Context, cr *tr
 	serviceConfig := ServiceConfig{
 		Name:      cr.Name,
 		Namespace: cr.Namespace,
+		Version:   Version,
 	}
 
 	var service *corev1.Service

--- a/controllers/templates/service/deployment.tmpl.yaml
+++ b/controllers/templates/service/deployment.tmpl.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Instance.Name }}
     app.kubernetes.io/name: {{ .Instance.Name }}
     app.kubernetes.io/part-of: trustyai
-    app.kubernetes.io/version: 0.1.0
+    app.kubernetes.io/version: {{ .Version }}
 spec:
   replicas: 1
   selector:
@@ -19,7 +19,7 @@ spec:
       app.kubernetes.io/instance: {{ .Instance.Name }}
       app.kubernetes.io/name: {{ .Instance.Name }}
       app.kubernetes.io/part-of: trustyai
-      app.kubernetes.io/version: 0.1.0
+      app.kubernetes.io/version: {{ .Version }}
   template:
     metadata:
       labels:
@@ -27,7 +27,7 @@ spec:
         app.kubernetes.io/instance: {{ .Instance.Name }}
         app.kubernetes.io/name: {{ .Instance.Name }}
         app.kubernetes.io/part-of: trustyai
-        app.kubernetes.io/version: 0.1.0
+        app.kubernetes.io/version: {{ .Version }}
       annotations:
         prometheus.io/path: /q/metrics
         prometheus.io/scheme: http

--- a/controllers/templates/service/service-internal.tmpl.yaml
+++ b/controllers/templates/service/service-internal.tmpl.yaml
@@ -12,7 +12,7 @@ metadata:
         app.kubernetes.io/instance: {{ .Name }}
         app.kubernetes.io/name: {{ .Name }}
         app.kubernetes.io/part-of: trustyai
-        app.kubernetes.io/version: 0.1.0
+        app.kubernetes.io/version: {{ .Version }}
 spec:
     ports:
         - name: http
@@ -25,4 +25,4 @@ spec:
         app.kubernetes.io/instance: {{ .Name }}
         app.kubernetes.io/name: {{ .Name }}
         app.kubernetes.io/part-of: trustyai
-        app.kubernetes.io/version: 0.1.0
+        app.kubernetes.io/version: {{ .Version }}

--- a/controllers/templates/service/service-tls.tmpl.yaml
+++ b/controllers/templates/service/service-tls.tmpl.yaml
@@ -10,7 +10,7 @@ metadata:
         app.kubernetes.io/instance: {{ .Instance.Name }}
         app.kubernetes.io/name: {{ .Instance.Name }}
         app.kubernetes.io/part-of: trustyai
-        app.kubernetes.io/version: 0.1.0
+        app.kubernetes.io/version: {{ .Version }}
         trustyai-service-name: {{ .Instance.Name }}
 spec:
     ports:

--- a/controllers/trustyaiservice_controller.go
+++ b/controllers/trustyaiservice_controller.go
@@ -68,17 +68,6 @@ type TrustyAIServiceReconciler struct {
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;watch;create;update;delete
 
-// getCommonLabels returns the service's common labels
-func getCommonLabels(serviceName string) map[string]string {
-	return map[string]string{
-		"app":                        serviceName,
-		"app.kubernetes.io/name":     serviceName,
-		"app.kubernetes.io/instance": serviceName,
-		"app.kubernetes.io/part-of":  componentName,
-		"app.kubernetes.io/version":  "0.1.0",
-	}
-}
-
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *TrustyAIServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/controllers/version.go
+++ b/controllers/version.go
@@ -1,0 +1,5 @@
+package controllers
+
+const (
+	Version = "1.17.0"
+)


### PR DESCRIPTION
See [RHOAIENG-2419](https://issues.redhat.com/browse/RHOAIENG-2419).

Currently, TrustyAI resources are created with a default version `0.1.0`.
Change to be consistent with the version in `version.go`.