### PR TITLE
feat(lmeval): Add operator online and execution feature flag

### DIFF
--- a/config/base/params.env
+++ b/config/base/params.env
@@ -9,4 +9,5 @@ lmes-image-pull-policy=Always
 lmes-max-batch-size=24
 lmes-default-batch-size=8
 lmes-detect-device=true
-
+lmes-allow-online=true
+lmes-allow-code-execution=true

--- a/config/overlays/odh-kueue/params.env
+++ b/config/overlays/odh-kueue/params.env
@@ -9,3 +9,5 @@ lmes-image-pull-policy=Always
 lmes-max-batch-size=24
 lmes-default-batch-size=8
 lmes-detect-device=true
+lmes-allow-online=true
+lmes-allow-code-execution=true

--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -9,3 +9,5 @@ lmes-image-pull-policy=Always
 lmes-max-batch-size=24
 lmes-default-batch-size=8
 lmes-detect-device=true
+lmes-allow-online=true
+lmes-allow-code-execution=true

--- a/config/overlays/rhoai/params.env
+++ b/config/overlays/rhoai/params.env
@@ -9,3 +9,5 @@ lmes-image-pull-policy=Always
 lmes-max-batch-size=24
 lmes-default-batch-size=8
 lmes-detect-device=true
+lmes-allow-online=false
+lmes-allow-code-execution=false

--- a/controllers/lmes/config.go
+++ b/controllers/lmes/config.go
@@ -37,6 +37,8 @@ var Options *serviceOptions = &serviceOptions{
 	MaxBatchSize:        DefaultMaxBatchSize,
 	DetectDevice:        DefaultDetectDevice,
 	DefaultBatchSize:    DefaultBatchSize,
+	AllowOnline:         false,
+	AllowCodeExecution:  false,
 }
 
 type serviceOptions struct {
@@ -47,6 +49,8 @@ type serviceOptions struct {
 	MaxBatchSize        int
 	DefaultBatchSize    string
 	DetectDevice        bool
+	AllowOnline         bool
+	AllowCodeExecution  bool
 }
 
 func constructOptionsFromConfigMap(log *logr.Logger, configmap *corev1.ConfigMap) error {

--- a/controllers/lmes/constants.go
+++ b/controllers/lmes/constants.go
@@ -34,6 +34,8 @@ const (
 	MaxBatchSizeKey            = "lmes-max-batch-size"
 	DefaultBatchSizeKey        = "lmes-default-batch-size"
 	DetectDeviceKey            = "lmes-detect-device"
+	AllowOnline                = "lmes-allow-online"
+	AllowCodeExecution         = "lmes-allow-code-execution"
 	DefaultPodImage            = "quay.io/trustyai/ta-lmes-job:latest"
 	DefaultDriverImage         = "quay.io/trustyai/ta-lmes-driver:latest"
 	DefaultPodCheckingInterval = time.Second * 10

--- a/controllers/lmes/lmevaljob_controller_test.go
+++ b/controllers/lmes/lmevaljob_controller_test.go
@@ -1683,6 +1683,177 @@ func Test_OfflineMode(t *testing.T) {
 	assert.Equal(t, expect, newPod)
 }
 
+// Test_OnlineModeDisabled tests that if the online mode is set, but the controller disables it
+// it will still run in offline mode
+func Test_OnlineModeDisabled(t *testing.T) {
+	log := log.FromContext(context.Background())
+	svcOpts := &serviceOptions{
+		PodImage:           "podimage:latest",
+		DriverImage:        "driver:latest",
+		ImagePullPolicy:    corev1.PullAlways,
+		AllowOnline:        false,
+		AllowCodeExecution: false,
+	}
+
+	jobName := "test"
+	pvcName := "my-pvc"
+	allowOnline := true
+	allowCodeExecution := true
+	var job = &lmesv1alpha1.LMEvalJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: "default",
+			UID:       "for-testing",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       lmesv1alpha1.KindName,
+			APIVersion: lmesv1alpha1.Version,
+		},
+		Spec: lmesv1alpha1.LMEvalJobSpec{
+			AllowOnline:        &allowOnline,
+			AllowCodeExecution: &allowCodeExecution,
+			Model:              "test",
+			ModelArgs: []lmesv1alpha1.Arg{
+				{Name: "arg1", Value: "value1"},
+			},
+			TaskList: lmesv1alpha1.TaskList{
+				TaskNames: []string{"task1", "task2"},
+			},
+			Offline: &lmesv1alpha1.OfflineSpec{
+				StorageSpec: lmesv1alpha1.OfflineStorageSpec{
+					PersistentVolumeClaimName: pvcName,
+				},
+			},
+		},
+	}
+
+	expect := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app.kubernetes.io/name": "ta-lmes",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: lmesv1alpha1.Version,
+					Kind:       lmesv1alpha1.KindName,
+					Name:       "test",
+					Controller: &isController,
+					UID:        "for-testing",
+				},
+			},
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{
+					Name:            "driver",
+					Image:           svcOpts.DriverImage,
+					ImagePullPolicy: svcOpts.ImagePullPolicy,
+					Command:         []string{DriverPath, "--copy", DestDriverPath},
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{
+								"ALL",
+							},
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "shared",
+							MountPath: "/opt/app-root/src/bin",
+						},
+					},
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:            "main",
+					Image:           svcOpts.PodImage,
+					ImagePullPolicy: svcOpts.ImagePullPolicy,
+					Command:         generateCmd(svcOpts, job),
+					Args:            generateArgs(svcOpts, job, log),
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{
+								"ALL",
+							},
+						},
+					},
+					Env: []corev1.EnvVar{
+						{
+							Name:  "TRUST_REMOTE_CODE",
+							Value: "0",
+						},
+						{
+							Name:  "HF_DATASETS_TRUST_REMOTE_CODE",
+							Value: "0",
+						},
+						{
+							Name:  "HF_DATASETS_OFFLINE",
+							Value: "1",
+						},
+						{
+							Name:  "HF_HUB_OFFLINE",
+							Value: "1",
+						},
+						{
+							Name:  "TRANSFORMERS_OFFLINE",
+							Value: "1",
+						},
+						{
+							Name:  "HF_EVALUATE_OFFLINE",
+							Value: "1",
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "shared",
+							MountPath: "/opt/app-root/src/bin",
+						},
+						{
+							Name:      "offline",
+							MountPath: "/opt/app-root/src/hf_home",
+						},
+					},
+				},
+			},
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot: &runAsNonRootUser,
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "shared", VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+				{
+					Name: "offline", VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: pvcName,
+							ReadOnly:  false,
+						},
+					},
+				},
+			},
+			RestartPolicy: corev1.RestartPolicyNever,
+		},
+	}
+
+	newPod := CreatePod(svcOpts, job, log)
+
+	assert.Equal(t, expect, newPod)
+}
+
 // Test_OnlineMode tests that if the online mode is set the configuration is correct
 func Test_OnlineMode(t *testing.T) {
 	log := log.FromContext(context.Background())
@@ -1690,6 +1861,7 @@ func Test_OnlineMode(t *testing.T) {
 		PodImage:        "podimage:latest",
 		DriverImage:     "driver:latest",
 		ImagePullPolicy: corev1.PullAlways,
+		AllowOnline:     true,
 	}
 
 	allowOnline := true
@@ -1837,9 +2009,11 @@ func Test_OnlineMode(t *testing.T) {
 func Test_AllowCodeOnlineMode(t *testing.T) {
 	log := log.FromContext(context.Background())
 	svcOpts := &serviceOptions{
-		PodImage:        "podimage:latest",
-		DriverImage:     "driver:latest",
-		ImagePullPolicy: corev1.PullAlways,
+		PodImage:           "podimage:latest",
+		DriverImage:        "driver:latest",
+		ImagePullPolicy:    corev1.PullAlways,
+		AllowOnline:        true,
+		AllowCodeExecution: true,
 	}
 
 	jobName := "test"
@@ -1979,9 +2153,11 @@ func Test_AllowCodeOnlineMode(t *testing.T) {
 func Test_AllowCodeOfflineMode(t *testing.T) {
 	log := log.FromContext(context.Background())
 	svcOpts := &serviceOptions{
-		PodImage:        "podimage:latest",
-		DriverImage:     "driver:latest",
-		ImagePullPolicy: corev1.PullAlways,
+		PodImage:           "podimage:latest",
+		DriverImage:        "driver:latest",
+		ImagePullPolicy:    corev1.PullAlways,
+		AllowOnline:        true,
+		AllowCodeExecution: true,
 	}
 
 	jobName := "test"


### PR DESCRIPTION
Add feature flag to the operator to enable the `allowOnline` and `allowCodeExecution` CR flags.

The operator feature will not set the LMEval Job deployment mode. This flag is purely to set (at the controller level) if an LMEval Job is _allowed_ to use the online and code execution flags.

Refer to [RHOAIENG-16816](https://issues.redhat.com/browse/RHOAIENG-16816).