### PR TITLE
Add guardrails orchestrator CRD and controller

### DIFF
--- a/api/guardrails/v1alpha1/guardrailsorchestrator_types.go
+++ b/api/guardrails/v1alpha1/guardrailsorchestrator_types.go
@@ -34,7 +34,8 @@ type GuardrailsOrchestrator struct {
 }
 
 type TLSModeSetting struct {
-	Mode string `json:"mode,omitempy"`
+	Mode           string  `json:"mode,omitempy"`
+	CredentialName *string `json:"credentialName,omitempty"`
 }
 type ServiceSpec struct {
 	Hostname string `json:"hostname"`
@@ -43,7 +44,8 @@ type ServiceSpec struct {
 
 type GenerationSpec struct {
 	Provider string `json:"provider,omitempty"`
-	Service  ServiceSpec
+
+	Service ServiceSpec
 }
 
 type ChunkersSpec struct {

--- a/api/guardrails/v1alpha1/guardrailsorchestrator_types.go
+++ b/api/guardrails/v1alpha1/guardrailsorchestrator_types.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
+// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
+
+// Represent a service's status
+// +kubebuilder:validation:Enum=New;Scheduled;Running;Complete;Cancelled
+type ServiceState string
+
+const (
+	// The service is just created
+	NewServiceState ServiceState = "New"
+	// The service is scheduled and waiting for available resources to run it
+	ScheduledServiceState ServiceState = "Scheduled"
+	// The service is running
+	RunningServiceState ServiceState = "Running"
+	// The service is complete
+	CompleteServiceState ServiceState = "Complete"
+	// The service is cancelled
+	CancelledServiceState ServiceState = "Cancelled"
+)
+
+// +kubebuilder:validation:Enum=NoReason;Succeeded;Failed;Cancelled
+type Reason string
+
+const (
+	// Service is still running and no final result yet
+	NoReason Reason = "NoReason"
+	// Service finished successfully
+	SucceedReason Reason = "Succeeded"
+	// Service failed
+	FailedReason Reason = "Failed"
+	// Service is cancelled
+	CancelledReason Reason = "Cancelled"
+)
+
+type Arg struct {
+	Name  string `json:"name"`
+	Value string `json:"value,omitempty"`
+}
+
+type EnvSecret struct {
+	// Environment's name
+	Env string `json:"env"`
+	// The secret is from a secret object
+	// +optional
+	SecretRef *corev1.SecretKeySelector `json:"secretRef,omitempty"`
+	// The secret is from a plain text
+	// +optional
+	Secret *string `json:"secret,omitempty"`
+}
+
+type FileSecret struct {
+	// The secret object
+	SecretRef corev1.SecretVolumeSource `json:"secretRef,omitempty"`
+	// The path to mount the secret
+	MountPath string `json:"mountPath"`
+}
+
+// GuardrailsServiceSpec defines the desired state of GuardrailsService
+type GuardrailsServiceSpec struct {
+	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+	// Important: Run "make" to regenerate code after modifying this file
+
+	// Generator name
+	Generator string `json:"generator"`
+	// Chunker name
+	// + Optional
+	Chunker string `json:"chunker"`
+	// Args for the chunker
+	// + optional
+	ChunkerArgs []Arg `json:"chunkerArgs,omitempty"`
+	// Detector name
+	Detector string `json:"detector"`
+	// Args for the detector
+	// +optional
+	DetectorArgs []Arg `json:"detectorArgs,omitempty"`
+	// Evaluation tasks
+	EnvSecrets []EnvSecret `json:"envSecrets,omitempty"`
+	// Use secrets as files
+	FileSecrets []FileSecret `json:"fileSecrets,omitempty"`
+}
+
+// GuardrailsServiceStatus defines the observed state of GuardrailsService
+type GuardrailsServiceStatus struct {
+	// Important: Run "make" to regenerate code after modifying this file
+
+	// The name of the Pod that runs the evaluation Service
+	// +optional
+	PodName string `json:"podName,omitempty"`
+	// State of the Service
+	// +optional
+	State ServiceState `json:"state,omitempty"`
+	// Final result of the Service
+	// +optional
+	Reason Reason `json:"reason,omitempty"`
+	// Message about the current/final status
+	// +optional
+	Message string `json:"message,omitempty"`
+	// Information when was the last time the Service was successfully scheduled.
+	// +optional
+	LastScheduleTime *metav1.Time `json:"lastScheduleTime,omitempty"`
+	// Information when the Service's state changes to Complete.
+	// +optional
+	CompleteTime *metav1.Time `json:"completeTime,omitempty"`
+	// Evaluation results
+	// +optional
+	Results string `json:"results,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+
+// GuardrailsService is the Schema for the GuardrailsService API
+type GuardrailsService struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   GuardrailsServiceSpec   `json:"spec,omitempty"`
+	Status GuardrailsServiceStatus `json:"status,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+
+// GuardrailsServiceList contains a list of GuardrailsService
+type GuardrailsServiceList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []GuardrailsService `json:"items"`
+}
+
+func init() {
+	SchemeBuilder.Register(&GuardrailsService{}, &GuardrailsServiceList{})
+}

--- a/api/guardrails/v1alpha1/guardrailsorchestrator_types.go
+++ b/api/guardrails/v1alpha1/guardrailsorchestrator_types.go
@@ -33,6 +33,9 @@ type GuardrailsOrchestrator struct {
 	Status GuardrailsOrchestratorStatus `json:"status,omitempty"`
 }
 
+type TLSModeSetting struct {
+	Mode string `json:"mode,omitempy"`
+}
 type ServiceSpec struct {
 	Hostname string `json:"hostname"`
 	Port     string `json:"port"`
@@ -55,22 +58,8 @@ type DetectorsSpec struct {
 	DefaultThreshold float32     `json:"default_threshold"`
 }
 
-type EnvSecret struct {
-	// Environment's name
-	Env string `json:"env"`
-	// The secret is from a secret object
-	// +optional
-	SecretRef *corev1.SecretKeySelector `json:"secretRef,omitempty"`
-	// The secret is from a plain text
-	// +optional
-	Secret *string `json:"secret,omitempty"`
-}
-
-type FileSecret struct {
-	// The secret object
-	SecretRef corev1.SecretVolumeSource `json:"secretRef,omitempty"`
-	// The path to mount the secret
-	MountPath string `json:"mountPath"`
+type TLSMode struct {
+	Mode string `json:"tlsMode,omitempty"`
 }
 
 // GuardrailsOrchestratorSpec defines the desired state of GuardrailsOrchestrator
@@ -87,10 +76,7 @@ type GuardrailsOrchestratorSpec struct {
 	// Detector name
 	Detectors string `json:"detector"`
 	// Number of replicas
-	Replicas   int32       `json:"replicas"`
-	EnvSecrets []EnvSecret `json:"envSecrets,omitempty"`
-	// Use secrets as files
-	FileSecrets []FileSecret `json:"fileSecrets,omitempty"`
+	Replicas int32 `json:"replicas"`
 }
 
 // GuardrailsOrchestratorStatus defines the observed state of GuardrailsOrchestrator
@@ -122,6 +108,18 @@ type GuardrailsOrchestratorList struct {
 
 func init() {
 	SchemeBuilder.Register(&GuardrailsOrchestrator{}, &GuardrailsOrchestratorList{})
+}
+
+func (t *TLSModeSetting) IsMTLS() bool {
+	return t.Mode == "mTLS"
+}
+
+func (t *TLSMode) IsTLS() bool {
+	return t.Mode == "TLS"
+}
+
+func (t *TLSMode) IsNone() bool {
+	return t.Mode == "None"
 }
 
 func (g *GuardrailsOrchestrator) SetStatus(condType, reason, message string, status corev1.ConditionStatus) {

--- a/api/guardrails/v1alpha1/guardrailsorchestrator_types.go
+++ b/api/guardrails/v1alpha1/guardrailsorchestrator_types.go
@@ -33,19 +33,20 @@ type GuardrailsOrchestrator struct {
 	Status GuardrailsOrchestratorStatus `json:"status,omitempty"`
 }
 
-type TLSModeSetting struct {
-	Mode           string  `json:"mode,omitempy"`
-	CredentialName *string `json:"credentialName,omitempty"`
-}
+//	type TLSModeSetting struct {
+//		Mode           string  `json:"mode,omitempy"`
+//		CredentialName *string `json:"credentialName,omitempty"`
+//	}
 type ServiceSpec struct {
-	Hostname string `json:"hostname"`
-	Port     string `json:"port"`
+	Hostname int    `json:"hostname"`
+	Port     int    `json:"port"`
+	Protocol string `json:"protocol"`
+	TLS      string `json:"tls,omitempty"`
 }
 
 type GenerationSpec struct {
 	Provider string `json:"provider,omitempty"`
-
-	Service ServiceSpec
+	Service  ServiceSpec
 }
 
 type ChunkersSpec struct {

--- a/api/guardrails/v1alpha1/guardrailsorchestrator_types.go
+++ b/api/guardrails/v1alpha1/guardrailsorchestrator_types.go
@@ -33,10 +33,12 @@ type GuardrailsOrchestrator struct {
 	Status GuardrailsOrchestratorStatus `json:"status,omitempty"`
 }
 
-//	type TLSModeSetting struct {
-//		Mode           string  `json:"mode,omitempy"`
-//		CredentialName *string `json:"credentialName,omitempty"`
-//	}
+type TLSSpec struct {
+	Name     string
+	CertPath string
+	KeyPath  string
+}
+
 type ServiceSpec struct {
 	Hostname int    `json:"hostname"`
 	Port     int    `json:"port"`
@@ -61,10 +63,6 @@ type DetectorsSpec struct {
 	DefaultThreshold float32     `json:"default_threshold"`
 }
 
-type TLSMode struct {
-	Mode string `json:"tlsMode,omitempty"`
-}
-
 // GuardrailsOrchestratorSpec defines the desired state of GuardrailsOrchestrator
 type GuardrailsOrchestratorSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
@@ -78,6 +76,9 @@ type GuardrailsOrchestratorSpec struct {
 	Chunker string `json:"chunkers"`
 	// Detector name
 	Detectors string `json:"detector"`
+	// TLS cert and key paths
+	// + Optional
+	TLS string `json:"tls"`
 	// Number of replicas
 	Replicas int32 `json:"replicas"`
 }
@@ -111,18 +112,6 @@ type GuardrailsOrchestratorList struct {
 
 func init() {
 	SchemeBuilder.Register(&GuardrailsOrchestrator{}, &GuardrailsOrchestratorList{})
-}
-
-func (t *TLSModeSetting) IsMTLS() bool {
-	return t.Mode == "mTLS"
-}
-
-func (t *TLSMode) IsTLS() bool {
-	return t.Mode == "TLS"
-}
-
-func (t *TLSMode) IsNone() bool {
-	return t.Mode == "None"
 }
 
 func (g *GuardrailsOrchestrator) SetStatus(condType, reason, message string, status corev1.ConditionStatus) {

--- a/artifacts/examples/guardrails/example-deployment.yaml
+++ b/artifacts/examples/guardrails/example-deployment.yaml
@@ -1,0 +1,98 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: fms-orchestr8-nlp
+  namespace: fms-orchestr8-nlp
+  annotations:
+    configmap.reloader.stakater.com/reload: 'fms-orchestr8-config'
+  labels:
+    app: fmstack-nlp
+    component: fms-orchestr8-nlp
+    deploy-name: fms-orchestr8-nlp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fmstack-nlp
+      component: fms-orchestr8-nlp
+      deploy-name: fms-orchestr8-nlp
+  template:
+    metadata:
+      labels:
+        app: fmstack-nlp
+        component: fms-orchestr8-nlp
+        deploy-name: fms-orchestr8-nlp
+    spec:
+      volumes:
+        - name: fms-orchestr8-config-nlp
+          configMap:
+            name: fms-orchestr8-config-nlp
+            defaultMode: 420
+        - name: server-tls
+          secret:
+            secretName: caikitstack-caikit-inf-tls
+            defaultMode: 256
+      containers:
+        - resources:
+            limits:
+              cpu: '1'
+              memory: 2Gi
+            requests:
+              cpu: '1'
+              memory: 2Gi
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8034
+              scheme: HTTP
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+            periodSeconds: 20
+            successThreshold: 1
+            failureThreshold: 3
+          terminationMessagePath: /dev/termination-log
+          name: fms-orchestr8-nlp
+          command:
+            - /app/bin/fms-guardrails-orchestr8
+          env:
+            - name: ORCHESTRATOR_CONFIG
+              value: /config/config.yaml
+            - name: HTTP_PORT
+              value: '8033'
+          # Mount certs to /tls/orch and uncomment to enable (m)TLS
+            - name: TLS_KEY_PATH
+              value: /tls/orch/server.key
+            - name: TLS_CERT_PATH
+              value: /tls/orch/server.crt
+            - name: TLS_CLIENT_CA_CERT_PATH
+              value: /tls/orch/ca.crt
+            - name: RUST_BACKTRACE
+              value: full
+            - name: RUST_LOG
+              value: 'fms_guardrails_orchestr8=debug'
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - name: http
+              containerPort: 8033
+              protocol: TCP
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: fms-orchestr8-config-nlp # This refers to the configmap below
+              readOnly: true
+              mountPath: /config/config.yaml
+              subPath: config.yaml
+            - name: server-tls # This is for the caikit server for generation [may want to name this better]
+              readOnly: true
+              mountPath: /tls/server
+          terminationMessagePolicy: File
+          image: 'us.icr.io/cil15-shared-registry/fms-guardrails-orchestr8:0.2.0'

--- a/artifacts/examples/guardrails/example-guardrails.yaml
+++ b/artifacts/examples/guardrails/example-guardrails.yaml
@@ -1,0 +1,30 @@
+apiVersion: trustyai.opendatahub.io/v1alpha1
+kind: GuardrailsOrchestrator
+metadata:
+  example: example-guardrails-orchestrator
+spec:
+  generation:
+    provider:
+    service:
+      hostname:
+      port:
+      protocol:
+      tls:
+  detectors:
+    regex:
+        service:
+          hostname: https://regex-detector-test.apps.rosa.mac-trustyai.swih.p3.openshiftapps.com/api/v1/text/contents
+          port: 443
+          protocol: https
+        chunker_id: whole_doc_chunker
+        default_threshold: 0.5
+  tls:
+    caikit:
+      cert_path: /tls/server/tls.crt
+      key_path: /tls/server/tls.key
+      client_ca_cert_path: /tls/ca/ca.crt
+  passthrough_headers:
+    - Authorization
+
+
+

--- a/config/crd/bases/trustyai.opendatahub.io_guadrailsorchestrator-template.yaml
+++ b/config/crd/bases/trustyai.opendatahub.io_guadrailsorchestrator-template.yaml
@@ -1,0 +1,153 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: fmsorchestr8nlps.apps.example.com
+spec:
+  group: apps.example.com
+  names:
+    kind: GuardrailOrchestrator
+    listkind: GuardrailsOrchestratorList
+    plural: guardrailsorchestrator
+    singular: guardrailsorchestrator
+  scope: Namespaced
+  versions:
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                replicas:
+                  type: integer
+                image:
+                  type: string
+                resources:
+                  type: object
+                  properties:
+                    limits:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                    requests:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                readinessProbe:
+                  type: object
+                  properties:
+                    httpGet:
+                      type: object
+                      properties:
+                        path:
+                          type: string
+                        port:
+                          type: integer
+                        scheme:
+                          type: string
+                    initialDelaySeconds:
+                      type: integer
+                    timeoutSeconds:
+                      type: integer
+                    periodSeconds:
+                      type: integer
+                    successThreshold:
+                      type: integer
+                    failureThreshold:
+                      type: integer
+                env:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      value:
+                        type: string
+                volumeMounts:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      mountPath:
+                        type: string
+                      subPath:
+                        type: string
+                      readOnly:
+                        type: boolean
+                volumes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      configMap:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          defaultMode:
+                            type: integer
+                      secret:
+                        type: object
+                        properties:
+                          secretName:
+                            type: string
+                          defaultMode:
+                            type: integer
+                          items:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                path:
+                                  type: string
+                securityContext:
+                  type: object
+                  properties:
+                    capabilities:
+                      type: object
+                      properties:
+                        drop:
+                          type: array
+                          items:
+                            type: string
+                    privileged:
+                      type: boolean
+                    runAsNonRoot:
+                      type: boolean
+                    readOnlyRootFilesystem:
+                      type: boolean
+                    allowPrivilegeEscalation:
+                      type: boolean
+                    seccompProfile:
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                ports:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      containerPort:
+                        type: integer
+                      protocol:
+                        type: string

--- a/config/crd/bases/trustyai.opendatahub.io_guadrailsorchestrator.yaml
+++ b/config/crd/bases/trustyai.opendatahub.io_guadrailsorchestrator.yaml
@@ -57,7 +57,6 @@ spec:
                           description: Port number to connect to at the server host
                           type: integer
                         tls:
-                          default: caikit
                           description: Name of the secret that holds the TLS certs
                             including the CA certificates
                           type: string
@@ -76,11 +75,12 @@ spec:
                         type: string
                       port:
                         description: The port
-                        default:
+                        type: integer
+                      protocol:
+                        description: gRPC or REST
                         type: string
                       tls:
-                        default: chunker
-                        description: TLS credentials
+                        description: Name of the secret that TLS credentials
                     type: object
               detectors:
                 description: Dectector models(s)

--- a/config/crd/bases/trustyai.opendatahub.io_guadrailsorchestrator.yaml
+++ b/config/crd/bases/trustyai.opendatahub.io_guadrailsorchestrator.yaml
@@ -5,20 +5,20 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
-  name: guardrailjobs.trustyai.opendatahub.io
+  name: guardrailsorchestrator.trustyai.opendatahub.io
 spec:
   group: trustyai.opendatahub.io
   names:
-    kind: GuardrailJob
-    listkind: GuardrailJobList
-    plural: guardrailsjobs
-    singular: guardrailsjob
+    kind: GuardrailOrchestrator
+    listkind: GuardrailsOrchestratorList
+    plural: guardrailsorchestrator
+    singular: guardrailsorchestrator
   scope: Namespaced
   versions:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: GuardrailsJob is the Schema for the guardrailjobs API
+        description: GuardrailsOrchestrator is the Schema for the guardrailorchestrator API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -33,73 +33,137 @@ spec:
           metadata:
             type: object
           spec:
-            description: 'GuardrailsJobSpec defines the desired state of GuardrailsJob'
+            description: 'GuardrailsOrchestratorSpec defines the desired state of GuardrailsOrchestrator'
             properties:
-              textInput:
-                description: Text input
-                type: string
-              chunker:
-                description: Chunker name
-                type: string
-                # items:
-                #   properties:
-                #     modelID:
-                #       description: The chunker model id
-                #
-              detector:
-                description: Detector name
-                type: string
-              model:
-                description: Model name
+              generation:
+                description: Text generation model name
+                type: object
+                properties:
+                  provider:
+                    type: string
+                    enum:
+                      - nlp
+                      - tgis
+                    pattern: ^(nlp|tgis)$
+                    service:
+                      type: object
+                      properties:
+                        hostname:
+                          type: string
+                        port:
+                          type: integer
+                        tls:
+                          type: string
+              chunkers:
+                description: Chunker model
+                type: object
+                properties:
+                  type:
+                    description: Chunker type
+                    type: string
+                  service:
+                    description:
+                    properties:
+                      hostname:
+                        description: The hostname
+                        type: string
+                      port:
+                        description: The port
+                        type: string
+                    type: object
+              detectors:
+                description: Dectector models(s)
+                type: object
+                properties:
+                  name: Detector model name
+                  service:
+                    properties:
+                      hostname:
+                        type: string
+                      port:
+                        type: string
+                    required:
+                      - hostname
+                      - port
+                    type: object
+                  chunker_id:
+                    description: Chunker name
+                    default: sentence_chunker
+                    type: string
+                  default_threshold:
+                    description: Threshold for detection
+                    default: 0.5
+                    type: number
+              tls:
+                description:
+                type: object
+                properties:
+                  cert_path:
+                    type: string
+                  key_path:
+                    type: sting
+                  client_ca_cert_path:
+                    type: string
+                required:
+                  - cert_path
+                  - key_path
+            replicas:
+              description: Number of replicas
+              type: integer
+              format: int32
+            required:
+              - detectors
+              - replicas
+              - tls
+            type: object
+          status:
+            description: GuardrailsOrchestratorStatus defines the observed state of GuardrailsOrchestrator
+              conditions:
+                items:
+                  description: Condition represents possible conditions of a GuardrailsOrchestratorStatus
+                  properties:
+                    lastTransitionTime:
+                      description: The last time the condition transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Message about the current/final status
+                      type: string
+                    reason:
+                      description: Final result of the orchestrator
+                      enum:
+                      - NoReason
+                      - Succeeded
+                      - Failed
+                      - Cancelled
+                      type: string
+                    status:
+                      description: State of the orchestrator
+                      enum:
+                      - New
+                      - Scheduled
+                      - Running
+                      - Complete
+                      - Cancelled
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  type: object
+                type: array
+              replicas:
+                format: int32
+                type: integer
+              url:
                 type: string
             required:
-            - textInput
-            # - orchestrator
-            - chunker
-            - detector
-            - model
-          status:
-            description: GuardrailsJobStatus defines the observed state of GuardrailsJob
-            properties:
-              completeTime:
-                description: Information when the job's state changes to Complete.
-                format: date-time
-                type: string
-              lastScheduleTime:
-                description: Information when was the last time the job was successfully
-                  scheduled.
-                format: date-time
-                type: string
-              message:
-                description: Message about the current/final status
-                type: string
-              podName:
-                description: The name of the Pod that runs the evaluation job
-                type: string
-              reason:
-                description: Final result of the job
-                enum:
-                - NoReason
-                - Succeeded
-                - Failed
-                - Cancelled
-                type:
-                  string
-              results:
-                description: Evaluation results
-                type: string
-              state:
-                description: State of the job
-                enum:
-                - New
-                - Scheduled
-                - Running
-                - Complete
-                - Cancelled
-                type: string
-            type: object
+            - conditions
+            - replicas
+            - url
           type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/crd/bases/trustyai.opendatahub.io_guadrailsorchestrator.yaml
+++ b/config/crd/bases/trustyai.opendatahub.io_guadrailsorchestrator.yaml
@@ -40,19 +40,26 @@ spec:
                 type: object
                 properties:
                   provider:
+                    default: tgis
+                    description: Caikit model server
                     type: string
                     enum:
                       - nlp
                       - tgis
-                    pattern: ^(nlp|tgis)$
                     service:
                       type: object
                       properties:
                         hostname:
+                          description: Name of host to connect to
                           type: string
                         port:
+                          default: 8085
+                          description: Port number to connect to at the server host
                           type: integer
                         tls:
+                          default: caikit
+                          description: Name of the secret that holds the TLS certs
+                            including the CA certificates
                           type: string
               chunkers:
                 description: Chunker model
@@ -69,7 +76,11 @@ spec:
                         type: string
                       port:
                         description: The port
+                        default:
                         type: string
+                      tls:
+                        default: chunker
+                        description: TLS credentials
                     type: object
               detectors:
                 description: Dectector models(s)
@@ -82,6 +93,7 @@ spec:
                         type: string
                       port:
                         type: string
+                        default: ...
                     required:
                       - hostname
                       - port
@@ -98,6 +110,8 @@ spec:
                 description:
                 type: object
                 properties:
+                  ...:
+
                   cert_path:
                     type: string
                   key_path:
@@ -107,6 +121,8 @@ spec:
                 required:
                   - cert_path
                   - key_path
+              server_tls_path: /tls/server
+              orchestrator_tls_path: /tls/orch
             replicas:
               description: Number of replicas
               type: integer
@@ -122,20 +138,14 @@ spec:
                 items:
                   description: Condition represents possible conditions of a GuardrailsOrchestratorStatus
                   properties:
+                    type:
+                      type: string
                     lastTransitionTime:
                       description: The last time the condition transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
                       description: Message about the current/final status
-                      type: string
-                    reason:
-                      description: Final result of the orchestrator
-                      enum:
-                      - NoReason
-                      - Succeeded
-                      - Failed
-                      - Cancelled
                       type: string
                     status:
                       description: State of the orchestrator
@@ -144,6 +154,14 @@ spec:
                       - Scheduled
                       - Running
                       - Complete
+                      - Cancelled
+                      type: string
+                    reason:
+                      description: Final result of the orchestrator
+                      enum:
+                      - NoReason
+                      - Succeeded
+                      - Failed
                       - Cancelled
                       type: string
                   required:

--- a/config/crd/bases/trustyai.opendatahub.io_guadrailsorchestrator.yaml
+++ b/config/crd/bases/trustyai.opendatahub.io_guadrailsorchestrator.yaml
@@ -1,0 +1,105 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.1
+  creationTimestamp: null
+  name: guardrailjobs.trustyai.opendatahub.io
+spec:
+  group: trustyai.opendatahub.io
+  names:
+    kind: GuardrailJob
+    listkind: GuardrailJobList
+    plural: guardrailsjobs
+    singular: guardrailsjob
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: GuardrailsJob is the Schema for the guardrailjobs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: 'GuardrailsJobSpec defines the desired state of GuardrailsJob'
+            properties:
+              textInput:
+                description: Text input
+                type: string
+              chunker:
+                description: Chunker name
+                type: string
+                # items:
+                #   properties:
+                #     modelID:
+                #       description: The chunker model id
+                #
+              detector:
+                description: Detector name
+                type: string
+              model:
+                description: Model name
+                type: string
+            required:
+            - textInput
+            # - orchestrator
+            - chunker
+            - detector
+            - model
+          status:
+            description: GuardrailsJobStatus defines the observed state of GuardrailsJob
+            properties:
+              completeTime:
+                description: Information when the job's state changes to Complete.
+                format: date-time
+                type: string
+              lastScheduleTime:
+                description: Information when was the last time the job was successfully
+                  scheduled.
+                format: date-time
+                type: string
+              message:
+                description: Message about the current/final status
+                type: string
+              podName:
+                description: The name of the Pod that runs the evaluation job
+                type: string
+              reason:
+                description: Final result of the job
+                enum:
+                - NoReason
+                - Succeeded
+                - Failed
+                - Cancelled
+                type:
+                  string
+              results:
+                description: Evaluation results
+                type: string
+              state:
+                description: State of the job
+                enum:
+                - New
+                - Scheduled
+                - Running
+                - Complete
+                - Cancelled
+                type: string
+            type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/config/crd/bases/trustyai.opendatahub.io_guardrailsorchestrator.yaml
+++ b/config/crd/bases/trustyai.opendatahub.io_guardrailsorchestrator.yaml
@@ -1,0 +1,154 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.1
+  creationTimestamp: null
+  name: guardrailsorchestrator.trustyai.opendatahub.io
+spec:
+  group: trustyai.opendatahub.io
+  names:
+    kind: GuardrailOrchestrator
+    listkind: GuardrailsOrchestratorList
+    plural: guardrailsorchestrator
+    singular: guardrailsorchestrator
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: GuardrailsOrchestrator is the Schema for the guardrailorchestrator API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: 'GuardrailsOrchestratorSpec defines the desired state of GuardrailsOrchestrator'
+            properties:
+              generation:
+                description: Text generation model name
+                type: object
+                properties:
+                  provider:
+                    default: tgis
+                    description: The Caikit model server
+                    type: string
+                    enum:
+                      - nlp
+                      - tgis
+                    service:
+                      required:
+                        - hostname
+                        - port
+                        - protocol
+                      type: object
+                      hostname:
+                        description: Name of host to connect to
+                        type: string
+                      port:
+                        description: Port number to connect to at the server host
+                        type: integer
+                      protocol:
+                        description: gRPC or REST
+                      tls:
+                        description: Key in config map that holds the TLS certs including the CA certs
+                        type: string
+              chunkers:
+                description: A list of chunker model(s)
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      description: The name of the chunker model
+                      type: string
+                    type:
+                      description: The
+                      type: string
+                    service:
+                      description:
+                      type: object
+                      properties:
+                        host:
+                          description: Name of host to connect to
+                          type: string
+                        port:
+                          description: Port number to connect to at the server host
+                          type: integer
+                        protocol:
+                          description: gRPC or REST
+                        tls:
+                          description: Key in config map that holds the TLS certs including the CA certs
+                          type: string
+                      required:
+                        - host
+                        - port
+                        - protocol
+                  required:
+                    - name
+                    - type
+                    - service
+              detectors:
+                description: List of detector model(s)
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      description: The name of the detector model
+                      type: string
+                    service:
+                      type: object
+                      properties:
+                        hostname:
+                          description: Name of host to connect to
+                          type: string
+                        port:
+                          description: Port number to connect to at the server host
+                          type: integer
+                        protocol:
+                          description: gRPC or REST
+                        tls:
+                          description: Key in config map that holds the TLS certs including the CA certs
+                          type: string
+                        required:
+                          - hostname
+                          - port
+                    chunker_id:
+                      description: The name of the chunker
+                      type: string
+                    default_threshold:
+                      default: 0.5
+                      type: number
+                  required:
+                    - name
+                    - service
+                    - chunker_id
+                    - default_threshold
+              tls:
+                description:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      description:
+                    cert_path:
+                      description:
+                      type: string
+                    key_path:
+                      description:
+                      type: string
+                    client_ca_path:
+                      description:
+                      type: string

--- a/controllers/guardrails/README.md
+++ b/controllers/guardrails/README.md
@@ -1,32 +1,84 @@
 # The Backend of Guardrails Orchestrator
 
 * CustomResourceDefinition: The CRD defines the components of GuardrailsOrchestator which are the generator, chunker, and detector
-    * Kind: `GuardrailsOrchestratorService`
+    * Kind: `GuardrailsService`
     * Version: `v1alpha1`
-* Controller: The controller reconciles the `GuadrailsOrchestratorSevice` custom resources, creates corresponding Pods, stores results, and cancels services.
+* Controller: The controller reconciles the `GuadrailsSevice` custom resources, creates corresponding Pods, stores results, and cancels services.
 
 ## High Level Architecture
+```mermaid
 
+flowchart RL
+    A((fa:fa-user Client))
+    classDef client fill:#9900ff,stroke:#9900ff,stroke-width:2px
+    A:::client --> |Guardrails Requests| OpenShift
+    OpenShift --> |Response| A
+    subgraph OpenShift
+        direction TB
+        subgraph ingress
+            direction LR
+            B[Load Balancer]
+            classDef ocingress fill:#cc6600,stroke:#ff9900,stroke-width:2px
+        end
+        B:::ocingress <--> C
+        subgraph Guardrails
+            direction RL
+            subgraph Deployments
+                direction LR
+                C[[API Server]]
+                D[Controller]
+                classDef deploy fill:#0033cc,stroke:#0066cc,stroke-width:2px
+            end
+            subgraph Pods
+                G1[service1]
+                G2[service2]
+                G3[service3]
+                classDef pod fill:#990000,stroke:#990000,stroke-width:2px
+            end
+            D --> |Create/Delete pod| G1:::pod & G2:::pod & G3:::pod
+        end
+        subgraph Control Plane
+            E[(etcd)]
+            F([kube-apiserver])
+            classDef control fill:#339966,stroke:#669999,stroke-width:2px
+        end
+        D:::deploy <--> |reconcile GuardrailsService| F:::control
+        C:::deploy <--> |Create/Get/Update GuardrailsService| F
+        G1 & G2 & G3 --> |Collect results and update GuardrailsService| D
+        F <--> E:::control
+    end
+```
 
-## State Transition of a GuardrailsOrchestrator
+## State Transition of a GuardrailsService
+```mermaid
+stateDiagram-v2
+    [*] --> New
+    New --> Scheduled : Prepare resources and create a pod to run the job
+    Scheduled --> Running : Get update from the orchestrator
+    Running --> Complete : Collect results
+    Scheduled --> Failed : Time-out or fail to initialize the pod
+    Running --> Failed : Program error or time-out
+    Failed --> Complete : Collect logs
+    Complete --> [*]
 
+```
 ## Design
 
 ### Custom Resource Definition (CRD)
-The data structure for a GuardrailsOrchestrator contains the following fields:
+The data structure for a GuardrailsService contains the following fields:
 
-| GuardrailsOrchestrator | Data Type | Optional | Parameter in GuardrailsOrchestrator | Description
+| GuardrailsService | Data Type | Optional | Parameter in GuardrailsService | Description
 | --- | --- | --- | --- | -- |
 | Generator | string | | --generator | Generator name or ID|
 | Detector | string |  | --detector | Detector name or ID |
-| DetectorArgs | []string |  | --detector_args | Configurations for the selected detector. The data is converted to a string in this format and passed to the GuardrailsOrchestrator: `arg1=val1,arg2=val2` |
+| DetectorArgs | []string |  | --detector_args | Configurations for the selected detector. The data is converted to a string in this format and passed to the GuardrailsService: `arg1=val1,arg2=val2` |
 | Chunker | string | ✅ | --chunker | Chunker name or ID |
-| ChunkerArgs | []string | ✅ | --chunker_args | Configurations for the selected chunker. The data is converted to a string in this format and passed to the GuardrailsOrchestrator: `arg1=val1,arg2=val2` |
+| ChunkerArgs | []string | ✅ | --chunker_args | Configurations for the selected chunker. The data is converted to a string in this format and passed to the GuardrailsService: `arg1=val1,arg2=val2` |
 
-The `Status` subresource of the `GuardrailsOrchestrator` CRB contains the following information:
+The `Status` subresource of the `GuardrailsService` CRB contains the following information:
 
-* `PodName`: the name of the Pod that runs the guardrails-orchestrator service
-* `State`: records the status of the  guardrails-orchestrator service. Possible values are:
+* `PodName`: the name of the Pod that runs the guardrails service
+* `State`: records the status of the  guardrails service. Possible values are:
     * `New`: the service is created but not yet processed by the controller
     * `Scheduled`: a Pod is created by the controller for the service
     * `Running`: the Pod for the service is running
@@ -40,17 +92,20 @@ The `Status` subresource of the `GuardrailsOrchestrator` CRB contains the follow
 * `Message`: additional details about the final state
 * `LastScheduleTime`: timestamp of when the Pod is scheduled
 * `CompleteTime`: timestamp of when the service's state is `Complete`
-* `Results`: stores the results of the guardrails-orchestrator service results
+* `Results`: stores the results of the guardrails service results
 
 ## The Controller
-The controller is responsible for monitoring the `GuardrailsOrchestratorService` CRs and reconciling the corresponding Pods. Here are the details of how the controller handles an `GuardrailsOrchestratorService` CR:
-* ConfigMap: provides the controller with instructions on how to configure the `GuardrailsOrchestrator` CR:
-    * pod-image
-    * pod-checking-interval
-    * image-pull-policy
+The controller is responsible for monitoring the `GuardrailsService` CRs and reconciling the corresponding Pods. Here are the details of how the controller handles an `GuardrailsService` CR:
+* ConfigMap: provides the controller with instructions on how to configure the `GuardrailsService` CR:
+    * orchestrator-image: Contains the orchestrator binary. Used in the `init` container
+    * pod-image: Used in the `main` container
+    * pod-checking-interval: The controller checks the scheduled pods at a fixed time interval. The defualt value is `10s`
+    * image-pull-policy: Default value is `Always`
 
 * Arguments: the controller supports the following command line arguments:
-    * --namespace: the namespace where you deploy the controller. By default, the namespace of the controller deployment is used
-    * --configmap: the name of the ConfigMap where the config settings are stored
+    * `--namespace`: the namespace where you deploy the controller. By default, the namespace of the controller deployment is used
+    * `--configmap`: the name of the ConfigMap where the config settings are stored
 
-* Finalizer
+* Finalizer: The controller is one of `GuardrailsService`'s finalizers. Ensures the controller reconciles `GuardrailsService`'s before deletion
+
+## The Orchestrator

--- a/controllers/guardrails/README.md
+++ b/controllers/guardrails/README.md
@@ -1,0 +1,56 @@
+# The Backend of Guardrails Orchestrator
+
+* CustomResourceDefinition: The CRD defines the components of GuardrailsOrchestator which are the generator, chunker, and detector
+    * Kind: `GuardrailsOrchestratorService`
+    * Version: `v1alpha1`
+* Controller: The controller reconciles the `GuadrailsOrchestratorSevice` custom resources, creates corresponding Pods, stores results, and cancels services.
+
+## High Level Architecture
+
+
+## State Transition of a GuardrailsOrchestrator
+
+## Design
+
+### Custom Resource Definition (CRD)
+The data structure for a GuardrailsOrchestrator contains the following fields:
+
+| GuardrailsOrchestrator | Data Type | Optional | Parameter in GuardrailsOrchestrator | Description
+| --- | --- | --- | --- | -- |
+| Generator | string | | --generator | Generator name or ID|
+| Detector | string |  | --detector | Detector name or ID |
+| DetectorArgs | []string |  | --detector_args | Configurations for the selected detector. The data is converted to a string in this format and passed to the GuardrailsOrchestrator: `arg1=val1,arg2=val2` |
+| Chunker | string | ✅ | --chunker | Chunker name or ID |
+| ChunkerArgs | []string | ✅ | --chunker_args | Configurations for the selected chunker. The data is converted to a string in this format and passed to the GuardrailsOrchestrator: `arg1=val1,arg2=val2` |
+
+The `Status` subresource of the `GuardrailsOrchestrator` CRB contains the following information:
+
+* `PodName`: the name of the Pod that runs the guardrails-orchestrator service
+* `State`: records the status of the  guardrails-orchestrator service. Possible values are:
+    * `New`: the service is created but not yet processed by the controller
+    * `Scheduled`: a Pod is created by the controller for the service
+    * `Running`: the Pod for the service is running
+    * `Complete`: the service request finishes or fails
+    * `Cancelled`: the controller canceled the service and will mark it as complete
+* `Reason`: details about the current state.
+    * `NoReason`: there is no information about the current state
+    * `Succeeded`: the service finished successfully
+    * `Failed`: the service failed
+    * `Cancelled`: the service is cancelled
+* `Message`: additional details about the final state
+* `LastScheduleTime`: timestamp of when the Pod is scheduled
+* `CompleteTime`: timestamp of when the service's state is `Complete`
+* `Results`: stores the results of the guardrails-orchestrator service results
+
+## The Controller
+The controller is responsible for monitoring the `GuardrailsOrchestratorService` CRs and reconciling the corresponding Pods. Here are the details of how the controller handles an `GuardrailsOrchestratorService` CR:
+* ConfigMap: provides the controller with instructions on how to configure the `GuardrailsOrchestrator` CR:
+    * pod-image
+    * pod-checking-interval
+    * image-pull-policy
+
+* Arguments: the controller supports the following command line arguments:
+    * --namespace: the namespace where you deploy the controller. By default, the namespace of the controller deployment is used
+    * --configmap: the name of the ConfigMap where the config settings are stored
+
+* Finalizer

--- a/controllers/guardrails/certificates.go
+++ b/controllers/guardrails/certificates.go
@@ -1,0 +1,83 @@
+package guardrails
+
+import (
+	"context"
+
+	guardrailsv1alpha1 "github.com/trustyai-explainability/trustyai-orchestrator-operator/api/guardrails/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	tlsMountPath = "/tls/server"
+)
+
+type TLSCertVolumes struct {
+	volume      corev1.Volume
+	volumeMount corev1.VolumeMount
+}
+
+func (cert *TLSCertVolumes) createCertVolume() {
+	volume := corev1.Volume{
+		Name: "server-tls",
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: "",
+			},
+		},
+	}
+	volumeMount := corev1.VolumeMount{
+		Name:      "server-tls",
+		MountPath: tlsMountPath,
+		ReadOnly:  true,
+	}
+	cert.volume = volume
+	cert.volumeMount = volumeMount
+}
+
+func (r *GuardrailsOrchestratorReconciler) getConfigMapNamesWithLabel(ctx context.Context, namespace string, labelSelector client.MatchingLabels) ([]string, error) {
+	configMapList := &corev1.ConfigMapList{}
+
+	// List ConfigMaps with the specified label selector
+	err := r.Client.List(ctx, configMapList, client.InNamespace(namespace), labelSelector)
+	if err != nil {
+		return nil, err
+	}
+
+	var names []string
+	for _, cm := range configMapList.Items {
+		names = append(names, cm.Name)
+	}
+
+	return names, nil
+}
+
+func (r *GuardrailsOrchestratorReconciler) getCustomCertificateBundle(ctx context.Context, orchestrator *guardrailsv1alpha1.GuardrailOrchestrator) CustomCertificatesBundle {
+	var customCertificatesBundle CustomCertificatesBundle
+	labelSelector := client.MatchingLabels{caBundleAnnotation: "true"}
+	configMapNames, err := r.getConfigMapNamesWithLabel(ctx, orchestrator.Namespace, labelSelector)
+	caNotFoundMessage := "ConfigMap resource named '" + caBundleName + "' not found. Not using custom CA bundle."
+
+	if err != nil {
+		log.FromContext(ctx).Info(caNotFoundMessage)
+		customCertificatesBundle.IsDefined = false
+	} else {
+		found := false
+		for _, configMapName := range configMapNames {
+			if configMapName == caBundleName {
+				found = true
+				break
+			}
+		}
+		if found {
+			log.FromContext(ctx).Info("Found trusted CA bundle ConfigMap. Using custom CA bundle.")
+			customCertificatesBundle.IsDefined = true
+			customCertificatesBundle.ConfigMapName = caBundleName
+		} else {
+			log.FromContext(ctx).Info(caNotFoundMessage)
+			customCertificatesBundle.IsDefined = false
+		}
+	}
+	return customCertificatesBundle
+}

--- a/controllers/guardrails/constants.go
+++ b/controllers/guardrails/constants.go
@@ -1,0 +1,44 @@
+package guardrails
+
+// TODO: create new orchestrator image
+const (
+	defaultImage       = string("")
+	finalizerName      = "guardrails.opendatahub.io/finalizer"
+	serverTLSMountPath = "/tls/server"
+	orchTLSMouthPath   = "/tls/orch"
+)
+
+// Allowed TLS modes
+const (
+	TLSMode_TLS  = "TLS"
+	TLSMode_mTLS = "mTLS"
+	TLSMode_None = "None"
+)
+
+// Status types
+const (
+	// StatusTypeGenerationPresent = "GeneratorPresent"
+	// StatusTypeChunkerPresent    = "ChunkerPresent"
+	StatusTypeDetectorPresent = "DetectorPresent"
+	StatusTypeRouteAvailable  = "RouteAvailable"
+	StatusTypeAvailable       = "Available"
+)
+
+// Status reasons
+const (
+	// StatusReasonGenerationNotFound = "GeneratorNotFound"
+	// StatusReasonGenerationFound    = "GeneratorFound"
+	// StatusReasonChunkerNotFound    = "ChunkerNotFound"
+	// StatusReasonChunkerFound       = "ChunkerFound"
+	StatusReasonDetectorNotFound = "DetectorNotFound"
+	StatusReasonDetectorFound    = "DetectorFound"
+	StatusReasonRouteNotFound    = "RouteNotFound"
+	StatusReasonRouteFound       = "RouteFound"
+	StatusAvailable              = "AllComponentsReady"
+	StatusNotAvailable           = "NotAllComponentsReady"
+)
+
+// Event reasons
+const (
+	EventReasonDetectorServiceConfigured = "DetectorServiceCreated"
+)

--- a/controllers/guardrails/constants.go
+++ b/controllers/guardrails/constants.go
@@ -1,4 +1,4 @@
-package guardrails
+package guaradrails
 
 // TODO: create new orchestrator image
 const (
@@ -8,12 +8,12 @@ const (
 	orchTLSMouthPath   = "/tls/orch"
 )
 
-// Allowed TLS modes
-const (
-	TLSMode_TLS  = "TLS"
-	TLSMode_mTLS = "mTLS"
-	TLSMode_None = "None"
-)
+// // Allowed TLS modes
+// const (
+// 	TLSMode_TLS  = "TLS"
+// 	TLSMode_mTLS = "mTLS"
+// 	TLSMode_None = "None"
+// )
 
 // Status types
 const (
@@ -39,4 +39,8 @@ const (
 const (
 	EventReasonGenerationCreated = "GeneratorServiceCreated"
 	EventReasonDetectorCreated   = "DetectorServiceCreated"
+)
+
+const (
+	StateReasonCrashLoopBackOff = "CrashLoopBackOff"
 )

--- a/controllers/guardrails/constants.go
+++ b/controllers/guardrails/constants.go
@@ -17,28 +17,26 @@ const (
 
 // Status types
 const (
-	// StatusTypeGenerationPresent = "GeneratorPresent"
-	// StatusTypeChunkerPresent    = "ChunkerPresent"
-	StatusTypeDetectorPresent = "DetectorPresent"
-	StatusTypeRouteAvailable  = "RouteAvailable"
-	StatusTypeAvailable       = "Available"
+	StatusTypeGenerationPresent = "GeneratorPresent"
+	StatusTypeDetectorPresent   = "DetectorPresent"
+	StatusTypeRouteAvailable    = "RouteAvailable"
+	StatusTypeAvailable         = "Available"
 )
 
 // Status reasons
 const (
-	// StatusReasonGenerationNotFound = "GeneratorNotFound"
-	// StatusReasonGenerationFound    = "GeneratorFound"
-	// StatusReasonChunkerNotFound    = "ChunkerNotFound"
-	// StatusReasonChunkerFound       = "ChunkerFound"
-	StatusReasonDetectorNotFound = "DetectorNotFound"
-	StatusReasonDetectorFound    = "DetectorFound"
-	StatusReasonRouteNotFound    = "RouteNotFound"
-	StatusReasonRouteFound       = "RouteFound"
-	StatusAvailable              = "AllComponentsReady"
-	StatusNotAvailable           = "NotAllComponentsReady"
+	StatusReasonGenerationNotFound = "GeneratorNotFound"
+	StatusReasonGenerationFound    = "GeneratorFound"
+	StatusReasonDetectorNotFound   = "DetectorNotFound"
+	StatusReasonDetectorFound      = "DetectorFound"
+	StatusReasonRouteNotFound      = "RouteNotFound"
+	StatusReasonRouteFound         = "RouteFound"
+	StatusAvailable                = "AllComponentsReady"
+	StatusNotAvailable             = "NotAllComponentsReady"
 )
 
 // Event reasons
 const (
-	EventReasonDetectorServiceConfigured = "DetectorServiceCreated"
+	EventReasonGenerationCreated = "GeneratorServiceCreated"
+	EventReasonDetectorCreated   = "DetectorServiceCreated"
 )

--- a/controllers/guardrails/deployment.go
+++ b/controllers/guardrails/deployment.go
@@ -1,0 +1,99 @@
+package guardrails
+
+import (
+	"context"
+	"reflect"
+
+	guardrailsv1alpha1 "github.com/trustyai-explainability/trustyai-service-operator/api/guardrails/v1alpha1"
+	templateParser "github.com/trustyai-explainability/trustyai-service-operator/controllers/tas/templates"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	deploymentTemplatePath = "templates/deployment.tmpl.yaml"
+)
+
+type DeploymentConfig struct {
+	Orchestrator      *guardrailsv1alpha1.GuardrailsOrchestrator
+	OrchestratorImage string
+}
+
+func (r *GuardrailsOrchestratorReconciler) createDeploymentObject(ctx context.Context, orchestrator *guardrailsv1alpha1.GuardrailsOrchestrator, orchestratorImage string) (*appsv1.Deployment, error) {
+	deploymentConfig := DeploymentConfig{
+		Orchestrator:      orchestrator,
+		OrchestratorImage: orchestratorImage,
+	}
+
+	var deployment *appsv1.Deployment
+	deployment, err := .ParseResource[appsv1.Deployment](deploymentTemplatePath, deploymentConfig, reflect.TypeOf(&appsv1.Deployment{}))
+	if err != nil {
+		log.FromContext(ctx).Error(err, "Error parsing the orchestrator's deployment template")
+		return nil, err
+	}
+	return deployment, nil
+}
+
+func (r *GuardrailsOrchestratorReconciler) createDeployment(ctx context.Context, orchestrator *guardrailsv1alpha1.GuardrailsOrchestrator) error {
+	deployment, err := r.createDeploymentObject(ctx, orchestrator, defaultImage)
+	if err != nil {
+		return err
+	}
+	if err := ctrl.SetControllerReference(orchestrator, deployment, r.Scheme); err != nil {
+		log.FromContext(ctx).Error(err, "Error setting Guardrails Orchestrator as the owner of Deployment")
+		return err
+	}
+	log.FromContext(ctx).Info("Creating Deployment")
+	err = r.Create(ctx, deployment)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "Error creating Deployment")
+	}
+	return nil
+}
+
+func (r *GuardrailsOrchestratorReconciler) checkDeploymentReady(ctx context.Context, orchestrator *guardrailsv1alpha1.GuardrailsOrchestrator) (bool, error) {
+	deployment := &appsv1.Deployment{}
+
+	err := r.Get(ctx, types.NamespacedName{Name: orchestrator.Name, Namespace: orchestrator.Namespace}, deployment)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	for _, cond := range deployment.Status.Conditions {
+		if cond.Type == appsv1.DeploymentAvailable && cond.Status == corev1.ConditionTrue {
+			if deployment.Status.ReadyReplicas == *deployment.Spec.Replicas {
+				podList := &corev1.PodList{}
+				listOpts := []client.ListOption{
+					client.InNamespace(orchestrator.Namespace),
+					client.MatchingLabels(deployment.Spec.Selector.MatchLabels),
+				}
+				if err := r.List(ctx, podList, listOpts...); err != nil {
+					return false, err
+				}
+
+				for _, pod := range podList.Items {
+					for _, cs := range pod.Status.ContainerStatuses {
+						if cs.State.Waiting != nil && cs.State.Waiting.Reason == StateReasonCrashLoopBackOff {
+							return false, nil
+						}
+						if cs.State.Terminated != nil && cs.State.Terminated.ExitCode != 0 {
+							return false, nil
+						}
+					}
+				}
+
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}

--- a/controllers/guardrails/guardrails_controller.go
+++ b/controllers/guardrails/guardrails_controller.go
@@ -1,0 +1,744 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package guardrails
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/go-logr/logr"
+	"github.com/spf13/viper"
+	guardrailsv1alpha1 "github.com/trustyai-explainability/trustyai-service-operator/api/guardrails/v1alpha1"
+)
+
+var (
+	optionKeys = map[string]string{
+		"PodImage":             PodImageKey,
+		"OrchestratorImage":    OrchestratorImageKey,
+		"PodCheckingInterval":  PodCheckingIntervalKey,
+		"ImagePullPolicy":      ImagePullPolicyKey,
+		"GrpcPort":             GrpcPortKey,
+		"GrpcService":          GrpcServiceKey,
+		"GrpcServerSecret":     GrpcServerSecretKey,
+		"GrpcClientSecret":     GrpcClientSecretKey,
+	}
+)
+
+type TLSMode int
+
+// GuardrailsService reconciles a GuardrailsService object
+type GuardrailsServiceReconciler struct {
+	client.Client
+	Scheme 		  *runtime.Scheme
+	EventRecorder record.EventRecorder
+	ConfigMap	  string
+	Namespace     string
+	options       *ServiceOptions
+}
+
+type ServiceOptions struct {
+	OrchestratorImage    string
+	PodImage             string
+	PodCheckingInterval  time.Duration
+	ImagePullPolicy      corev1.PullPolicy
+	GrpcPort             int
+	GrpcService          string
+	GrpcServerSecret     string
+	GrpcClientSecret     string
+	grpcTLSMode          TLSMode
+}
+
+func ControllerSetUp(mgr manager.Manager, ns, configmap string, recorder record.EventRecorder) error {
+	return (&GuardrailsServiceReconciler{
+		ConfigMap:     configmap,
+		Namespace:     ns,
+		Client:        mgr.GetClient(),
+		Scheme:        mgr.GetScheme(),
+		EventRecorder: recorder,
+	}).SetupWithManager(mgr)
+}
+
+// +kubebuilder:rbac:groups=trustyai.opendatahub.io,resources=guardrailsservices,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=trustyai.opendatahub.io,resources=guardrailsservices/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=trustyai.opendatahub.io,resources=guardrailsservices/finalizers,verbs=update
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;create;delete
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;watch;list
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;watch;list
+
+func (r *GuardrailsServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := log.FromContext(ctx)
+
+	service := &guardrailsv1alpha1.GuardrailsService{}
+	if err := r.Get(ctx, req.NamespacedName, service); err != nil {
+		log.Info("unable to fetch GuardrailsService. could be from a deletion request")
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if !service.ObjectMeta.DeletionTimestamp.IsZero() {
+		// Handle deletion here
+		return r.handleDeletion(ctx, service, log)
+	}
+
+	// Treat this as NewserviceState
+	if service.Status.LastScheduleTime == nil {
+		service.Status.State = guardrailsv1alpha1.NewServiceState
+	}
+
+	// Handle the service based on its state
+	switch service.Status.State {
+	case guardrailsv1alpha1.NewServiceState:
+		// Handle newly created service
+		return r.handleNewCR(ctx, log, service)
+	case guardrailsv1alpha1.ScheduledServiceState:
+		// the service's pod has been created
+		// let's check the pod status and detect pod failure if there is
+		return r.checkScheduledPod(ctx, log, service)
+	case guardrailsv1alpha1.RunningServiceState:
+		// TODO: need a timeout/retry mechanism here to transite to other states
+		return r.checkScheduledPod(ctx, log, service)
+	case guardrailsv1alpha1.CompleteServiceState:
+		return r.handleComplete(ctx, log, service)
+	case guardrailsv1alpha1.CancelledserviceState:
+		return r.handleCancel(ctx, log, service)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *GuardrailsServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+
+	// Add a runnable to retrieve the settings from the specified configmap
+	if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+		var cm corev1.ConfigMap
+		if err := r.Get(
+			ctx,
+			types.NamespacedName{Namespace: r.Namespace, Name: r.ConfigMap},
+			&cm); err != nil {
+
+			ctrl.Log.WithName("setup").Error(err,
+				"failed to get configmap",
+				"namespace", r.Namespace,
+				"name", r.ConfigMap)
+
+			return err
+		}
+
+		if err := r.constructOptionsFromConfigMap(ctx, &cm); err != nil {
+			return err
+		}
+
+		if err := r.checkSecrets(ctx); err != nil {
+			// if mTLS/TLS is not enable, then we are good. Otherwise error out
+			if viper.IsSet(GrpcServerCertEnv) ||
+				viper.IsSet(GrpcServerKeyEnv) ||
+				viper.IsSet(GrpcClientCaEnv) {
+				return fmt.Errorf("TLS or mTLS is enabled for GRPC server but secrets don't exist")
+			}
+		}
+
+		go StartGrpcServer(ctx, r)
+
+		return nil
+	})); err != nil {
+		return err
+	}
+
+	// watch the pods created by the controller but only for the deletion event
+	return ctrl.NewControllerManagedBy(mgr).
+		// since we register the finalizer, no need to monitor deletion events
+		For(&guardrailsv1alpha1.GuardrailsService{}, builder.WithPredicates(predicate.Funcs{
+			// drop deletion events
+			DeleteFunc: func(event.DeleteEvent) bool {
+				return false
+			},
+		})).
+		Watches(
+			&source.Kind{Type: &corev1.Pod{}},
+			&handler.EnqueueRequestForOwner{
+				OwnerType:    &guardrailsv1alpha1.GuardrailsService{},
+				IsController: true,
+			},
+			builder.WithPredicates(predicate.Funcs{
+				// drop all events except deletion
+				CreateFunc: func(event.CreateEvent) bool {
+					return false
+				},
+				UpdateFunc: func(event.UpdateEvent) bool {
+					return false
+				},
+				GenericFunc: func(event.GenericEvent) bool {
+					return false
+				},
+			}),
+		).
+		Complete(r)
+}
+
+func (r *GuardrailsServiceReconciler) checkSecrets(ctx context.Context) error {
+	var isSecretExists = func(name string) bool {
+		var secret corev1.Secret
+		err := r.Get(ctx, types.NamespacedName{Namespace: r.Namespace, Name: name}, &secret)
+		return err == nil
+	}
+
+	if !isSecretExists(r.options.GrpcServerSecret) {
+		return fmt.Errorf("secret %s not found", r.options.GrpcServerSecret)
+	}
+	if !isSecretExists(r.options.GrpcClientSecret) {
+		return fmt.Errorf("secret %s not found", r.options.GrpcServerSecret)
+	}
+	return nil
+}
+
+// TO-DO
+func (r *GuardrailsServiceReconciler) updateStatus(ctx context.Context, newStatus *) (err error) {
+	log := log.FromContext(ctx)
+
+	if strings.Trim(newStatus.GetServiceName(), )
+	return err
+}
+
+func (r *GuardrailsServiceReconciler) constructOptionsFromConfigMap(
+	ctx context.Context, configmap *corev1.ConfigMap) error {
+	r.options = &ServiceOptions{
+		OrchestratorImage:	  DefualtOrchestratorImage,
+		PodImage:             DefaultPodImage,
+		PodCheckingInterval:  DefaultPodCheckingInterval,
+		ImagePullPolicy:      DefaultImagePullPolicy,
+		GrpcPort:             DefaultGrpcPort,
+		GrpcService:          DefaultGrpcService,
+		GrpcServerSecret:     DefaultGrpcServerSecret,
+		GrpcClientSecret:     DefaultGrpcClientSecret,
+	}
+	log := log.FromContext(ctx)
+	rv := reflect.ValueOf(r.options).Elem()
+	var msgs []string
+
+	for idx, cap := 0, rv.NumField(); idx < cap; idx++ {
+		frv := rv.Field(idx)
+		fname := rv.Type().Field(idx).Name
+		configKey, ok := optionKeys[fname]
+		if !ok {
+			continue
+		}
+
+		if v, found := configmap.Data[configKey]; found {
+			var err error
+			switch frv.Type().Name() {
+			case "string":
+				frv.SetString(v)
+			case "int":
+				var intVal int
+				intVal, err = strconv.Atoi(v)
+				if err == nil {
+					frv.SetInt(int64(intVal))
+				}
+			case "Duration":
+				var d time.Duration
+				d, err = time.ParseDuration(v)
+				if err == nil {
+					frv.Set(reflect.ValueOf(d))
+				}
+			case "PullPolicy":
+				if p, found := pullPolicyMap[corev1.PullPolicy(v)]; found {
+					frv.Set(reflect.ValueOf(p))
+				} else {
+					err = fmt.Errorf("invalid PullPolicy")
+				}
+			default:
+				return fmt.Errorf("can not handle the config %v, type: %v", optionKeys[fname], frv.Type().Name())
+			}
+
+			if err != nil {
+				msgs = append(msgs, fmt.Sprintf("invalid setting for %v: %v, use default setting instead", optionKeys[fname], v))
+			}
+		}
+	}
+
+	if len(msgs) > 0 {
+		log.Error(fmt.Errorf("some settings in the configmap are invalid"), strings.Join(msgs, "\n"))
+	}
+
+	return nil
+}
+
+func (r *GuardrailsServiceReconciler) handleDeletion(ctx context.Context, service *guardrailsv1alpha1.Guardrails, log logr.Logger) (reconcile.Result, error) {
+	// check if the service contains finalizer
+	if controllerutil.ContainsFinalizer(service, guardrailsv1alpha1.FinalizerName) {
+		// check for incomplete or cancelled service
+		if service.Status.State != guardrailsv1alpha1.CompleteServiceState ||
+			service.Status.Reason != guardrailsv1alpha1.CancelledReason {
+			// check for pod deletion error
+			if err := r.deleteservicePod(ctx, service); err != nil && client.IgnoreNotFound(err) != nil {
+				log.Error(err, "failed to delete pod")
+			}
+		}
+
+		// remove finalizer
+		controllerutil.RemoveFinalizer(service, guardrailsv1alpha1.FinalizerName)
+		if err := r.Update(ctx, service); err != nil {
+			return ctrl.Result{}, err
+		}
+		r.EventRecorder.Event(service, "Normal", "DetachFinalizer",
+			fmt.Sprintf("Removed finalizer from GuardrailsService %s in namespace %s",
+				service.Name,
+				service.Namespace))
+		log.Info("Sucessfully remove the finalizer", "name", service.Name)
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *GuardrailsServiceReconciler) handleNewCR(ctx context.Context, log logr.Logger, service *guardrailsv1alpha1.Guardrails) (reconcile.Result, error) {
+	// check if the service contains our finalizer, if not, add it
+	if controllerutil.ContainsFinalizer(service, guardrailsv1alpha1.FinalizerName) {
+		controllerutil.AddFinalizer(service, guardrailsv1alpha1.FinalizerName)
+		// check for finalizer update errors
+		if err := r.Update(ctx, service); err != nil {
+			log.Error(err, "Unable to update finalizer")
+			return ctrl.Result{}, err
+		}
+		r.EventRecorder.Event(service, "Normal", "AttachFinalizer",
+			fmt.Sprintf("Added the finalizer to the Guardrails %s in namespace %s",
+				service.Name,
+				service.Namespace))
+		return ctrl.Result{}, nil
+	}
+	// contruct a new pod and create a pod for the service
+	currentTime := v1.Now()
+	pod := r.createPod(service, log)
+	// check for pod creation errors
+	if err := r.Create(ctx, pod, &client.CreateOptions{}); err != nil {
+		service.Status.State = guardrailsv1alpha1.CompleteServiceState
+		service.Status.Reason = guardrailsv1alpha1.FailedReason
+		service.Status.Message = err.Error()
+		if err := r.Status().Update(ctx, service); err != nil {
+			log.Error(err, "Unable to update GuardrailsService status for pod creation failure")
+		}
+		log.Error(err, "Failed to create GuardrailsService pod")
+		return ctrl.Result{}, nil
+	}
+	// if pod creation is successful
+	service.Status.Status = guardrailsv1alpha1.ScheduledServiceState
+	service.Status.PodName = pod.BatcherConfigMapKeyName
+	service.Status.LastScheduleTime = &currentTime
+	if err := r.Status().Update(ctx, service); err != nil {
+		log.Error(err, "Unable to update GuardrailsService status after pod creation")
+		return ctrl.Result{}, nil
+	}
+	r.EventRecorder.Event(service, "Normal", "PodCompleted",
+		fmt.Sprintf("The pod for the GuardrailsService %s in namespace %s has completed",
+			service.Name,
+			service.Namespace))
+	log.Info("Succesfully created a Pod for the GuardrailsService")
+	// check the pod after the config interval
+	return ctrl.Result{Requeue: true, RequeueAfter: r.options.PodCheckingInterval}, nil
+}
+
+func (r *GuardrailsServiceReconciler) checkScheduledPod(ctx context.Context, log logr.Logger, service *guardrailsv1alpha1.Guardrails) (ctrl.Result, error) {
+	pod, err := r.getPod(ctx, service)
+	if err != nil {
+		service.Status.State = guardrailsv1alpha1.CompleteServiceState
+		service.Status.Reason = guardrailsv1alpha1.FailedReason
+		service.Status.Message = err.Error()
+		if err := r.Status().Update(ctx, service); err != nil {
+			log.Error(err, "Unaled to update GuardrailsService", "state", service.Status.State)
+			return ctrl.Result{}, err
+		}
+		r.EventRecorder.Event(service, "Warning", "PodMissing",
+			fmt.Sprintf("The pod for GuardrailsService %s in namespace %s is missing",
+				service.Name,
+				service.Namespace))
+		log.Error(err, "Since the pod is missing, mark the GuardrailsService as complete with error.")
+		return ctrl.Result{}, err
+	}
+
+	if pod.Status.ContainerStatuses == nil {
+		// wait for the pod to initialize and run the containers
+		return ctrl.Result{Requeue: true, RequeueAfter: r.options.PodCheckingInterval}, nil
+	}
+
+	// TO DO: Check container status
+
+	err = r.Status().Update(ctx, service)
+	if err != nil {
+		log.Error(err, "Unable to update GuardrailsService status", "state", service.Status.State)
+	}
+	r.EventRecorder.Event(service, "Normal", "PodCompleted",
+		fmt.Sprintf("The pod for GuardrailsService %s in namespace %s is complete",
+			service.Name,
+			service.Namespace))
+	return ctrl.Result{}, err
+}
+
+func (r *GuardrailsServiceReconciler) getPod(ctx context.Context, log logr.Logger) *corev1.Pod {
+	var allowPrivilegeEscalation = false
+	var runAsNonRootUser = true
+	var ownerRefController = true
+	var runAsUser int64 = 1001030000
+	// compose the pod CR
+	pod := corev1.Pod{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      service.Name,
+			Namespace: service.Namespace,
+		},
+	}
+	return &pod
+}
+
+func (r *GuardrailsServiceReconciler) deletePod(ctx context.Context, service *guardrailsv1alpha1.Guardrails) error {
+	pod := corev1.Pod{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      job.Status.PodName,
+			Namespace: job.Namespace,
+			OwnerReferences: []v1.OwnerReference{
+				{
+					APIVersion: job.APIVersion,
+					Kind:       job.Kind,
+					Name:       job.Name,
+				},
+			},
+		},
+	}
+	return r.Delete(ctx, &pod, &client.DeleteOptions{})
+}
+
+func (r *&GuardrailsServiceReconciler) handleCancel(ctx context.Context, log logr.Logger, service *guardrailsv1alpha1.GuardrailsService) (ctrl.Result, error) {
+	// delete the pod and update its state to Complete
+	if _, err := r.getPod(ctx, service); err != nil {
+		// pod is deleted so update its state to Complete
+		service.Status.State = guardrailsv1alpha1.CompleteServiceState
+		service.Status.Reason = guardrailsv1alpha1.FailedReason
+		service.Status.Message = err.Error()
+	} else {
+		service.Status.State = guardrailsv1alphav1.CompleteServiceState
+		service.Status.Reason = guardrailsv1alpha.CancelledReason
+		if err := r.deleteservicePod(ctx, service); err != nil {
+			log.Error(err, "Failed to delete pod. Retry scheduled", "interval", r.options.PodCheckingInterval.String())
+			return ctrl.Result{Requeue: true, RequeueAfter: r.options.PodCheckingInterval}, err
+		}
+	}
+	err := r.Status().Update(ctx, service)
+	if err != nil {
+		log.Error(err, "Failed to update status for cancellation.")
+	}
+	r.EventRecorder.Event(service, "Normal", "Cancelled"
+		fmt.Sprintf("The GuardrailsService %s in namespace %s has been cancelled and its state is now Complete",
+			service.Name,
+			service.Namespace))
+	return ctrl.Result{}, err
+}
+
+// TO-DO: Need to figure out what resources the Pod needs
+func (r *&GuardrailsServiceReconciler) createPod(service * guardrailsv1alpha1.GuardrailsService, log logr.Logger) *corev1.Pod {
+	var allowPrivilegeEscalation = false
+	var runAsNonRootUser = true
+	var ownerRefController = true
+	var runAsUser int64 = 1001030000
+
+	var envVars = generateEnvs(service.Spec.EnvSecrets)
+
+	var volumeMounts = []corev1.VolumeMount{
+		{
+			Name:      "shared",
+			MountPath: "/opt/app-root/src/bin",
+		},
+	}
+
+	var volumes []corev1.Volume{
+		{
+			Name: "shared", VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+	}
+	// compose the Pod CR
+	pod := corev1.Pod{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name: service.Name,
+			Namespace: service.Namespace,
+			OwnerReferences: []v1.OwnerReference{
+				{
+					APIVersion: service.APIVersion,
+					Kind: service.Kind,
+					Name: service.Name,
+					Controller: &ownerRefController,
+					UID: service.UID,
+				},
+			},
+			Labels: map[string]string{
+				"app.kubernetes.io/name": "guardrails-service",
+			},
+		},
+		Spec: core1.PodSpec{
+			InitContainers: []corev1.Container{
+				{
+					Name: "orchestrator",
+					Image: r.options.OrchestratorImage,
+					ImagePullPolicy: r.options.ImagePullPolicy,
+					Command: []string{OrchestratorPath, "--copy", DestOrchestrator},
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+						RunAsUser: &runAsUser,
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{
+								"ALL",
+							},
+						},
+					},
+					Volume: []corev1.VolumeMount{
+						{
+							Name: "shared",
+							MountPath: "opt/app-root/src/bin",
+						},
+					},
+				},
+			},
+
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Image: r.options.PodImage,
+					ImagePullPolicy: r.options.ImagePullPolicy,
+					Env: envVars,
+					Command: r.generateCmd(service),
+					Args: r.generateArgs(service, log),
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+						RunAsUser: &runAsUser,
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{
+								"ALL",
+							},
+						},
+					},
+					VolumeMounts: volumeMounts,
+				},
+			},
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot: &runAsNonRootUser,
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
+			Volumes: volumes,
+			RestartPolicy: corev1.RestartPolicyNever,
+		},
+	}
+	return &pod
+}
+
+func (r *GuardrailsServiceReconciler) generateArgs(service *guardrailsv1alpha1, log logr.Logger) []string {
+	if service == nil {
+		return nil
+	}
+
+	cmds := make([]string, 0, 10)
+
+	// --generator
+	cmds = append(cmds, "--generator", service.Spec.Generator)
+	// --model_args
+	cmds = append(cmds, "--generator_args", service.Spec.GeneratorArgs)
+
+	// --chunker
+	cmds = append(cmds, "--chunker", service.Spec.Chunker)
+	// --chunker_args
+	// eg. en_regex:
+	//     type: sentence
+	//     service:
+	// 			hostname: localhost
+	// 			port: 8085
+	//  		tls: caikit
+	cmds = append(cmds, "--chunker_args", service.Spec.ChunkerArgs)
+
+	// --detector
+	cmds = append(cmds, "--detector", service.Spec.Detector)
+	// --detector_args
+	// eg. hap-en:
+	//     service:
+	// 			hostname: localhost
+	// 			port: 8085
+	// 			tls: detector
+	// 		chunker_id: en_regex
+	//  	default_threshold: 0.5
+	if service.Spec.DetectorArgs != nil {
+		cmds = append(cmds, "--detector_args", argsToString(service.Spec.DetectorArgs))
+	}
+
+	return []string{"sh", "-ec", strings.Join(cmds, " ")}
+}
+
+func (r *GuardrailsServiceReconciler) generateCmd(service *guardrailsv1alpha1.GuardrailsService) []string {
+	if service == nil {
+		return nil
+	}
+	return []string{
+		"--service-namespace", service.Namespace,
+		"--service-name", service.Name,
+		"--grpc-service", fmt.Sprintf("%s.%s.svc", r.options.GrpcService, r.Namespace),
+		"--grpc-port", strconv.Itoa(r.options.GrpcPort),
+		"--output-path", "/opt/app-root/src/output",
+		"--",
+	}
+}
+
+func argsToString(args []guardrailsv1alpha1.Arg) string {
+	if args == nil {
+		return ""
+	}
+	var equalForms []string
+	for _, arg := range args {
+		equalForms = append(equalForms, fmt.Sprintf("%s=%s", arg.Name, arg.Value))
+	}
+	return strings.Join(equalForms, ",")
+}
+
+func generateEnvs(secrets []guardrailsv1alpha1.EnvSecret) []corev1.EnvVar {
+	var envs = []corev1.EnvVar{}
+	for _, secret := range secrets {
+		if secret.Secret != nil {
+			envs = append(envs, corev1.EnvVar{
+				Name:  secret.Env,
+				Value: *secret.Secret,
+			})
+		} else if secret.SecretRef != nil {
+			envs = append(envs, corev1.EnvVar{
+				Name: secret.Env,
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: secret.SecretRef,
+				},
+			})
+		}
+	}
+	return envs
+}
+
+func (r *GuardrailsServiceReconciler) patch4GrpcTLS(
+	envVars []corev1.EnvVar,
+	volumes []corev1.Volume,
+	volumeMounts []corev1.VolumeMount,
+	tlsMode TLSMode) ([]corev1.EnvVar, []corev1.Volume, []corev1.VolumeMount) {
+
+	var secretMode int32 = 420
+
+	envVars = append(
+		corev1.EnvVar{
+			Name:  driver.GrpcClientKeyEnv,
+			Value: "/tmp/k8s-grpc-client/certs/tls.key",
+		},
+		corev1.EnvVar{
+			Name:  driver.GrpcClientCertEnv,
+			Value: "/tmp/k8s-grpc-client/certs/tls.crt",
+		},
+		corev1.EnvVar{
+			Name:  driver.GrpcServerCaEnv,
+			Value: "/tmp/k8s-grpc-server/certs/ca.crt",
+		},
+	)
+
+	volumeMounts = append(volumeMounts,
+		corev1.VolumeMount{
+			Name:      "client-cert",
+			MountPath: "/tmp/k8s-grpc-client/certs",
+			ReadOnly:  true,
+		},
+		corev1.VolumeMount{
+			Name:      "server-cert",
+			MountPath: "/tmp/k8s-grpc-server/certs",
+			ReadOnly:  true,
+		},
+	)
+
+	volumes = append(volumes,
+		corev1.Volume{
+			Name: "client-cert",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  r.options.GrpcClientSecret,
+					DefaultMode: &secretMode,
+				},
+			},
+		},
+		corev1.Volume{
+			Name: "server-cert",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  r.options.GrpcServerSecret,
+					DefaultMode: &secretMode,
+					Items: []corev1.KeyToPath{
+						{Key: "ca.crt", Path: "ca.crt"},
+					},
+				},
+			},
+		},
+	)
+	return envVars, volumes, volumeMounts
+}
+
+func patch4FileSecrets(
+	volumes []corev1.Volume,
+	volumeMounts []corev1.VolumeMount,
+	secrets []lmesv1alpha1.FileSecret) ([]corev1.Volume, []corev1.VolumeMount) {
+
+	var counter = 1
+	for _, secret := range secrets {
+		volumes = append(volumes, corev1.Volume{
+			Name: fmt.Sprintf("secVol%d", counter),
+			VolumeSource: corev1.VolumeSource{
+				Secret: &secret.SecretRef,
+			},
+		})
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      fmt.Sprintf("secVol%d", counter),
+			MountPath: secret.MountPath,
+			ReadOnly:  true,
+		})
+		counter++
+	}
+	return volumes, volumeMounts
+}

--- a/controllers/guardrails/guardrails_controller.go
+++ b/controllers/guardrails/guardrails_controller.go
@@ -18,74 +18,41 @@ package guardrails
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	guardrailsv1alpha1 "github.com/trustyai-explainability/trustyai-service-operator/api/guardrails/v1alpha1"
+	"github.com/trustyai-explainability/trustyai-service-operator/controllers/utils"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/controller-runtime/pkg/source"
-
-	"github.com/docker/docker/api/types/volume"
-	"github.com/go-logr/logr"
-	"github.com/spf13/viper"
-	guardrailsv1alpha1 "github.com/trustyai-explainability/trustyai-service-operator/api/guardrails/v1alpha1"
 )
-
-var (
-	optionKeys = map[string]string{
-		"OrchestratorImage":    OrchestratorImageKey,
-		"ImagePullPolicy":      ImagePullPolicyKey,
-		"GrpcPort":             GrpcPortKey,
-		"GrpcService":          GrpcServiceKey,
-		"GrpcServerSecret":     GrpcServerSecretKey,
-		"GrpcClientSecret":     GrpcClientSecretKey,
-	}
-)
-
-type TLSMode int
-
-const (
-	TLSMode_None TLSMode = 0
-	TLSMode_TLS  TLSMode = 1
-	TLSMode_mTLS TLSMode = 2
-)
-
-// GuardrailsService reconciles a GuardrailsService object
-type GuardrailsServiceReconciler struct {
-	client.Client
-	Scheme 		  *runtime.Scheme
-	EventRecorder record.EventRecorder
-	ConfigMap	  string
-	Namespace     string
-	options       *ServiceOptions
-}
 
 type ServiceOptions struct {
-	PodImage             string
-	ImagePullPolicy      corev1.PullPolicy
-	GrpcPort             int
-	GrpcService          string
-	GrpcServerSecret     string
-	GrpcClientSecret     string
-	grpcTLSMode          TLSMode
+	OrchestratorImage string
+	ImagePullPolicy   corev1.PullPolicy
+	GrpcPort          int
+	GrpcService       string
+	GrpcServerSecret  string
+	GrpcClientSecret  string
+}
+
+// GuardrailsOrchestrator reconciles a GuardrailsOrchestrator object
+type GuardrailsOrchestratorReconciler struct {
+	client.Client
+	Scheme        *runtime.Scheme
+	EventRecorder record.EventRecorder
+	ConfigMap     string
+	Namespace     string
 }
 
 func ControllerSetUp(mgr manager.Manager, ns, configmap string, recorder record.EventRecorder) error {
-	return (&GuardrailsServiceReconciler{
+	return (&GuardrailsOrchestratorReconciler{
 		ConfigMap:     configmap,
 		Namespace:     ns,
 		Client:        mgr.GetClient(),
@@ -94,556 +61,97 @@ func ControllerSetUp(mgr manager.Manager, ns, configmap string, recorder record.
 	}).SetupWithManager(mgr)
 }
 
-// +kubebuilder:rbac:groups=trustyai.opendatahub.io,resources=guardrailsservices,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=trustyai.opendatahub.io,resources=guardrailsservices/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=trustyai.opendatahub.io,resources=guardrailsservices/finalizers,verbs=update
-// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;create;delete
+// +kubebuilder:rbac:groups=trustyai.opendatahub.io,resources=guardrailsorchestrators,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=trustyai.opendatahub.io,resources=guardrailsorchestrators/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=trustyai.opendatahub.io,resources=guardrailsorchestrators/finalizers,verbs=update
+// +kubebuilder:rbac:groups="",resources=deployments,verbs=get;list;watch;create;delete
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;watch;list
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;watch;list
-
-func (r *GuardrailsServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *GuardrailsOrchestratorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
 
-	service := &guardrailsv1alpha1.GuardrailsService{}
-	if err := r.Get(ctx, req.NamespacedName, service); err != nil {
-		log.Info("unable to fetch GuardrailsService. could be from a deletion request")
-		return ctrl.Result{}, client.IgnoreNotFound(err)
-	}
-
-	if !service.ObjectMeta.DeletionTimestamp.IsZero() {
-		// Handle deletion here
-		return r.handleDeletion(ctx, service, log)
-	}
-
-	// Treat this as NewserviceState
-	if service.Status.LastScheduleTime == nil {
-		service.Status.State = guardrailsv1alpha1.NewServiceState
-	}
-
-	// Handle the service based on its state
-	switch service.Status.State {
-	case guardrailsv1alpha1.NewServiceState:
-		// Handle newly created service
-		return r.handleNewCR(ctx, log, service)
-	case guardrailsv1alpha1.ScheduledServiceState:
-		// the service's pod has been created
-		// let's check the pod status and detect pod failure if there is
-		return r.checkScheduledPod(ctx, log, service)
-	case guardrailsv1alpha1.RunningServiceState:
-		// TODO: need a timeout/retry mechanism here to transite to other states
-		return r.checkScheduledPod(ctx, log, service)
-	case guardrailsv1alpha1.CompleteServiceState:
-		return r.handleComplete(ctx, log, service)
-	case guardrailsv1alpha1.CancelledserviceState:
-		return r.handleCancel(ctx, log, service)
-	}
-
-	return ctrl.Result{}, nil
-}
-
-// SetupWithManager sets up the controller with the Manager.
-func (r *GuardrailsServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
-
-	// Add a runnable to retrieve the settings from the specified configmap
-	if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
-		var cm corev1.ConfigMap
-		if err := r.Get(
-			ctx,
-			types.NamespacedName{Namespace: r.Namespace, Name: r.ConfigMap},
-			&cm); err != nil {
-
-			ctrl.Log.WithName("setup").Error(err,
-				"failed to get configmap",
-				"namespace", r.Namespace,
-				"name", r.ConfigMap)
-
-			return err
-		}
-
-		if err := r.constructOptionsFromConfigMap(ctx, &cm); err != nil {
-			return err
-		}
-
-		if err := r.checkSecrets(ctx); err != nil {
-			// if mTLS/TLS is not enable, then we are good. Otherwise error out
-			if viper.IsSet(GrpcServerCertEnv) ||
-				viper.IsSet(GrpcServerKeyEnv) ||
-				viper.IsSet(GrpcClientCaEnv) {
-				return fmt.Errorf("TLS or mTLS is enabled for GRPC server but secrets don't exist")
-			}
-		}
-
-		go StartGrpcServer(ctx, r)
-
-		return nil
-	})); err != nil {
-		return err
-	}
-
-	// watch the pods created by the controller but only for the deletion event
-	return ctrl.NewControllerManagedBy(mgr).
-		// since we register the finalizer, no need to monitor deletion events
-		For(&guardrailsv1alpha1.GuardrailsService{}, builder.WithPredicates(predicate.Funcs{
-			// drop deletion events
-			DeleteFunc: func(event.DeleteEvent) bool {
-				return false
-			},
-		})).
-		Watches(
-			&source.Kind{Type: &corev1.Pod{}},
-			&handler.EnqueueRequestForOwner{
-				OwnerType:    &guardrailsv1alpha1.GuardrailsService{},
-				IsController: true,
-			},
-			builder.WithPredicates(predicate.Funcs{
-				// drop all events except deletion
-				CreateFunc: func(event.CreateEvent) bool {
-					return false
-				},
-				UpdateFunc: func(event.UpdateEvent) bool {
-					return false
-				},
-				GenericFunc: func(event.GenericEvent) bool {
-					return false
-				},
-			}),
-		).
-		Complete(r)
-}
-
-func (r *GuardrailsServiceReconciler) checkSecrets(ctx context.Context) error {
-	var isSecretExists = func(name string) bool {
-		var secret corev1.Secret
-		err := r.Get(ctx, types.NamespacedName{Namespace: r.Namespace, Name: name}, &secret)
-		return err == nil
-	}
-
-	if !isSecretExists(r.options.GrpcServerSecret) {
-		return fmt.Errorf("secret %s not found", r.options.GrpcServerSecret)
-	}
-	if !isSecretExists(r.options.GrpcClientSecret) {
-		return fmt.Errorf("secret %s not found", r.options.GrpcServerSecret)
-	}
-	return nil
-}
-
-// TO-DO
-func (r *GuardrailsServiceReconciler) updateStatus(ctx context.Context, newStatus *) (err error) {
-	log := log.FromContext(ctx)
-
-	if strings.Trim(newStatus.GetServiceName(), )
-	return err
-}
-
-
-func (r *GuardrailsServiceReconciler) constructOptionsFromConfigMap(
-	ctx context.Context, configmap *corev1.ConfigMap) error {
-	r.options = &ServiceOptions{
-		PodImage:	  DefualtPodImage,
-		ImagePullPolicy:      DefaultImagePullPolicy,
-		GrpcPort:             DefaultGrpcPort,
-		GrpcService:          DefaultGrpcService,
-		GrpcServerSecret:     DefaultGrpcServerSecret,
-		GrpcClientSecret:     DefaultGrpcClientSecret,
-	}
-	log := log.FromContext(ctx)
-	rv := reflect.ValueOf(r.options).Elem()
-	var msgs []string
-
-	if len(msgs) > 0 {
-		log.Error(fmt.Errorf("some settings in the configmap are invalid"), strings.Join(msgs, "\n"))
-	}
-
-	return nil
-}
-
-func (r *GuardrailsServiceReconciler) handleDeletion(ctx context.Context, service *guardrailsv1alpha1.Guardrails, log logr.Logger) (reconcile.Result, error) {
-	// check if the service contains finalizer
-	if controllerutil.ContainsFinalizer(service, guardrailsv1alpha1.FinalizerName) {
-		// check for incomplete or cancelled service
-		if service.Status.State != guardrailsv1alpha1.CompleteServiceState ||
-			service.Status.Reason != guardrailsv1alpha1.CancelledReason {
-			// check for pod deletion error
-			if err := r.deleteservicePod(ctx, service); err != nil && client.IgnoreNotFound(err) != nil {
-				log.Error(err, "failed to delete pod")
-			}
-		}
-
-		// remove finalizer
-		controllerutil.RemoveFinalizer(service, guardrailsv1alpha1.FinalizerName)
-		if err := r.Update(ctx, service); err != nil {
-			return ctrl.Result{}, err
-		}
-		r.EventRecorder.Event(service, "Normal", "DetachFinalizer",
-			fmt.Sprintf("Removed finalizer from GuardrailsService %s in namespace %s",
-				service.Name,
-				service.Namespace))
-		log.Info("Sucessfully remove the finalizer", "name", service.Name)
-	}
-	return ctrl.Result{}, nil
-}
-
-func (r *GuardrailsServiceReconciler) handleNewCR(ctx context.Context, log logr.Logger, service *guardrailsv1alpha1.Guardrails) (reconcile.Result, error) {
-	// check if the service contains our finalizer, if not, add it
-	if controllerutil.ContainsFinalizer(service, guardrailsv1alpha1.FinalizerName) {
-		controllerutil.AddFinalizer(service, guardrailsv1alpha1.FinalizerName)
-		// check for finalizer update errors
-		if err := r.Update(ctx, service); err != nil {
-			log.Error(err, "Unable to update finalizer")
-			return ctrl.Result{}, err
-		}
-		r.EventRecorder.Event(service, "Normal", "AttachFinalizer",
-			fmt.Sprintf("Added the finalizer to the Guardrails %s in namespace %s",
-				service.Name,
-				service.Namespace))
-		return ctrl.Result{}, nil
-	}
-	// contruct a new pod and create a pod for the service
-	currentTime := v1.Now()
-	pod := r.createPod(service, log)
-	// check for pod creation errors
-	if err := r.Create(ctx, pod, &client.CreateOptions{}); err != nil {
-		service.Status.State = guardrailsv1alpha1.CompleteServiceState
-		service.Status.Reason = guardrailsv1alpha1.FailedReason
-		service.Status.Message = err.Error()
-		if err := r.Status().Update(ctx, service); err != nil {
-			log.Error(err, "Unable to update GuardrailsService status for pod creation failure")
-		}
-		log.Error(err, "Failed to create GuardrailsService pod")
-		return ctrl.Result{}, nil
-	}
-	// if pod creation is successful
-	service.Status.Status = guardrailsv1alpha1.ScheduledServiceState
-	service.Status.PodName = pod.BatcherConfigMapKeyName
-	service.Status.LastScheduleTime = &currentTime
-	if err := r.Status().Update(ctx, service); err != nil {
-		log.Error(err, "Unable to update GuardrailsService status after pod creation")
-		return ctrl.Result{}, nil
-	}
-	r.EventRecorder.Event(service, "Normal", "PodCompleted",
-		fmt.Sprintf("The pod for the GuardrailsService %s in namespace %s has completed",
-			service.Name,
-			service.Namespace))
-	log.Info("Succesfully created a Pod for the GuardrailsService")
-	// check the pod after the config interval
-	return ctrl.Result{Requeue: true, RequeueAfter: r.options.PodCheckingInterval}, nil
-}
-
-func (r *GuardrailsServiceReconciler) checkScheduledPod(ctx context.Context, log logr.Logger, service *guardrailsv1alpha1.Guardrails) (ctrl.Result, error) {
-	pod, err := r.getPod(ctx, service)
+	orchestrator := &guardrailsv1alpha1.GuardrailsOrchestrator{}
+	err := r.Get(ctx, req.NamespacedName, orchestrator)
 	if err != nil {
-		service.Status.State = guardrailsv1alpha1.CompleteServiceState
-		service.Status.Reason = guardrailsv1alpha1.FailedReason
-		service.Status.Message = err.Error()
-		if err := r.Status().Update(ctx, service); err != nil {
-			log.Error(err, "Unaled to update GuardrailsService", "state", service.Status.State)
-			return ctrl.Result{}, err
+		if errors.IsNotFound {
+			log.Info("unable to find GuardrailsOrchestrator. check if CR is being deleted")
+			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
-		r.EventRecorder.Event(service, "Warning", "PodMissing",
-			fmt.Sprintf("The pod for GuardrailsService %s in namespace %s is missing",
-				service.Name,
-				service.Namespace))
-		log.Error(err, "Since the pod is missing, mark the GuardrailsService as complete with error.")
+		log.Error(err, "failed to get GuardrailsOrchestrator")
 		return ctrl.Result{}, err
 	}
 
-	if pod.Status.ContainerStatuses == nil {
-		// wait for the pod to initialize and run the containers
-		return ctrl.Result{Requeue: true, RequeueAfter: r.options.PodCheckingInterval}, nil
+	if orchestrator.DeletionTimestamp != nil {
+		if utils.ContainsString(orchestrator.Finalizers, finalizerName) {
+			if err := r.deleteExternalDependency(req.Name, orchestrator, req.Namespace, ctx); err != nil {
+				log.FromContext(ctx).Error(err, "Failed to delete external dependencies, but preceeding with finalizer removal.")
+			}
+		}
+		//  Remove the finalizer and update the orchestrator
+		orchestrator.Finalizers = utils.RemoveString(orchestrator.Finalizers, finalizerName)
+		if err := r.Update(ctx, orchestrator); err != nil {
+			log.FromContext(ctx).Error(err, "Failed to remove the finalizer")
+			return ctrl.Result{Requeue: true}, nil
+		}
+		return ctrl.Result{Requeue: false}, nil
 	}
 
-	// TO DO: Check container status
+	// Add the finalizer if it does not exist
+	if !utils.ContainsString(orchestrator.Finalizers, finalizerName) {
+		orchestrator.Finalizers = append(orchestrator.Finalizers, finalizerName)
+		if err := r.Update(ctx, orchestrator); err != nil {
+			log.FromContext(ctx).Error(err, "Failed to add the finalizer")
+		}
+	}
 
-	err = r.Status().Update(ctx, service)
+	// Apply the deployment spec
+	if err := r.ensureDeployment(ctx, orchestrator); err != nil {
+		log.FromContext(ctx).Error(err, "Deployment failedf")
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// Reconcile statuses
+	result, err := r.reconcileStatuses(ctx, orchestrator)
 	if err != nil {
-		log.Error(err, "Unable to update GuardrailsService status", "state", service.Status.State)
+		return result, err
 	}
-	r.EventRecorder.Event(service, "Normal", "PodCompleted",
-		fmt.Sprintf("The pod for GuardrailsService %s in namespace %s is complete",
-			service.Name,
-			service.Namespace))
-	return ctrl.Result{}, err
+	return ctrl.Result{Requeue: true}, nil
 }
 
-func (r *GuardrailsServiceReconciler) getPod(ctx context.Context, log logr.Logger) *corev1.Pod {
-	var allowPrivilegeEscalation = false
-	var runAsNonRootUser = true
-	var ownerRefController = true
-	var runAsUser int64 = 1001030000
-	// compose the pod CR
-	pod := corev1.Pod{
-		TypeMeta: v1.TypeMeta{
-			Kind:       "Pod",
-			APIVersion: "v1",
-		},
-		ObjectMeta: v1.ObjectMeta{
-			Name:      service.Name,
-			Namespace: service.Namespace,
-		},
-	}
-	return &pod
+func (r *GuardrailsOrchestratorReconciler) SetupWithManager(mgr ctrl.Manager) error {
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&guardrailsv1alpha1.GuardrailsOrchestrator{}).
+		Owns(&appsv1.Deployment{}).
+		Owns(&appsv1.Service{}).
+		Owns(&appsv1.Route{}).
+		Complete(r)
 }
 
-func (r *GuardrailsServiceReconciler) deletePod(ctx context.Context, service *guardrailsv1alpha1.Guardrails) error {
-	pod := corev1.Pod{
-		TypeMeta: v1.TypeMeta{
-			Kind:       "Pod",
-			APIVersion: "v1",
-		},
-		ObjectMeta: v1.ObjectMeta{
-			Name:      job.Status.PodName,
-			Namespace: job.Namespace,
-			OwnerReferences: []v1.OwnerReference{
-				{
-					APIVersion: service.APIVersion,
-					Kind:       service.Kind,
-					Name:       service.Name,
-					Controller:
-				},
-			},
-		},
-	}
-	return r.Delete(ctx, &pod, &client.DeleteOptions{})
-}
+// func (*GuardrailsOrchestratorReconciler) patchForMTLS(orchestrator guardrailsv1alpha1.GuardrailOrchestrator) {
+// 	envVars := guardrails.spec.containers.env
+// 	if tlsMode == TLSMode_mTLS {
+// 		envVars = append(envVars,
+// 			corev1.EnvVar{
+// 			Name: TLS_KEY_PATH,
+// 			Value: "/tls/orch/server.key",
 
-func (r *&GuardrailsServiceReconciler) handleCancel(ctx context.Context, log logr.Logger, service *guardrailsv1alpha1.GuardrailsService) (ctrl.Result, error) {
-	// delete the pod and update its state to Complete
-	if _, err := r.getPod(ctx, service); err != nil {
-		// pod is deleted so update its state to Complete
-		service.Status.State = guardrailsv1alpha1.CompleteServiceState
-		service.Status.Reason = guardrailsv1alpha1.FailedReason
-		service.Status.Message = err.Error()
-	} else {
-		service.Status.State = guardrailsv1alphav1.CompleteServiceState
-		service.Status.Reason = guardrailsv1alpha.CancelledReason
-		if err := r.deleteservicePod(ctx, service); err != nil {
-			log.Error(err, "Failed to delete pod. Retry scheduled", "interval", r.options.PodCheckingInterval.String())
-			return ctrl.Result{Requeue: true, RequeueAfter: r.options.PodCheckingInterval}, err
-		}
-	}
-	err := r.Status().Update(ctx, service)
-	if err != nil {
-		log.Error(err, "Failed to update status for cancellation.")
-	}
-	r.EventRecorder.Event(service, "Normal", "Cancelled"
-		fmt.Sprintf("The GuardrailsService %s in namespace %s has been cancelled and its state is now Complete",
-			service.Name,
-			service.Namespace))
-	return ctrl.Result{}, err
-}
+// 			},
+// 			corev1.EnvVar{
+// 				Name: TLS_CERT_PATH,
+// 				Value: "/tls/orch/server.crt",
+// 			},
+// 			corev1.EnvVar{
+// 				Name: TLS_CLIENT_CA_CERT_PATH,
+// 				Value: "/tls/orch/ca.crt",
+// 			},
+// 		)
 
-// TO-DO: Need to figure out what resources the Pod needs
-func (r *&GuardrailsServiceReconciler) createPod(service * guardrailsv1alpha1.GuardrailsService, log logr.Logger) *corev1.Pod {
-	var allowPrivilegeEscalation = false
-	var runAsNonRootUser = true
-	var ownerRefController = true
-	var runAsUser int64 = 1001030000
-	var privileged = false
-	var runAsNonRoot = true
-	var ReadOnlyRootFilesystem = true
-	var envVars = generateEnvs(service.Spec.EnvSecrets)
-
-	var volumeMounts = []corev1.VolumeMount{
-		{
-			Name: "fms-orchestr8-config-nlp",
-			MountPath: "/config/config.yaml",
-			SubPath: "config.yaml",
-		},
-		// is it the kube-api-access vol mount required ?
-	}
-
-	var volumes = []corev1.Volume{
-		{
-			Name: "fms-orchestr8-config-nlp", VolumeSource: corev1.VolumeSource{
-				EmptyDir: &corev1.EmptyDirVolumeSource{},
-			},
-		},
-		// is it the kube-api-access vol required ?
-	}
-
-	envVars, volumes, volumeMounts = r.patch4GrpcTLS(ennVars, volumes, volumeMounts, r.options.grpcTLSMode)
-	volumes, volumeMounts = patch4FileSecrets(volumes, volumeMounts, service.Spec.FileSecrets)
-
-	// Compose the Pod CR
-	pod := corev1.Pod{
-		TypeMeta: v1.TypeMeta{
-			Kind: "Pod",
-			APIVersion: "v1",
-		},
-		ObjectMeta: v1.ObjectMeta{
-			Name: service.Name,
-			Namespace: service.Namespace,
-			OwnerReferences: []v1.OwnerReference{
-				{
-					APIVersion: service.APIVersion,
-					Kind: service.Kind,
-					Name: service.Name,
-					Controller: &ownerRefController,
-					UID: service.UID,
-
-				}
-			},
-			Labels: map[string]string{
-				"app": "fmstack-nlp",
-				"component": "fms-orchestr8-nlp",
-				"deployment": "fms-orchestr8-nlp",
-
-			},
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name: "fms-orchestr8-nlp",
-					Image: r.options.PodImage,
-					ImagePullPolicy: r.options.ImagePullPolicy,
-					Env: envVars,
-					Command: "-/app/bin/fms-guardrails-orchestr8",
-					SecurityContext: &corev1.SecurityContext{
-						AllowPrivilegeEscalation: &allowPrivilegeEscalation,
-						RunAsUser:                &runAsUser,
-						Privileged: &privileged,
-						ReadOnlyRootFilesystem: &readOnlyFileSystem,
-						Capabilities: &corev1.Capabilities{
-							Drop: []corev1.Capability{
-								"ALL",
-							},
-						},
-					},
-					VolumeMounts: volumeMounts,
-				},
-			},
-			SecurityContext: &corev1.PodSecurityContext{
-				RunAsNonRoot: &runAsNonRoot,
-				SeccompProfile: &corev1.SeccompProfile{
-					Type: corev1.SeccompProfileTypeRuntimeDefault,
-				},
-			},
-			Volumes: volumes,
-			RestartPolicy: corev1.RestartPolicyAlways,
-		}
-	}
-	return &pod
-}
-
-func argsToString(args []guardrailsv1alpha1.Arg) string {
-	if args == nil {
-		return ""
-	}
-	var equalForms []string
-	for _, arg := range args {
-		equalForms = append(equalForms, fmt.Sprintf("%s=%s", arg.Name, arg.Value))
-	}
-	return strings.Join(equalForms, ",")
-}
-
-func generateEnvs(secrets []guardrailsv1alpha1.EnvSecret) []corev1.EnvVar {
-	var envs = []corev1.EnvVar{}
-	for _, secret := range secrets {
-		if secret.Secret != nil {
-			envs = append(envs, corev1.EnvVar{
-				Name:  secret.Env,
-				Value: *secret.Secret,
-			})
-		} else if secret.SecretRef != nil {
-			envs = append(envs, corev1.EnvVar{
-				Name: secret.Env,
-				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: secret.SecretRef,
-				},
-			})
-		}
-	}
-	return envs
-}
-
-func (r *GuardrailsServiceReconciler) patch4GrpcTLS(
-	envVars []corev1.EnvVar,
-	volumes []corev1.Volume,
-	volumeMounts []corev1.VolumeMount,
-	tlsMode TLSMode) ([]corev1.EnvVar, []corev1.Volume, []corev1.VolumeMount) {
-
-	var secretMode int32 = 420
-
-	if tlsMode == TLSMode_mTLS {
-		envVars = append(
-			corev1.EnvVar{
-				Name:  driver.GrpcClientKeyEnv,
-				Value: "/tmp/k8s-grpc-client/certs/tls.key",
-			},
-			corev1.EnvVar{
-				Name:  driver.GrpcClientCertEnv,
-				Value: "/tmp/k8s-grpc-client/certs/tls.crt",
-			},
-			corev1.EnvVar{
-				Name:  driver.GrpcServerCaEnv,
-				Value: "/tmp/k8s-grpc-server/certs/ca.crt",
-			},
-		)
-
-		volumeMounts = append(volumeMounts,
-			corev1.VolumeMount{
-				Name:      "client-cert",
-				MountPath: "/tmp/k8s-grpc-client/certs",
-				ReadOnly:  true,
-			},
-			corev1.VolumeMount{
-				Name:      "server-cert",
-				MountPath: "/tmp/k8s-grpc-server/certs",
-				ReadOnly:  true,
-			},
-		)
-
-		volumes = append(volumes,
-			corev1.Volume{
-				Name: "client-cert",
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName:  r.options.GrpcClientSecret,
-						DefaultMode: &secretMode,
-					},
-				},
-			},
-			corev1.Volume{
-				Name: "server-cert",
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName:  r.options.GrpcServerSecret,
-						DefaultMode: &secretMode,
-						Items: []corev1.KeyToPath{
-							{Key: "ca.crt", Path: "ca.crt"},
-						},
-					},
-				},
-			},
-		)
-	} else if tlsMode == TLSMode {
-		envVars = append(envVars,
-			corev1.Volume
-		)
-	}
-
-	return envVars, volumes, volumeMounts
-}
-
-func patch4FileSecrets(
-	volumes []corev1.Volume,
-	volumeMounts []corev1.VolumeMount,
-	secrets []lmesv1alpha1.FileSecret) ([]corev1.Volume, []corev1.VolumeMount) {
-
-	var counter = 1
-	for _, secret := range secrets {
-		volumes = append(volumes, corev1.Volume{
-			Name: fmt.Sprintf("secVol%d", counter),
-			VolumeSource: corev1.VolumeSource{
-				Secret: &secret.SecretRef,
-			},
-		})
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      fmt.Sprintf("secVol%d", counter),
-			MountPath: secret.MountPath,
-			ReadOnly:  true,
-		})
-		counter++
-	}
-	return volumes, volumeMounts
-}
+// 	} else if tlsMode == TLSMode_TLS {
+// 		envVars = append(envVars,
+// 			corev1.EnvVar{
+// 			},
+// 		)
+// 	}
+// 	return envVars
+// }

--- a/controllers/guardrails/secrets.go
+++ b/controllers/guardrails/secrets.go
@@ -1,0 +1,71 @@
+package guardrails
+
+import (
+	guardrailsv1alpha1 ""
+	"context"
+	"fmt"
+	"go/format"
+	"github.com/trustyai-explainability/trustyai-service-operator/controllers/guardrails"
+)
+
+func (r *GuardrailsOrchestratorReconciler) getSecret(ctx context.Context, name, namespace) {
+	secret := &corev1.Secret{}
+	err := r.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, secret)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, fmt.Errorf("secret %s not found in namespace %s: %w", name, namespace, err)
+		}
+		return nil, fmt.Errorf("failed to get secret %s in namespace %s: %w", name, namespace, err)
+	}
+	return secret, nil
+}
+
+func (r *GuardrailsOrchestratorReconciler) getDetectorTLSCert(orchestrator guardrailsv1alpha1.GuardrailOrchestrator) (*corev1.Secret, error) {
+	detectorTLSSecretName := orchestrator.Spec.
+
+	if detectorTLSSecretName != "" {
+		secret, err := r.getSecret(ctx, detectorTLSSecretName, orchestrator.Namespace)
+		if err != nil {
+			return nil, err
+		}
+		if secret != nil {
+			return secret, nil
+
+		}
+	}
+}
+func (r *GuardrailsOrchestratorReconciler) validateTLSSecret(secret *corev1.Secret) error {
+	// check Secret type is tls
+	if secret.Type != "kubernetes.io/tls" {
+		return fmt.Errorf("No secret for TLS credentials found")
+	}
+	mandatoryKeys := []string{
+		"cert_path",
+		"key_path"
+	}
+
+	for _, key in range mamandatoryKeys {
+		value, exists := secret.Data[key]
+		if !exists {
+			return fmt.Errorf("Mandatory key %s missing from secret", key)
+		}
+		if len(value) == 0 {
+			return fmt.Errorf("Mandatory key %s is empty", key)
+		}
+	}
+}
+
+func (r *GuardrailsOrchestratorReconciler) getGeneratorTLSCert(orchestrator guardrailsv1alpha1.GuardrailOrchestrator) (*corev1.Secret, error) {
+	generatorTLSSecretName := orchestrator.Spec
+
+	if generatorTLSSecretName != "" {
+		secret, err := r.getSecret(ctx, generatorTLSSecretName, orchestrator.Namespace)
+		if err != nil (
+			return nil, error
+		)
+		if secret != nil (
+			return secret, nil
+		)
+	}
+}
+

--- a/controllers/guardrails/templates/deployment.tmpl.yaml
+++ b/controllers/guardrails/templates/deployment.tmpl.yaml
@@ -1,3 +1,4 @@
+---
 kind: Deployment
 apiVersion: apps/v1
 metadata:

--- a/controllers/guardrails/templates/deployment.tmpl.yaml
+++ b/controllers/guardrails/templates/deployment.tmpl.yaml
@@ -1,0 +1,98 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  annotations:
+    configmap.reloader.stakater.com/reload: 'fms-orchestr8-config'
+  name: {{ .Orchestrator.Name }}
+  namespace: {{ .Orchestrator.Namespace }}
+  labels:
+    app: ...
+    component: {{ .Orchestrator.Name }}
+    deploy-name: {{ .Orchestrator.Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ...
+      component: {{ .Orchestrator.Name }}
+      deploy-name: {{ .Orchestrator.Name }}
+  template:
+    metadata:
+      labels:
+        app:
+        component: {{ .Orchestrator.Name }}
+        deploy-name: {{ .Orchestrator.Name }}
+    spec:
+      containers:
+        name: {{ .Orchestrator.Name }}
+         - resources:
+            limits:
+              cpu: '1'
+              memory: 2Gi
+            requests:
+              cpu: '1'
+              memory: 2Gi
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8034
+            scheme: HTTP
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 20
+          successThreshold: 1
+          failureThreshold: 3
+        terminationMessagePath: /dev/termination-log
+        image: {{ .OrchestratorImage }}
+        command:
+          - /app/bin/fms-guardrails-orchestr8
+        env:
+          - name: ORCHESTRATOR_CONFIG
+            value: /config/config.yaml
+          - name: HTTP_PORT
+            value: '8033'
+        {{if eq .Orchestrator.Spec.TLS.Mode "mTLS" }}
+          - name: TLS_KEY_PATH
+            value: /tls/orch/server.key
+          - name: TLS_CERT_PATH
+            value: /tls/orch/server.crt
+          - name: TLS_CLIENT_CA_CERT_PATH
+            value: /tls/orch/ca.crt
+        {{ end }}
+          - name: RUST_BACKTRACE
+            value: full
+          - name: RUST_LOG
+            value: 'fms_guardrails_orchestr8=debug'
+        volumeMounts:
+          - name: fms-orchestr8-config-nlp # This refers to the configmap below
+            readOnly: true
+            mountPath: /config/config.yaml
+            subPath: config.yaml
+          - name: server-tls # This is for the caikit server for generation
+            readOnly: true
+            mountPath: /tls/server
+        securityContext:
+          capabilities:
+            drop:
+              - ALL
+          privileged: false
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
+        ports:
+          - name: http
+            containerPort: 8033
+            protocol: TCP
+        imagePullPolicy: Always
+      volumes:
+        - name: fms-orchestr8-config-nlp
+          configMap:
+            name: fms-orchestr8-config-nlp
+            defaultMode: 420
+        # Add if statement to check if we are using caikit standalone as our server
+        - name: server-tls
+          secret:
+            secretName: {{ .Orchestrator.Name }}-tls
+            defaultMode: 256

--- a/controllers/guardrails/templates/deployment.tmpl.yaml
+++ b/controllers/guardrails/templates/deployment.tmpl.yaml
@@ -47,12 +47,8 @@ spec:
         command:
           - /app/bin/fms-guardrails-orchestr8
         env:
-          # - name: ORCHESTRATOR_CONFIG
-          #   valueFrom:
-          #     configMapKeyRef:
-          #       name: a-config
-          #       key: akey
-          #       optional: true
+          - name: ORCHESTRATOR_CONFIG
+            value: /config/config.yaml
           - name: HTTP_PORT
             value: '8033'
         {{if eq .Orchestrator.Spec.TLS.Mode "mTLS" }}
@@ -95,6 +91,7 @@ spec:
           configMap:
             name: fms-orchestr8-config-nlp
             defaultMode: 420
+            optional: true
         # Add if statement to check if we are using caikit standalone as our server
         - name: server-tls
           secret:

--- a/controllers/guardrails/templates/deployment.tmpl.yaml
+++ b/controllers/guardrails/templates/deployment.tmpl.yaml
@@ -47,8 +47,12 @@ spec:
         command:
           - /app/bin/fms-guardrails-orchestr8
         env:
-          - name: ORCHESTRATOR_CONFIG
-            value: /config/config.yaml
+          # - name: ORCHESTRATOR_CONFIG
+          #   valueFrom:
+          #     configMapKeyRef:
+          #       name: a-config
+          #       key: akey
+          #       optional: true
           - name: HTTP_PORT
             value: '8033'
         {{if eq .Orchestrator.Spec.TLS.Mode "mTLS" }}
@@ -64,7 +68,7 @@ spec:
           - name: RUST_LOG
             value: 'fms_guardrails_orchestr8=debug'
         volumeMounts:
-          - name: fms-orchestr8-config-nlp # This refers to the configmap below
+          - name: fms-orchestr8-config-nlp
             readOnly: true
             mountPath: /config/config.yaml
             subPath: config.yaml


### PR DESCRIPTION
This PR adds the following files:

* `api/orchestrator/v1alpha1/guardrailsorchestrator_types.go`- defines the GuardrailsOrchestrator types
* `config/crd/bases/trustyai.opendatahub.io_guadrailsorchestrator.yaml` - GuardrailsOrchestrator CRD
* `controllers/guardrails/README.md` - more info about the CRD and controller 
* `controllers/guardrails/guardrails.go` - main controller logic