### PR TITLE
fix(lmeval): Remove unneeded metrics fetch

### DIFF
--- a/Dockerfile.lmes-job
+++ b/Dockerfile.lmes-job
@@ -12,14 +12,9 @@ RUN mkdir -p /opt/app-root/src/my_catalogs/cards && chmod -R g+rwx /opt/app-root
 RUN mkdir -p /opt/app-root/src/.cache
 ENV PATH="/opt/app-root/bin:/opt/app-root/src/.local/bin/:/opt/app-root/src/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
-# Clone the Git repository, check out v0.4.4 and install the Python package
 RUN git clone https://github.com/opendatahub-io/lm-evaluation-harness.git && \
     cd lm-evaluation-harness &&  git checkout release-0.4.5 && \
     pip install --no-cache-dir --user -e .[api,ibm_watsonx_ai]
-
-RUN git clone --branch odh-2.22 https://github.com/opendatahub-io/hf-evaluate.git /tmp/evaluate && \
-    cp -R /tmp/evaluate/metrics/. . && \
-    rm -Rf /tmp/evaluate
 
 RUN python -c 'from lm_eval.tasks.unitxt import task; import os.path; print("class: !function " + task.__file__.replace("task.py", "task.Unitxt"))' > ./my_tasks/unitxt
 


### PR DESCRIPTION
Metrics are now included in the lm-evaluation-harness repository with https://github.com/opendatahub-io/lm-evaluation-harness/pull/13