### PR TITLE
Change job's user ID to fix SCC violation

### DIFF
--- a/controllers/lmes/lmevaljob_controller.go
+++ b/controllers/lmes/lmevaljob_controller.go
@@ -76,6 +76,11 @@ var (
 	annotationFilterPrefixes = []string{}
 )
 
+// Constants
+const (
+	jobUserId int64 = 1000840000
+)
+
 // maintain a list of key-time pair data.
 // provide a function to add the key and update the time
 // atomitcally and return a reconcile requeue event
@@ -662,7 +667,7 @@ func (r *LMEvalJobReconciler) createPod(job *lmesv1alpha1.LMEvalJob, log logr.Lo
 	var allowPrivilegeEscalation = false
 	var runAsNonRootUser = true
 	var ownerRefController = true
-	var runAsUser int64 = 1001030000
+	var runAsUser = jobUserId
 
 	var envVars = job.Spec.Pod.GetContainer().GetEnv()
 

--- a/controllers/lmes/lmevaljob_controller_test.go
+++ b/controllers/lmes/lmevaljob_controller_test.go
@@ -30,10 +30,10 @@ import (
 )
 
 var (
-	isController                   = true
-	allowPrivilegeEscalation       = false
-	runAsNonRootUser               = true
-	runAsUser                int64 = 1001030000
+	isController             = true
+	allowPrivilegeEscalation = false
+	runAsNonRootUser         = true
+	runAsUser                = jobUserId
 )
 
 func Test_SimplePod(t *testing.T) {


### PR DESCRIPTION
Refers to [RHOAIENG-13846](https://issues.redhat.com/browse/RHOAIENG-13846).

The pod is trying to run with a runAsUser UID of 1001030000, which is outside the allowed UID ranges specified by the Security Context Constraints available to the pod's service account.

This PR sets it to a UID within the allowed range `[1000840000, 1000849999]`.