### PR TITLE
RHOAIENG-12337: Add KServe Logger TLS bundle support

### DIFF
--- a/controllers/inference_services.go
+++ b/controllers/inference_services.go
@@ -3,13 +3,16 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	trustyaiopendatahubiov1alpha1 "github.com/trustyai-explainability/trustyai-service-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"strings"
 )
 
 const (
@@ -227,7 +230,33 @@ func (r *TrustyAIServiceReconciler) handleInferenceServices(ctx context.Context,
 			}
 		}
 		if kServeServerlessEnabled {
-			err := r.patchKServe(ctx, instance, infService, namespace, crName, remove)
+			loggerConfig, err := r.getKServeLoggerConfig(ctx)
+			if err != nil {
+				log.FromContext(ctx).Error(err, "Could not read logger configuration")
+				return false, err
+			}
+
+			useTLS := false
+
+			if loggerConfig != nil && loggerConfig.CaBundle != nil {
+				// Check if the ConfigMap exists
+				caConfigMap := &corev1.ConfigMap{}
+				err = r.Get(ctx, types.NamespacedName{Name: *loggerConfig.CaBundle, Namespace: instance.Namespace}, caConfigMap)
+				if err == nil {
+					useTLS = true
+				} else if errors.IsNotFound(err) {
+					useTLS = false
+					log.FromContext(ctx).Info("CA ConfigMap not found, proceeding without TLS")
+				} else {
+					log.FromContext(ctx).Error(err, "Error fetching CA ConfigMap")
+					return false, err
+				}
+			} else {
+				// If no CaBundle is specified, proceed without TLS
+				useTLS = false
+			}
+
+			err = r.patchKServe(ctx, instance, infService, namespace, crName, remove, useTLS)
 			if err != nil {
 				log.FromContext(ctx).Error(err, "could not patch InferenceLogger for KServe deployment")
 				return false, err
@@ -238,9 +267,14 @@ func (r *TrustyAIServiceReconciler) handleInferenceServices(ctx context.Context,
 }
 
 // patchKServe adds a TrustyAI service as an InferenceLogger to a KServe InferenceService
-func (r *TrustyAIServiceReconciler) patchKServe(ctx context.Context, instance *trustyaiopendatahubiov1alpha1.TrustyAIService, infService kservev1beta1.InferenceService, namespace string, crName string, remove bool) error {
+func (r *TrustyAIServiceReconciler) patchKServe(ctx context.Context, instance *trustyaiopendatahubiov1alpha1.TrustyAIService, infService kservev1beta1.InferenceService, namespace string, crName string, remove bool, useTLS bool) error {
 
-	url := generateNonTLSServiceURL(crName, namespace)
+	var url string
+	if useTLS {
+		url = generateTLSServiceURL(crName, namespace)
+	} else {
+		url = generateNonTLSServiceURL(crName, namespace)
+	}
 
 	if remove {
 		if infService.Spec.Predictor.Logger == nil || *infService.Spec.Predictor.Logger.URL != url {

--- a/controllers/templates/service/deployment.tmpl.yaml
+++ b/controllers/templates/service/deployment.tmpl.yaml
@@ -122,6 +122,10 @@ spec:
             - name: STORAGE_MIGRATION_CONFIG_FROM_FILENAME
               value: {{ .Instance.Spec.Data.Filename }}
             {{ end }}
+            {{ if .CertName }}
+            - name: KSERVE_LOGGER_CA_CERT
+              value: {{ .CertName }}
+            {{ end }}
           volumeMounts:
             - name: {{ .Instance.Name }}-internal
               readOnly: false
@@ -134,6 +138,11 @@ spec:
             {{ if .UseDBTLSCerts }}
             - name: db-tls-certs
               mountPath: /etc/tls/db
+              readOnly: true
+            {{ end }}
+            {{ if .ConfigMapExists }}
+            - name: kserve-logger-tls-certs
+              mountPath: /etc/tls/kserve
               readOnly: true
             {{ end }}
         - resources:
@@ -228,4 +237,9 @@ spec:
           secret:
             secretName: {{ .Instance.Name }}-db-tls
             defaultMode: 420
+        {{ end }}
+        {{ if .ConfigMapExists }}
+        - name: kserve-logger-tls-certs
+          configMap:
+            name: {{ .ConfigMapName }}
         {{ end }}


### PR DESCRIPTION
Refer to [RHOAIENG-12337](https://issues.redhat.com/browse/RHOAIENG-12337).

This PR adds support for KServe's InferenceLogger TLS CA bundles.

If a KServe `InferenceService` is deployed in the same namespace as the `TrustyAIService`, the operator will:

- Check the configured CA bundle for logging in the global KServe `inferenceservice-config` CM.
- If the there isn't a CA bundle defined, the operator will add a non-TLS logger to the IS (i.e. `http://...`)
- If there is a CA bundle defined:
  - If it is already present in the namespace, will be mounted at `/etc/tls/kserve` on the service and specified with the env var `KSERVE_LOGGER_CA_CERT`
  - If there is no CA bundle CM defined, it will be created by operator (using OpenShift Serving Certificates) with CM name and CA name as in the global KServe config and mounted on the service as above
  - A TLS logger URL will be created (i.e. `https://...`)