### PR TITLE
RHOAIENG-11109: Enable KServe serverless in the rhoai overlay

### DIFF
--- a/config/base/params.env
+++ b/config/base/params.env
@@ -1,4 +1,4 @@
 trustyaiServiceImage=quay.io/trustyai/trustyai-service:latest
 trustyaiOperatorImage=quay.io/trustyai/trustyai-service-operator:latest
 oauthProxyImage=quay.io/openshift/origin-oauth-proxy:4.14.0
-kServeServerless=disabled
+kServeServerless=enabled

--- a/config/overlays/rhoai/params.env
+++ b/config/overlays/rhoai/params.env
@@ -1,4 +1,4 @@
 trustyaiServiceImage=quay.io/trustyai/trustyai-service:latest
 trustyaiOperatorImage=quay.io/trustyai/trustyai-service-operator:latest
 oauthProxyImage=registry.redhat.io/openshift4/ose-oauth-proxy@sha256:ab112105ac37352a2a4916a39d6736f5db6ab4c29bad4467de8d613e80e9bb33
-kServeServerless=disabled
+kServeServerless=enabled


### PR DESCRIPTION
Refers to [RHOAIENG-11109](https://issues.redhat.com/browse/RHOAIENG-11109).

Re-enable the KServe serverless support by default.