### PR TITLE
feat: Add TLS certificate mount on ModelMesh

### DIFF
--- a/controllers/certificates.go
+++ b/controllers/certificates.go
@@ -3,9 +3,40 @@ package controllers
 import (
 	"context"
 	trustyaiopendatahubiov1alpha1 "github.com/trustyai-explainability/trustyai-service-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+const (
+	tlsMountPath = "/etc/trustyai/tls"
+)
+
+// TLSCertVolumes holds the volume and volume mount for the TLS certificates
+type TLSCertVolumes struct {
+	volume      corev1.Volume
+	volumeMount corev1.VolumeMount
+}
+
+// createFor creates the required volumes and volume mount for the TLS certificates for a specific Kubernetes secret
+func (cert *TLSCertVolumes) createFor(instance *trustyaiopendatahubiov1alpha1.TrustyAIService) {
+	volume := corev1.Volume{
+		Name: instance.Name + "-internal",
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: instance.Name + "-internal",
+			},
+		},
+	}
+
+	volumeMount := corev1.VolumeMount{
+		Name:      instance.Name + "-internal",
+		MountPath: tlsMountPath,
+		ReadOnly:  true,
+	}
+	cert.volume = volume
+	cert.volumeMount = volumeMount
+}
 
 func (r *TrustyAIServiceReconciler) GetCustomCertificatesBundle(ctx context.Context, instance *trustyaiopendatahubiov1alpha1.TrustyAIService) CustomCertificatesBundle {
 

--- a/controllers/constants.go
+++ b/controllers/constants.go
@@ -9,6 +9,8 @@ const (
 	serviceMonitorName   = "trustyai-metrics"
 	finalizerName        = "trustyai.opendatahub.io/finalizer"
 	payloadProcessorName = "MM_PAYLOAD_PROCESSORS"
+	tlsKeyCertPathName   = "MM_TLS_KEY_CERT_PATH"
+	mmContainerName      = "mm"
 	modelMeshLabelKey    = "modelmesh-service"
 	modelMeshLabelValue  = "modelmesh-serving"
 	volumeMountName      = "volume"

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -64,5 +64,5 @@ func (r *TrustyAIServiceReconciler) GetDeploymentsByLabel(ctx context.Context, n
 
 // generateServiceURL generates an internal URL for a TrustyAI service
 func generateServiceURL(crName string, namespace string) string {
-	return "https://" + crName + "." + namespace + ".svc"
+	return "http://" + crName + "." + namespace + ".svc"
 }

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -2,9 +2,10 @@ package controllers
 
 import (
 	"context"
+	"os"
+
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -63,5 +64,5 @@ func (r *TrustyAIServiceReconciler) GetDeploymentsByLabel(ctx context.Context, n
 
 // generateServiceURL generates an internal URL for a TrustyAI service
 func generateServiceURL(crName string, namespace string) string {
-	return "http://" + crName + "." + namespace + ".svc.cluster.local"
+	return "https://" + crName + "." + namespace + ".svc"
 }


### PR DESCRIPTION
Adds support for mounting TrustyAI internal's service serving certificates on the ModelMesh container.
Changes the TrustyAI payload processor to match the TLS certificate's CN and SAN.

See [RHOAIENG-4963](https://issues.redhat.com/browse/RHOAIENG-4963).