### PR TITLE
fix: Bring back multi-arch image builds

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -81,10 +81,16 @@ jobs:
         run: sed -i 's#summary="odh-trustyai-service-operator\"#summary="odh-trustyai-service-operator" \\ \n      quay.expires-after=7d#' Dockerfile
       - name: Log in to Quay
         run: docker login -u ${{ secrets.QUAY_ROBOT_USERNAME }} -p ${{ secrets.QUAY_ROBOT_SECRET }} quay.io
-      - name: Build image
-        run: docker build -t ${{ env.IMAGE_NAME }}:$TAG .
-      - name: Push to Quay CI repo
-        run: docker push ${{ env.IMAGE_NAME }}:$TAG
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build and Push Image
+        uses: docker/build-push-action@v3
+        with:
+          tags: ${{ env.IMAGE_NAME }}:${{ env.TAG }}
+          platforms: linux/amd64,linux/s390x,linux/ppc64le
+          push: true
 
       # Create CI Manifests
       - name: Set up manifests for CI


### PR DESCRIPTION
Bring back multi-arch builds.
Removed with:
- https://github.com/trustyai-explainability/trustyai-service-operator/pull/235