### PR TITLE
Add KServe destination rule for Inference Services in the ServiceMesh

### DIFF
--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -1,4 +1,4 @@
-trustyaiServiceImage=quay.io/trustyai/trustyai-service:v0.19.0
-trustyaiOperatorImage=quay.io/trustyai/trustyai-service-operator:v1.25.0
+trustyaiServiceImage=quay.io/trustyai/trustyai-service:latest
+trustyaiOperatorImage=quay.io/trustyai/trustyai-service-operator:latest
 oauthProxyImage=quay.io/openshift/origin-oauth-proxy:4.14.0
 kServeServerless=enabled

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -135,6 +135,17 @@ rules:
   - list
   - watch
 - apiGroups:
+  - networking.istio.io
+  resources:
+  - destinationrules
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -139,6 +139,7 @@ rules:
   resources:
   - destinationrules
   verbs:
+  - create
   - delete
   - get
   - list

--- a/controllers/destination_rule.go
+++ b/controllers/destination_rule.go
@@ -1,0 +1,69 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	trustyaiopendatahubiov1alpha1 "github.com/trustyai-explainability/trustyai-service-operator/api/v1alpha1"
+	templateParser "github.com/trustyai-explainability/trustyai-service-operator/controllers/templates"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	destinationRuleTemplatePath = "service/destination-rule.tmpl.yaml"
+)
+
+// DestinationRuleConfig has the variables for the DestinationRule template
+type DestinationRuleConfig struct {
+	Name                string
+	Namespace           string
+	DestinationRuleName string
+}
+
+func (r *TrustyAIServiceReconciler) ensureDestinationRule(ctx context.Context, instance *trustyaiopendatahubiov1alpha1.TrustyAIService) error {
+	destinationRuleName := instance.Name + "-internal"
+
+	existingDestinationRule := &unstructured.Unstructured{}
+	existingDestinationRule.SetKind("DestinationRule")
+	existingDestinationRule.SetAPIVersion("networking.istio.io/v1beta1")
+
+	// Check if the DestinationRule already exists
+	err := r.Get(ctx, types.NamespacedName{Name: destinationRuleName, Namespace: instance.Namespace}, existingDestinationRule)
+	if err == nil {
+		// DestinationRule exists
+		return nil
+	}
+
+	if !errors.IsNotFound(err) {
+		return fmt.Errorf("failed to check for existing DestinationRule: %v", err)
+	}
+
+	destinationRuleConfig := DestinationRuleConfig{
+		Name:                instance.Name,
+		Namespace:           instance.Namespace,
+		DestinationRuleName: destinationRuleName,
+	}
+
+	var destinationRule *unstructured.Unstructured
+	destinationRule, err = templateParser.ParseResource[unstructured.Unstructured](destinationRuleTemplatePath, destinationRuleConfig, reflect.TypeOf(&unstructured.Unstructured{}))
+	if err != nil {
+		log.FromContext(ctx).Error(err, "could not parse the DestinationRule template")
+		return err
+	}
+
+	if err := ctrl.SetControllerReference(instance, destinationRule, r.Scheme); err != nil {
+		return err
+	}
+
+	err = r.Create(ctx, destinationRule)
+	if err != nil {
+		return fmt.Errorf("failed to create DestinationRule: %v", err)
+	}
+
+	return nil
+}

--- a/controllers/inference_services.go
+++ b/controllers/inference_services.go
@@ -3,13 +3,14 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	trustyaiopendatahubiov1alpha1 "github.com/trustyai-explainability/trustyai-service-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"strings"
 )
 
 const (
@@ -269,6 +270,15 @@ func (r *TrustyAIServiceReconciler) patchKServe(ctx context.Context, instance *t
 
 		// Set the InferenceLogger to the InferenceService instance
 		infService.Spec.Predictor.Logger = &logger
+	}
+
+	// Only if the Istio sidecar annotation is set
+	annotations := infService.GetAnnotations()
+	if inject, exists := annotations["sidecar.istio.io/inject"]; exists && inject == "true" {
+		err := r.ensureDestinationRule(ctx, instance)
+		if err != nil {
+			return fmt.Errorf("failed to ensure DestinationRule: %v", err)
+		}
 	}
 
 	// Update the InferenceService

--- a/controllers/templates/service/destination-rule.tmpl.yaml
+++ b/controllers/templates/service/destination-rule.tmpl.yaml
@@ -1,0 +1,13 @@
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: {{ .DestinationRuleName }}
+  namespace: {{ .Namespace }}
+spec:
+  host: {{ .Name }}.{{ .Namespace }}.svc.cluster.local
+  trafficPolicy:
+    portLevelSettings:
+        - port:
+          number: 443
+          tls:
+            mode: SIMPLE

--- a/controllers/templates/service/destination-rule.tmpl.yaml
+++ b/controllers/templates/service/destination-rule.tmpl.yaml
@@ -7,7 +7,7 @@ spec:
   host: {{ .Name }}.{{ .Namespace }}.svc.cluster.local
   trafficPolicy:
     portLevelSettings:
-        - port:
+      - port:
           number: 443
-          tls:
-            mode: SIMPLE
+        tls:
+          mode: SIMPLE

--- a/controllers/trustyaiservice_controller.go
+++ b/controllers/trustyaiservice_controller.go
@@ -69,6 +69,7 @@ type TrustyAIServiceReconciler struct {
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;watch;create;update;delete
 //+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;create;update
+//+kubebuilder:rbac:groups=networking.istio.io,resources=destinationrules,verbs=list;watch;get;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/controllers/trustyaiservice_controller.go
+++ b/controllers/trustyaiservice_controller.go
@@ -69,7 +69,7 @@ type TrustyAIServiceReconciler struct {
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;watch;create;update;delete
 //+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;create;update
-//+kubebuilder:rbac:groups=networking.istio.io,resources=destinationrules,verbs=list;watch;get;update;patch;delete
+//+kubebuilder:rbac:groups=networking.istio.io,resources=destinationrules,verbs=create;list;watch;get;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
This PR adds a `DestinationRule` to the `TrustyAIService` namespace when configuring a KServe `InferenceService` inside the ServiceMesh, so that the Inference Logger is able to send payloads to the TAS (outside the mesh).