### PR TITLE
feat: Add TLS ConfigMap parameter

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -48,3 +48,10 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.kServeServerless
+  - name: tls
+    objref:
+      kind: ConfigMap
+      name: config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.tls

--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -1,3 +1,5 @@
-trustyaiServiceImage=quay.io/trustyai/trustyai-service:v0.13.0
-trustyaiOperatorImage=quay.io/trustyai/trustyai-service-operator:v1.19.0
+trustyaiServiceImage=quay.io/trustyai/trustyai-service:latest
+trustyaiOperatorImage=quay.io/trustyai/trustyai-service-operator:latest
 oauthProxyImage=quay.io/openshift/origin-oauth-proxy:4.14.0
+kServeServerless=enabled
+tls=disabled

--- a/config/overlays/rhoai/kustomization.yaml
+++ b/config/overlays/rhoai/kustomization.yaml
@@ -3,3 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+configMapGenerator:
+  - env: params.env
+    behavior: merge
+    name: config

--- a/config/overlays/rhoai/params.env
+++ b/config/overlays/rhoai/params.env
@@ -1,5 +1,5 @@
 trustyaiServiceImage=quay.io/trustyai/trustyai-service:latest
 trustyaiOperatorImage=quay.io/trustyai/trustyai-service-operator:latest
-oauthProxyImage=quay.io/openshift/origin-oauth-proxy:4.14.0
+oauthProxyImage=registry.redhat.io/openshift4/ose-oauth-proxy@sha256:ab112105ac37352a2a4916a39d6736f5db6ab4c29bad4467de8d613e80e9bb33
 kServeServerless=disabled
 tls=enabled

--- a/controllers/constants.go
+++ b/controllers/constants.go
@@ -30,6 +30,7 @@ const (
 	configMapOAuthProxyImageKey  = "oauthProxyImage"
 	configMapServiceImageKey     = "trustyaiServiceImage"
 	configMapkServeServerlessKey = "kServeServerless"
+	configMapTLSKey              = "tls"
 )
 
 // OAuth constants


### PR DESCRIPTION
This PR adds a new field to the TrustyAI operator configuration `ConfigMap` called `tls` with can be either `enabled` or `disabled`.

- If `tls: enabled`, payload processors will be registered with ModelMesh as `https`. This is the default value if the configuration key is missing.
- If `tls: disabled`, payload processors will be registered as `http`. This is the opt-in value, only set is explicitly changed on the config map.

Two overlays were also updated:


| key | `odh` | `rhoai` |
| ----- | ------- | ------------- |
| `tls`  | `disabled`  | `enabled` |
| `kServeServerless`  | `enabled`  | `disabled` |
| OAuth container image | tag `4.14` | sha `registry.redhat.io/openshift4/ose-oauth-proxy@sha256:ab112105ac37352a2a4916a39d6736f5db6ab4c29bad4467de8d613e80e9bb33` |

This allows for:

- `odh`: TLS-disabled and KServe integration enabled
- `rhoai`: TLS-enabled and KServe integration disabled and a pinned OAuth proxy image 