### PR TITLE
RHOAIENG-13846: Remove hardcoded job's user ID

### DIFF
--- a/controllers/lmes/lmevaljob_controller.go
+++ b/controllers/lmes/lmevaljob_controller.go
@@ -662,7 +662,6 @@ func (r *LMEvalJobReconciler) createPod(job *lmesv1alpha1.LMEvalJob, log logr.Lo
 	var allowPrivilegeEscalation = false
 	var runAsNonRootUser = true
 	var ownerRefController = true
-	var runAsUser int64 = 1001030000
 
 	var envVars = job.Spec.Pod.GetContainer().GetEnv()
 
@@ -717,7 +716,6 @@ func (r *LMEvalJobReconciler) createPod(job *lmesv1alpha1.LMEvalJob, log logr.Lo
 					Command:         []string{DriverPath, "--copy", DestDriverPath},
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: &allowPrivilegeEscalation,
-						RunAsUser:                &runAsUser,
 						Capabilities: &corev1.Capabilities{
 							Drop: []corev1.Capability{
 								"ALL",
@@ -742,7 +740,6 @@ func (r *LMEvalJobReconciler) createPod(job *lmesv1alpha1.LMEvalJob, log logr.Lo
 					Args:            r.generateArgs(job, log),
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: &allowPrivilegeEscalation,
-						RunAsUser:                &runAsUser,
 						Capabilities: &corev1.Capabilities{
 							Drop: []corev1.Capability{
 								"ALL",

--- a/controllers/lmes/lmevaljob_controller_test.go
+++ b/controllers/lmes/lmevaljob_controller_test.go
@@ -30,10 +30,9 @@ import (
 )
 
 var (
-	isController                   = true
-	allowPrivilegeEscalation       = false
-	runAsNonRootUser               = true
-	runAsUser                int64 = 1001030000
+	isController             = true
+	allowPrivilegeEscalation = false
+	runAsNonRootUser         = true
 )
 
 func Test_SimplePod(t *testing.T) {
@@ -97,7 +96,6 @@ func Test_SimplePod(t *testing.T) {
 					Command:         []string{DriverPath, "--copy", DestDriverPath},
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: &allowPrivilegeEscalation,
-						RunAsUser:                &runAsUser,
 						Capabilities: &corev1.Capabilities{
 							Drop: []corev1.Capability{
 								"ALL",
@@ -121,7 +119,6 @@ func Test_SimplePod(t *testing.T) {
 					Args:            lmevalRec.generateArgs(job, log),
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: &allowPrivilegeEscalation,
-						RunAsUser:                &runAsUser,
 						Capabilities: &corev1.Capabilities{
 							Drop: []corev1.Capability{
 								"ALL",
@@ -259,7 +256,6 @@ func Test_WithLabelsAnnotationsResourcesVolumes(t *testing.T) {
 					Command:         []string{DriverPath, "--copy", DestDriverPath},
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: &allowPrivilegeEscalation,
-						RunAsUser:                &runAsUser,
 						Capabilities: &corev1.Capabilities{
 							Drop: []corev1.Capability{
 								"ALL",
@@ -283,7 +279,6 @@ func Test_WithLabelsAnnotationsResourcesVolumes(t *testing.T) {
 					Args:            lmevalRec.generateArgs(job, log),
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: &allowPrivilegeEscalation,
-						RunAsUser:                &runAsUser,
 						Capabilities: &corev1.Capabilities{
 							Drop: []corev1.Capability{
 								"ALL",
@@ -430,7 +425,6 @@ func Test_EnvSecretsPod(t *testing.T) {
 					Command:         []string{DriverPath, "--copy", DestDriverPath},
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: &allowPrivilegeEscalation,
-						RunAsUser:                &runAsUser,
 						Capabilities: &corev1.Capabilities{
 							Drop: []corev1.Capability{
 								"ALL",
@@ -467,7 +461,6 @@ func Test_EnvSecretsPod(t *testing.T) {
 					Args:    lmevalRec.generateArgs(job, log),
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: &allowPrivilegeEscalation,
-						RunAsUser:                &runAsUser,
 						Capabilities: &corev1.Capabilities{
 							Drop: []corev1.Capability{
 								"ALL",
@@ -592,7 +585,6 @@ func Test_FileSecretsPod(t *testing.T) {
 					Command:         []string{DriverPath, "--copy", DestDriverPath},
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: &allowPrivilegeEscalation,
-						RunAsUser:                &runAsUser,
 						Capabilities: &corev1.Capabilities{
 							Drop: []corev1.Capability{
 								"ALL",
@@ -616,7 +608,6 @@ func Test_FileSecretsPod(t *testing.T) {
 					Args:            lmevalRec.generateArgs(job, log),
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: &allowPrivilegeEscalation,
-						RunAsUser:                &runAsUser,
 						Capabilities: &corev1.Capabilities{
 							Drop: []corev1.Capability{
 								"ALL",


### PR DESCRIPTION
Refers to [RHOAIENG-13846](https://issues.redhat.com/browse/RHOAIENG-13846).

This PR removes the hardcoded job's pod user id, so that it can use the id automatically assigned by OpenShift.