### PR TITLE
feat: Add support for custom certificates in database connection

### DIFF
--- a/controllers/secrets.go
+++ b/controllers/secrets.go
@@ -9,34 +9,42 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// getSecret retrieves a secret if it exists, returns an error if not
+func (r *TrustyAIServiceReconciler) getSecret(ctx context.Context, name, namespace string) (*corev1.Secret, error) {
+	secret := &corev1.Secret{}
+	err := r.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, secret)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, fmt.Errorf("secret %s not found in namespace %s: %w", name, namespace, err)
+		}
+		return nil, fmt.Errorf("failed to get secret %s in namespace %s: %w", name, namespace, err)
+	}
+	return secret, nil
+}
+
 // findDatabaseSecret finds the DB configuration secret named (specified or default) in the same namespace as the CR
 func (r *TrustyAIServiceReconciler) findDatabaseSecret(ctx context.Context, instance *trustyaiopendatahubiov1alpha1.TrustyAIService) (*corev1.Secret, error) {
 
 	databaseConfigurationsName := instance.Spec.Storage.DatabaseConfigurations
 	defaultDatabaseConfigurationsName := instance.Name + dbCredentialsSuffix
 
-	secret := &corev1.Secret{}
-
 	if databaseConfigurationsName != "" {
-		secret := &corev1.Secret{}
-		err := r.Get(ctx, client.ObjectKey{Name: databaseConfigurationsName, Namespace: instance.Namespace}, secret)
-		if err == nil {
-			return secret, nil
+		secret, err := r.getSecret(ctx, databaseConfigurationsName, instance.Namespace)
+		if err != nil {
+			return nil, err
 		}
-		if !errors.IsNotFound(err) {
-			return nil, fmt.Errorf("failed to get secret %s in namespace %s: %w", databaseConfigurationsName, instance.Namespace, err)
+		if secret != nil {
+			return secret, nil
 		}
 	} else {
 		// If specified not found, try the default
-
-		err := r.Get(ctx, client.ObjectKey{Name: defaultDatabaseConfigurationsName, Namespace: instance.Namespace}, secret)
-		if err == nil {
+		secret, err := r.getSecret(ctx, defaultDatabaseConfigurationsName, instance.Namespace)
+		if err != nil {
+			return nil, err
+		}
+		if secret != nil {
 			return secret, nil
 		}
-		if !errors.IsNotFound(err) {
-			return nil, fmt.Errorf("failed to get secret %s in namespace %s: %w", defaultDatabaseConfigurationsName, instance.Namespace, err)
-		}
-
 	}
 
 	return nil, fmt.Errorf("neither secret %s nor %s found in namespace %s", databaseConfigurationsName, defaultDatabaseConfigurationsName, instance.Namespace)

--- a/controllers/templates/service/deployment.tmpl.yaml
+++ b/controllers/templates/service/deployment.tmpl.yaml
@@ -94,7 +94,11 @@ spec:
                   name: {{ .Instance.Spec.Storage.DatabaseConfigurations }}
                   key: databasePort
             - name: QUARKUS_DATASOURCE_JDBC_URL
+            {{ if .UseDBTLSCerts }}
+              value: "jdbc:${QUARKUS_DATASOURCE_DB_KIND}://${DATABASE_SERVICE}:${DATABASE_PORT}/trustyai_database?sslMode=verify-ca&serverSslCert=/etc/tls/db/tls.crt"
+            {{ else }}
               value: "jdbc:${QUARKUS_DATASOURCE_DB_KIND}://${DATABASE_SERVICE}:${DATABASE_PORT}/trustyai_database"
+            {{ end }}
             - name: SERVICE_DATA_FORMAT
               value: "HIBERNATE"
             - name: QUARKUS_DATASOURCE_GENERATION
@@ -121,7 +125,12 @@ spec:
             - name: {{ .VolumeMountName }}
               mountPath: {{ .Instance.Spec.Storage.Folder }}
               readOnly: false
-          {{ end }}
+            {{ end }}
+            {{ if .UseDBTLSCerts }}
+            - name: db-tls-certs
+              mountPath: /etc/tls/db
+              readOnly: true
+            {{ end }}
         - resources:
             limits:
               cpu: 100m
@@ -209,3 +218,9 @@ spec:
           secret:
             secretName: {{ .Instance.Name }}-internal
             defaultMode: 420
+        {{ if .UseDBTLSCerts }}
+        - name: db-tls-certs
+          secret:
+            secretName: {{ .Instance.Name }}-db-tls
+            defaultMode: 420
+        {{ end }}


### PR DESCRIPTION
This PR adds support for custom certificates for the TrustyAI service database connection.

Certificates are stored in a Kubernetes `Secret` named `${TRUSTY_SERVICE_NAME}-db-tls` and must include at least a `tls.crt` key.

- If the certificate is present, it will be mounted on the TrustyAI pod and passed to the JDBC connection string
- If the certificate is _not_ present, a connection without TLS will be created (this is same behaviour as previously)

The secret must be created prior to TrustyAI as the operator will not watch for database TLS secrets creation.