### PR TITLE
RHOAIENG-14773: Change batchSize to string in order to support "auto" and "auto:N"

### DIFF
--- a/api/lmes/v1alpha1/lmevaljob_types.go
+++ b/api/lmes/v1alpha1/lmevaljob_types.go
@@ -247,7 +247,7 @@ type LMEvalJobSpec struct {
 	LogSamples *bool `json:"logSamples,omitempty"`
 	// Batch size for the evaluation. This is used by the models that run and are loaded
 	// locally and not apply for the commercial APIs.
-	BatchSize *int `json:"batchSize,omitempty"`
+	BatchSize *string `json:"batchSize,omitempty"`
 	// Specify extra information for the lm-eval job's pod
 	// +optional
 	Pod *LMEvalPodSpec `json:"pod,omitempty"`

--- a/api/lmes/v1alpha1/zz_generated.deepcopy.go
+++ b/api/lmes/v1alpha1/zz_generated.deepcopy.go
@@ -174,7 +174,7 @@ func (in *LMEvalJobSpec) DeepCopyInto(out *LMEvalJobSpec) {
 	}
 	if in.BatchSize != nil {
 		in, out := &in.BatchSize, &out.BatchSize
-		*out = new(int)
+		*out = new(string)
 		**out = **in
 	}
 	if in.Pod != nil {

--- a/config/crd/bases/trustyai.opendatahub.io_lmevaljobs.yaml
+++ b/config/crd/bases/trustyai.opendatahub.io_lmevaljobs.yaml
@@ -47,7 +47,7 @@ spec:
                 description: |-
                   Batch size for the evaluation. This is used by the models that run and are loaded
                   locally and not apply for the commercial APIs.
-                type: integer
+                type: string
               genArgs:
                 description: Map to `--gen_kwargs` parameter for the underlying library.
                 items:

--- a/controllers/lmes/config.go
+++ b/controllers/lmes/config.go
@@ -43,7 +43,7 @@ type serviceOptions struct {
 	PodCheckingInterval time.Duration
 	ImagePullPolicy     corev1.PullPolicy
 	MaxBatchSize        int
-	DefaultBatchSize    int
+	DefaultBatchSize    string
 	DetectDevice        bool
 }
 

--- a/controllers/lmes/constants.go
+++ b/controllers/lmes/constants.go
@@ -38,7 +38,7 @@ const (
 	DefaultPodCheckingInterval = time.Second * 10
 	DefaultImagePullPolicy     = corev1.PullAlways
 	DefaultMaxBatchSize        = 24
-	DefaultBatchSize           = 8
+	DefaultBatchSize           = "1"
 	DefaultDetectDevice        = true
 	ServiceName                = "LMES"
 )

--- a/controllers/lmes/lmevaljob_controller.go
+++ b/controllers/lmes/lmevaljob_controller.go
@@ -845,7 +845,7 @@ func validateBatchSize(input string, maxBatchSize int, log logr.Logger) string {
 		// If N is valid, but larger than maxBatchSize, set it to maximum batch size
 		if n > maxBatchSize {
 			log.Info("batchSize is greater than max-batch-size of the controller's configuration, use the max-batch-size instead")
-			return strconv.Itoa(maxBatchSize)
+			return maxBatchSizeString
 		}
 		// If N is valid, use it
 		return strconv.Itoa(n)

--- a/controllers/lmes/lmevaljob_controller.go
+++ b/controllers/lmes/lmevaljob_controller.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -818,6 +819,42 @@ func mergeMapWithFilters(dest, src map[string]string, prefixFilters []string, lo
 	}
 }
 
+func validateBatchSize(input string, maxBatchSize int, log logr.Logger) string {
+
+	maxBatchSizeString := strconv.Itoa(maxBatchSize)
+
+	if input == "auto" {
+		// No validation needed, return original
+		return input
+	}
+
+	// Validate "auto:N" style batch size
+	if strings.HasPrefix(input, "auto:") {
+		autoN := strings.TrimPrefix(input, "auto:")
+		if n, err := strconv.Atoi(autoN); err == nil && n > 0 {
+			// If N is a positive integer, use it and ignore maxBatchSize, since is now the maximum batch size
+			return input
+		}
+		// If N is an invalid integer, use "auto:maxBatchSize"
+		log.Info(input + " not supported. Using auto:" + maxBatchSizeString)
+		return "auto:" + maxBatchSizeString
+	}
+
+	// Validate N batch size
+	if n, err := strconv.Atoi(input); err == nil && n > 0 {
+		// If N is valid, but larger than maxBatchSize, set it to maximum batch size
+		if n > maxBatchSize {
+			log.Info("batchSize is greater than max-batch-size of the controller's configuration, use the max-batch-size instead")
+			return strconv.Itoa(maxBatchSize)
+		}
+		// If N is valid, use it
+		return strconv.Itoa(n)
+	}
+
+	log.Info("invalid batchSize " + input + " using batch size " + DefaultBatchSize)
+	return DefaultBatchSize
+}
+
 func generateArgs(svcOpts *serviceOptions, job *lmesv1alpha1.LMEvalJob, log logr.Logger) []string {
 	if job == nil {
 		return nil
@@ -853,15 +890,12 @@ func generateArgs(svcOpts *serviceOptions, job *lmesv1alpha1.LMEvalJob, log logr
 	}
 	// --batch_size
 	var batchSize = svcOpts.DefaultBatchSize
-	if job.Spec.BatchSize != nil && *job.Spec.BatchSize > 0 {
-		batchSize = *job.Spec.BatchSize
+	if job.Spec.BatchSize != nil {
+		// This could be done in the webhook if it's enabled.
+		batchSize = validateBatchSize(*job.Spec.BatchSize, svcOpts.MaxBatchSize, log)
 	}
-	// This could be done in the webhook if it's enabled.
-	if batchSize > svcOpts.MaxBatchSize {
-		batchSize = svcOpts.MaxBatchSize
-		log.Info("batchSize is greater than max-batch-size of the controller's configuration, use the max-batch-size instead")
-	}
-	cmds = append(cmds, "--batch_size", fmt.Sprintf("%d", batchSize))
+
+	cmds = append(cmds, "--batch_size", batchSize)
 
 	return []string{"sh", "-ec", strings.Join(cmds, " ")}
 }


### PR DESCRIPTION
Refers to [RHOAIENG-14773](https://issues.redhat.com/browse/RHOAIENG-14773).

This PR changes the field `batchSize` from `int` to `string` in order to support the values `auto` and `auto:N`.
Validation is performed by the controller for the following scenarios:

* `batchSize="n"`, assuming `n` is a positive integer it will be used, otherwise use the default batch size
* `batchSize="auto"`, `auto` will be used
* `batchSize="auto:n"`, if `n` is a positive integer `auto:n` will be used and the maximum batch size will be ignored (`n` will be the maximum batch size). If `n` is invalid (negative, or not a `int`), `auto:maxBatchSize` will be used.
* `batchSize="n"`, (where `n > maxBatchSize`) maximum batch size will be used

This PR also lower the default batch size from `8` to `1`.