### PR TITLE
feat: ConfigMap key to disable KServe Serverless configuration

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -41,3 +41,10 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.oauthProxyImage
+  - name: kServeServerless
+    objref:
+      kind: ConfigMap
+      name: config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.kServeServerless

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -1,3 +1,4 @@
 trustyaiServiceImage=quay.io/trustyai/trustyai-service:latest
 trustyaiOperatorImage=quay.io/trustyai/trustyai-service-operator:latest
 oauthProxyImage=quay.io/openshift/origin-oauth-proxy:4.14.0
+kServeServerless=disabled

--- a/controllers/config_maps.go
+++ b/controllers/config_maps.go
@@ -46,6 +46,44 @@ func (r *TrustyAIServiceReconciler) getImageFromConfigMap(ctx context.Context, k
 	}
 }
 
+// getKServeServerlessConfig checks the kServeServerless value in a ConfigMap in the operator's namespace
+func (r *TrustyAIServiceReconciler) getKServeServerlessConfig(ctx context.Context) (bool, error) {
+
+	if r.Namespace != "" {
+		// Define the key for the ConfigMap
+		configMapKey := types.NamespacedName{
+			Namespace: r.Namespace,
+			Name:      imageConfigMap,
+		}
+
+		// Create an empty ConfigMap object
+		var cm corev1.ConfigMap
+
+		// Try to get the ConfigMap
+		if err := r.Get(ctx, configMapKey, &cm); err != nil {
+			if errors.IsNotFound(err) {
+				// ConfigMap not found, return false as the default behavior
+				return false, nil
+			}
+			// Other error occurred when trying to fetch the ConfigMap
+			return false, fmt.Errorf("error reading configmap %s", configMapKey)
+		}
+
+		// ConfigMap is found, extract the kServeServerless value
+		kServeServerless, ok := cm.Data[configMapkServeServerlessKey]
+
+		if !ok || kServeServerless != "enabled" {
+			// Key is missing or its value is not "enabled", return false
+			return false, nil
+		}
+
+		// kServeServerless is "enabled"
+		return true, nil
+	} else {
+		return false, nil
+	}
+}
+
 // getConfigMapNamesWithLabel retrieves the names of ConfigMaps that have the specified label
 func (r *TrustyAIServiceReconciler) getConfigMapNamesWithLabel(ctx context.Context, namespace string, labelSelector client.MatchingLabels) ([]string, error) {
 	configMapList := &corev1.ConfigMapList{}

--- a/controllers/constants.go
+++ b/controllers/constants.go
@@ -26,9 +26,10 @@ const (
 
 // Configuration constants
 const (
-	imageConfigMap              = "trustyai-service-operator-config"
-	configMapOAuthProxyImageKey = "oauthProxyImage"
-	configMapServiceImageKey    = "trustyaiServiceImage"
+	imageConfigMap               = "trustyai-service-operator-config"
+	configMapOAuthProxyImageKey  = "oauthProxyImage"
+	configMapServiceImageKey     = "trustyaiServiceImage"
+	configMapkServeServerlessKey = "kServeServerless"
 )
 
 // OAuth constants


### PR DESCRIPTION
See [RHOAIENG-10687](https://issues.redhat.com/browse/RHOAIENG-10687).

This PR adds a configuration option to the TrustyAI operator `ConfigMap` to enable/disable KServe Serverless patching.
By default, KServe Serverless will be disabled, meaning KServe `InferenceServices` will not be patched.

To enable it, the following `ConfigMap` can be deployed in the operator's namespace:

```yaml
apiVersion: v1
data:
  kServeServerless: enabled
  oauthProxyImage: quay.io/openshift/origin-oauth-proxy:4.14.0
  trustyaiOperatorImage: quay.io/ruimvieira/trustyai-service-operator:...
  trustyaiServiceImage: quay.io/ruimvieira/trustyai-service:...
kind: ConfigMap
metadata:
  labels:
    app.kubernetes.io/part-of: trustyai
  name: trustyai-service-operator-config
```