### PR TITLE
Add TLS endpoint for ModelMesh payload processors.

### DIFF
--- a/controllers/inference_services.go
+++ b/controllers/inference_services.go
@@ -147,7 +147,7 @@ func (r *TrustyAIServiceReconciler) patchEnvVarsByLabelForDeployments(ctx contex
 	}
 
 	// Build the payload processor endpoint
-	url := generateServiceURL(crName, namespace) + "/consumer/kserve/v2"
+	url := generateTLSServiceURL(crName, namespace) + "/consumer/kserve/v2"
 
 	// Patch environment variables for the Deployments
 	if shouldContinue, err := r.patchEnvVarsForDeployments(ctx, instance, deployments, envVarName, url, remove); err != nil {
@@ -240,7 +240,7 @@ func (r *TrustyAIServiceReconciler) handleInferenceServices(ctx context.Context,
 // patchKServe adds a TrustyAI service as an InferenceLogger to a KServe InferenceService
 func (r *TrustyAIServiceReconciler) patchKServe(ctx context.Context, instance *trustyaiopendatahubiov1alpha1.TrustyAIService, infService kservev1beta1.InferenceService, namespace string, crName string, remove bool) error {
 
-	url := generateServiceURL(crName, namespace)
+	url := generateNonTLSServiceURL(crName, namespace)
 
 	if remove {
 		if infService.Spec.Predictor.Logger == nil || *infService.Spec.Predictor.Logger.URL != url {

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -62,7 +62,12 @@ func (r *TrustyAIServiceReconciler) GetDeploymentsByLabel(ctx context.Context, n
 	return deployments.Items, nil
 }
 
-// generateServiceURL generates an internal URL for a TrustyAI service
-func generateServiceURL(crName string, namespace string) string {
+// generateTLSServiceURL generates an internal URL for a TLS-enabled TrustyAI service
+func generateTLSServiceURL(crName string, namespace string) string {
+	return "https://" + crName + "." + namespace + ".svc"
+}
+
+// generateNonTLSServiceURL generates an internal URL for a TrustyAI service
+func generateNonTLSServiceURL(crName string, namespace string) string {
 	return "http://" + crName + "." + namespace + ".svc"
 }


### PR DESCRIPTION
- Add TLS endpoint for ModelMesh payload processors.
- Keep non-TLS endpoint for KServe Serverless (disabled by default)

Only to be merged after https://github.com/opendatahub-io/modelmesh/pull/65 is merged.