### PR TITLE
feat: Driver updates job's status periodically

### DIFF
--- a/Dockerfile.driver
+++ b/Dockerfile.driver
@@ -1,7 +1,16 @@
 FROM registry.access.redhat.com/ubi8/go-toolset:1.21 AS builder
 
 WORKDIR /go/src/github.com/trustyai-explainability/trustyai-service-operator
-COPY . .
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+# Copy the go source
+COPY cmd/ cmd/
+COPY api/ api/
+COPY controllers/ controllers/
 
 RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux go build -tags netgo -ldflags '-extldflags "-static"' -o /bin/driver ./cmd/lmes_driver/*.go
 

--- a/cmd/lmes_driver/main.go
+++ b/cmd/lmes_driver/main.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -36,13 +37,14 @@ const (
 )
 
 var (
-	copy         = flag.String("copy", "", "copy this binary to specified destination path")
-	jobNameSpace = flag.String("job-namespace", "", "Job's namespace ")
-	jobName      = flag.String("job-name", "", "Job's name")
-	grpcService  = flag.String("grpc-service", "", "grpc service name")
-	grpcPort     = flag.Int("grpc-port", 8082, "grpc port")
-	outputPath   = flag.String("output-path", OutputPath, "output path")
-	driverLog    = ctrl.Log.WithName("driver")
+	copy           = flag.String("copy", "", "copy this binary to specified destination path")
+	jobNameSpace   = flag.String("job-namespace", "", "Job's namespace ")
+	jobName        = flag.String("job-name", "", "Job's name")
+	grpcService    = flag.String("grpc-service", "", "grpc service name")
+	grpcPort       = flag.Int("grpc-port", 8082, "grpc port")
+	outputPath     = flag.String("output-path", OutputPath, "output path")
+	reportInterval = flag.Duration("report-interval", time.Second*10, "specify the druation interval to report the progress")
+	driverLog      = ctrl.Log.WithName("driver")
 )
 
 func main() {
@@ -75,14 +77,15 @@ func main() {
 	}
 
 	driverOpt := driver.DriverOption{
-		Context:      ctx,
-		JobNamespace: *jobNameSpace,
-		JobName:      *jobName,
-		OutputPath:   *outputPath,
-		GrpcService:  *grpcService,
-		GrpcPort:     *grpcPort,
-		Logger:       driverLog,
-		Args:         args,
+		Context:        ctx,
+		JobNamespace:   *jobNameSpace,
+		JobName:        *jobName,
+		OutputPath:     *outputPath,
+		GrpcService:    *grpcService,
+		GrpcPort:       *grpcPort,
+		Logger:         driverLog,
+		Args:           args,
+		ReportInterval: *reportInterval,
 	}
 
 	driver, err := driver.NewDriver(&driverOpt)

--- a/controllers/lmes/constants.go
+++ b/controllers/lmes/constants.go
@@ -23,26 +23,29 @@ import (
 )
 
 const (
-	DriverPath                 = "/bin/driver"
-	DestDriverPath             = "/opt/app-root/src/bin/driver"
-	PodImageKey                = "lmes-pod-image"
-	DriverImageKey             = "lmes-driver-image"
-	PodCheckingIntervalKey     = "lmes-pod-checking-interval"
-	ImagePullPolicyKey         = "lmes-image-pull-policy"
-	GrpcPortKey                = "lmes-grpc-port"
-	GrpcServiceKey             = "lmes-grpc-service"
-	GrpcServerSecretKey        = "lmes-grpc-server-secret"
-	GrpcClientSecretKey        = "lmes-grpc-client-secret"
-	GrpcServerCertEnv          = "GRPC_SERVER_CERT"
-	GrpcServerKeyEnv           = "GRPC_SERVER_KEY"
-	GrpcClientCaEnv            = "GRPC_CLIENT_CA"
-	DefaultPodImage            = "quay.io/yhwang/lm-eval-aas-flask:test"
-	DefaultDriverImage         = "quay.io/yhwang/lm-eval-aas-driver:test"
-	DefaultPodCheckingInterval = time.Second * 10
-	DefaultImagePullPolicy     = corev1.PullAlways
-	DefaultGrpcPort            = 8082
-	DefaultGrpcService         = "lm-eval-grpc"
-	DefaultGrpcServerSecret    = "grpc-server-cert"
-	DefaultGrpcClientSecret    = "grpc-client-cert"
-	ServiceName                = "LMES"
+	DriverPath              = "/bin/driver"
+	DestDriverPath          = "/opt/app-root/src/bin/driver"
+	PodImageKey             = "lmes-pod-image"
+	DriverImageKey          = "lmes-driver-image"
+	PodCheckingIntervalKey  = "lmes-pod-checking-interval"
+	ImagePullPolicyKey      = "lmes-image-pull-policy"
+	GrpcPortKey             = "lmes-grpc-port"
+	GrpcServiceKey          = "lmes-grpc-service"
+	GrpcServerSecretKey     = "lmes-grpc-server-secret"
+	GrpcClientSecretKey     = "lmes-grpc-client-secret"
+	DriverReportIntervalKey = "driver-report-interval"
+	GrpcServerCertEnv       = "GRPC_SERVER_CERT"
+	GrpcServerKeyEnv        = "GRPC_SERVER_KEY"
+	GrpcClientCaEnv         = "GRPC_CLIENT_CA"
+	// FIXME: move these images to quay.io/trustyai
+	DefaultPodImage             = "quay.io/yhwang/ta-lmes-job:latest"
+	DefaultDriverImage          = "quay.io/yhwang/ta-lmes-driver:latest"
+	DefaultPodCheckingInterval  = time.Second * 10
+	DefaultDriverReportInterval = time.Second * 10
+	DefaultImagePullPolicy      = corev1.PullAlways
+	DefaultGrpcPort             = 8082
+	DefaultGrpcService          = "lm-eval-grpc"
+	DefaultGrpcServerSecret     = "grpc-server-cert"
+	DefaultGrpcClientSecret     = "grpc-client-cert"
+	ServiceName                 = "LMES"
 )


### PR DESCRIPTION
The driver periodically update the LMEvalJob.Status.Message field with the outputs from the lm-eval. The message pattern the driver captures is like `Running text generation:  81%|`. Then users can use this information to check the progress of the job.