### PR TITLE
Add check if DestinationRule CRD is present before creating it

### DIFF
--- a/controllers/destination_rule.go
+++ b/controllers/destination_rule.go
@@ -7,6 +7,7 @@ import (
 
 	trustyaiopendatahubiov1alpha1 "github.com/trustyai-explainability/trustyai-service-operator/api/v1alpha1"
 	templateParser "github.com/trustyai-explainability/trustyai-service-operator/controllers/templates"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
@@ -16,6 +17,7 @@ import (
 
 const (
 	destinationRuleTemplatePath = "service/destination-rule.tmpl.yaml"
+	destinationRuleCDRName      = "destinationrules.networking.istio.io"
 )
 
 // DestinationRuleConfig has the variables for the DestinationRule template
@@ -25,7 +27,25 @@ type DestinationRuleConfig struct {
 	DestinationRuleName string
 }
 
+// isDestinationRuleCRDPresent returns true if the DestinationRule CRD is present, false otherwise
+func (r *TrustyAIServiceReconciler) isDestinationRuleCRDPresent(ctx context.Context) (bool, error) {
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+
+	err := r.Get(ctx, types.NamespacedName{Name: destinationRuleCDRName}, crd)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return false, fmt.Errorf("error getting "+destinationRuleCDRName+" CRD: %v", err)
+		}
+		// Not found
+		return false, nil
+	}
+
+	// Found
+	return true, nil
+}
+
 func (r *TrustyAIServiceReconciler) ensureDestinationRule(ctx context.Context, instance *trustyaiopendatahubiov1alpha1.TrustyAIService) error {
+
 	destinationRuleName := instance.Name + "-internal"
 
 	existingDestinationRule := &unstructured.Unstructured{}


### PR DESCRIPTION
This PR adds a check that `DestinationRule` CRDs exist before attempting to create one (this code path is only applicable if the `InferenceService` is annotated as being part of a service mesh)