### PR TITLE
fix(RHOAIENG-14321): Revert metrics service target port to https

### DIFF
--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -16,6 +16,6 @@ spec:
     - name: https
       port: 8443
       protocol: TCP
-      targetPort: 8081
+      targetPort: https
   selector:
     control-plane: controller-manager


### PR DESCRIPTION
Reverts the operator's metrics service target port to `https`.