### PR TITLE
feat: Add testing overlay

### DIFF
--- a/config/overlays/testing/image-pull-policy.yaml
+++ b/config/overlays/testing/image-pull-policy.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          imagePullPolicy: Always

--- a/config/overlays/testing/kustomization.yaml
+++ b/config/overlays/testing/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - ../../base
+
+patchesStrategicMerge:
+  - image-pull-policy.yaml


### PR DESCRIPTION
This overlay is intended to use in TrustyAI development and testing.

This PR adds an `ImagePullPolicy: Always` to the operator image for testing purposes.