### PR TITLE
feat: add device detection in lmes driver

### DIFF
--- a/cmd/lmes_driver/main.go
+++ b/cmd/lmes_driver/main.go
@@ -43,6 +43,7 @@ var (
 	grpcService    = flag.String("grpc-service", "", "grpc service name")
 	grpcPort       = flag.Int("grpc-port", 8082, "grpc port")
 	outputPath     = flag.String("output-path", OutputPath, "output path")
+	detectDevice   = flag.Bool("detect-device", true, "detect available device(s), CUDA or CPU")
 	reportInterval = flag.Duration("report-interval", time.Second*10, "specify the druation interval to report the progress")
 	driverLog      = ctrl.Log.WithName("driver")
 )
@@ -83,6 +84,7 @@ func main() {
 		OutputPath:     *outputPath,
 		GrpcService:    *grpcService,
 		GrpcPort:       *grpcPort,
+		DetectDevice:   *detectDevice,
 		Logger:         driverLog,
 		Args:           args,
 		ReportInterval: *reportInterval,

--- a/controllers/lmes/constants.go
+++ b/controllers/lmes/constants.go
@@ -35,6 +35,7 @@ const (
 	GrpcClientSecretKey     = "lmes-grpc-client-secret"
 	MaxBatchSizeKey         = "lmes-max-batch-size"
 	DefaultBatchSizeKey     = "lmes-default-batch-size"
+	DetectDeviceKey         = "lmes-detect-device"
 	DriverReportIntervalKey = "driver-report-interval"
 	GrpcServerCertEnv       = "GRPC_SERVER_CERT"
 	GrpcServerKeyEnv        = "GRPC_SERVER_KEY"
@@ -51,5 +52,6 @@ const (
 	DefaultGrpcClientSecret     = "grpc-client-cert"
 	DefaultMaxBatchSize         = 24
 	DefaultBatchSize            = 8
+	DefaultDetectDevice         = true
 	ServiceName                 = "LMES"
 )

--- a/controllers/lmes/lmevaljob_controller.go
+++ b/controllers/lmes/lmevaljob_controller.go
@@ -68,6 +68,7 @@ var (
 		"DriverReportInterval": DriverReportIntervalKey,
 		"DefaultBatchSize":     DefaultBatchSizeKey,
 		"MaxBatchSize":         MaxBatchSizeKey,
+		"DetectDevice":         DetectDeviceKey,
 	}
 )
 
@@ -101,6 +102,7 @@ type ServiceOptions struct {
 	GrpcClientSecret     string
 	MaxBatchSize         int
 	DefaultBatchSize     int
+	DetectDevice         bool
 	grpcTLSMode          TLSMode
 }
 
@@ -303,6 +305,7 @@ func (r *LMEvalJobReconciler) constructOptionsFromConfigMap(
 		GrpcServerSecret:     DefaultGrpcServerSecret,
 		GrpcClientSecret:     DefaultGrpcClientSecret,
 		MaxBatchSize:         DefaultMaxBatchSize,
+		DetectDevice:         DefaultDetectDevice,
 		DefaultBatchSize:     DefaultBatchSize,
 	}
 
@@ -679,8 +682,7 @@ func (r *LMEvalJobReconciler) generateArgs(job *lmesv1alpha1.LMEvalJob, log logr
 	}
 
 	cmds := make([]string, 0, 10)
-	// FIXME: use CPU for now
-	cmds = append(cmds, "python", "-m", "lm_eval", "--output_path", "/opt/app-root/src/output", "--device", "cpu")
+	cmds = append(cmds, "python", "-m", "lm_eval", "--output_path", "/opt/app-root/src/output")
 	// --model
 	cmds = append(cmds, "--model", job.Spec.Model)
 	// --model_args
@@ -732,6 +734,7 @@ func (r *LMEvalJobReconciler) generateCmd(job *lmesv1alpha1.LMEvalJob) []string 
 		"--grpc-service", fmt.Sprintf("%s.%s.svc", r.options.GrpcService, r.Namespace),
 		"--grpc-port", strconv.Itoa(r.options.GrpcPort),
 		"--output-path", "/opt/app-root/src/output",
+		"--detect-device", fmt.Sprintf("%t", r.options.DetectDevice),
 		"--report-interval", r.options.DriverReportInterval.String(),
 		"--",
 	}

--- a/controllers/lmes/lmevaljob_controller_test.go
+++ b/controllers/lmes/lmevaljob_controller_test.go
@@ -760,7 +760,7 @@ func Test_GenerateArgBatchSize(t *testing.T) {
 	// no batchSize in the job, use default batchSize
 	assert.Equal(t, []string{
 		"sh", "-ec",
-		"python -m lm_eval --output_path /opt/app-root/src/output --device cpu --model test --model_args arg1=value1 --tasks task1,task2 --batch_size 8",
+		"python -m lm_eval --output_path /opt/app-root/src/output --model test --model_args arg1=value1 --tasks task1,task2 --batch_size 8",
 	}, lmevalRec.generateArgs(job, log))
 
 	// exceed the max-batch-size, use max-batch-size
@@ -768,7 +768,7 @@ func Test_GenerateArgBatchSize(t *testing.T) {
 	job.Spec.BatchSize = &biggerBatchSize
 	assert.Equal(t, []string{
 		"sh", "-ec",
-		"python -m lm_eval --output_path /opt/app-root/src/output --device cpu --model test --model_args arg1=value1 --tasks task1,task2 --batch_size 24",
+		"python -m lm_eval --output_path /opt/app-root/src/output --model test --model_args arg1=value1 --tasks task1,task2 --batch_size 24",
 	}, lmevalRec.generateArgs(job, log))
 
 	// normal batchSize
@@ -776,6 +776,6 @@ func Test_GenerateArgBatchSize(t *testing.T) {
 	job.Spec.BatchSize = &normalBatchSize
 	assert.Equal(t, []string{
 		"sh", "-ec",
-		"python -m lm_eval --output_path /opt/app-root/src/output --device cpu --model test --model_args arg1=value1 --tasks task1,task2 --batch_size 16",
+		"python -m lm_eval --output_path /opt/app-root/src/output --model test --model_args arg1=value1 --tasks task1,task2 --batch_size 16",
 	}, lmevalRec.generateArgs(job, log))
 }


### PR DESCRIPTION
Added a new feature in the LMES driver to detect the available devices by using the PyTorch API. This feature can be disabled by passing the `--detect-device false` option.

fix: #297