### PR TITLE
RHOAIENG-6275: Change route termination to reencrypt

### DIFF
--- a/controllers/templates/service/route.tmpl.yaml
+++ b/controllers/templates/service/route.tmpl.yaml
@@ -13,4 +13,6 @@ spec:
     port:
         targetPort: {{ .PortName }}
     tls:
-        termination: passthrough
+        termination: Reencrypt
+        insecureEdgeTerminationPolicy: Redirect
+


### PR DESCRIPTION
See [RHOAIENG-6275](https://issues.redhat.com/browse/RHOAIENG-6275) and https://github.com/trustyai-explainability/trustyai-service-operator/issues/233.


Edge TLS for the external route is now managed by OpenShift.
Connection is reencrypted to the OAuth proxy, since that pod does not accept unencrypted connections.
