### PR TITLE
RHOAIENG-14321: Fix operator metrics service target port

### DIFF
--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -16,6 +16,6 @@ spec:
     - name: https
       port: 8443
       protocol: TCP
-      targetPort: 8080
+      targetPort: 8081
   selector:
     control-plane: controller-manager


### PR DESCRIPTION
Refer to [RHOAIENG-14321](https://issues.redhat.com/browse/RHOAIENG-14321).

Fix target port in operator's service metrics.