### PR TITLE
fix(tas): Operator not detecting KServe Serverless correctly

### DIFF
--- a/controllers/tas/inference_services.go
+++ b/controllers/tas/inference_services.go
@@ -231,12 +231,7 @@ func (r *TrustyAIServiceReconciler) handleInferenceServices(ctx context.Context,
 
 	for _, infService := range inferenceServices.Items {
 		annotations := infService.GetAnnotations()
-		deploymentMode, ok := annotations["serving.kserve.io/deploymentMode"]
-
-		if !ok {
-			// Model is not annotated as either KServe serverless, KServe Raw or ModelMesh
-			continue
-		}
+		deploymentMode := annotations["serving.kserve.io/deploymentMode"]
 
 		switch deploymentMode {
 		case DEPLOYMENT_MODE_MODELMESH:


### PR DESCRIPTION
KServe Serverless `InferenceServices` do not have an annotation, so the operator was skipping patching.
Refer [RHOAIENG-16566](https://issues.redhat.com/browse/RHOAIENG-16566).