### PR TITLE
feat(lmeval): Allow unitxt code execution when LMEval code execution enabled

### DIFF
--- a/controllers/lmes/lmevaljob_controller.go
+++ b/controllers/lmes/lmevaljob_controller.go
@@ -715,7 +715,7 @@ func CreatePod(svcOpts *serviceOptions, job *lmesv1alpha1.LMEvalJob, log logr.Lo
 		volumes = append(volumes, outputPVC)
 	}
 
-	remoteCodeEnvVars := []corev1.EnvVar{
+	disallowRemoteCodeEnvVars := []corev1.EnvVar{
 		{
 			Name:  "TRUST_REMOTE_CODE",
 			Value: "0",
@@ -724,17 +724,37 @@ func CreatePod(svcOpts *serviceOptions, job *lmesv1alpha1.LMEvalJob, log logr.Lo
 			Name:  "HF_DATASETS_TRUST_REMOTE_CODE",
 			Value: "0",
 		},
+		{
+			Name:  "UNITXT_ALLOW_UNVERIFIED_CODE",
+			Value: "False",
+		},
 	}
-
+	allowRemoteCodeEnvVars := []corev1.EnvVar{
+		{
+			Name:  "TRUST_REMOTE_CODE",
+			Value: "1",
+		},
+		{
+			Name:  "HF_DATASETS_TRUST_REMOTE_CODE",
+			Value: "1",
+		},
+		{
+			Name:  "UNITXT_ALLOW_UNVERIFIED_CODE",
+			Value: "True",
+		},
+	}
 	if job.Spec.AllowCodeExecution != nil && *job.Spec.AllowCodeExecution {
 		// Disable remote code execution by default
 
 		if !svcOpts.AllowCodeExecution {
 			log.Error(fmt.Errorf("code execution not allowed by the operator"), "change this setting and redeploy the operator")
-			envVars = append(envVars, remoteCodeEnvVars...)
+			envVars = append(envVars, disallowRemoteCodeEnvVars...)
+		} else {
+			log.Info("enabling code execution")
+			envVars = append(envVars, allowRemoteCodeEnvVars...)
 		}
 	} else {
-		envVars = append(envVars, remoteCodeEnvVars...)
+		envVars = append(envVars, disallowRemoteCodeEnvVars...)
 	}
 
 	offlineHuggingFaceEnvVars := []corev1.EnvVar{
@@ -1086,7 +1106,15 @@ func getContainerByName(status *corev1.PodStatus, name string) int {
 	})
 }
 
-var ProtectedEnvVarNames = []string{"TRUST_REMOTE_CODE", "HF_DATASETS_TRUST_REMOTE_CODE", "HF_DATASETS_OFFLINE", "HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE", "HF_EVALUATE_OFFLINE"}
+var ProtectedEnvVarNames = []string{
+	"TRUST_REMOTE_CODE",
+	"HF_DATASETS_TRUST_REMOTE_CODE",
+	"HF_DATASETS_OFFLINE",
+	"HF_HUB_OFFLINE",
+	"TRANSFORMERS_OFFLINE",
+	"HF_EVALUATE_OFFLINE",
+	"UNITXT_ALLOW_UNVERIFIED_CODE",
+}
 
 // removeProtectedEnvVars removes protected EnvVars from a list of EnvVars
 func removeProtectedEnvVars(envVars []corev1.EnvVar) []corev1.EnvVar {

--- a/controllers/lmes/lmevaljob_controller_test.go
+++ b/controllers/lmes/lmevaljob_controller_test.go
@@ -126,6 +126,10 @@ func Test_SimplePod(t *testing.T) {
 							Value: "0",
 						},
 						{
+							Name:  "UNITXT_ALLOW_UNVERIFIED_CODE",
+							Value: "False",
+						},
+						{
 							Name:  "HF_DATASETS_OFFLINE",
 							Value: "1",
 						},
@@ -334,6 +338,10 @@ func Test_WithCustomPod(t *testing.T) {
 							Value: "0",
 						},
 						{
+							Name:  "UNITXT_ALLOW_UNVERIFIED_CODE",
+							Value: "False",
+						},
+						{
 							Name:  "HF_DATASETS_OFFLINE",
 							Value: "1",
 						},
@@ -524,6 +532,10 @@ func Test_EnvSecretsPod(t *testing.T) {
 							Value: "0",
 						},
 						{
+							Name:  "UNITXT_ALLOW_UNVERIFIED_CODE",
+							Value: "False",
+						},
+						{
 							Name:  "HF_DATASETS_OFFLINE",
 							Value: "1",
 						},
@@ -676,6 +688,10 @@ func Test_FileSecretsPod(t *testing.T) {
 						{
 							Name:  "HF_DATASETS_TRUST_REMOTE_CODE",
 							Value: "0",
+						},
+						{
+							Name:  "UNITXT_ALLOW_UNVERIFIED_CODE",
+							Value: "False",
 						},
 						{
 							Name:  "HF_DATASETS_OFFLINE",
@@ -1131,6 +1147,10 @@ func Test_ManagedPVC(t *testing.T) {
 							Value: "0",
 						},
 						{
+							Name:  "UNITXT_ALLOW_UNVERIFIED_CODE",
+							Value: "False",
+						},
+						{
 							Name:  "HF_DATASETS_OFFLINE",
 							Value: "1",
 						},
@@ -1272,6 +1292,10 @@ func Test_ExistingPVC(t *testing.T) {
 						{
 							Name:  "HF_DATASETS_TRUST_REMOTE_CODE",
 							Value: "0",
+						},
+						{
+							Name:  "UNITXT_ALLOW_UNVERIFIED_CODE",
+							Value: "False",
 						},
 						{
 							Name:  "HF_DATASETS_OFFLINE",
@@ -1432,6 +1456,10 @@ func Test_PVCPreference(t *testing.T) {
 						{
 							Name:  "HF_DATASETS_TRUST_REMOTE_CODE",
 							Value: "0",
+						},
+						{
+							Name:  "UNITXT_ALLOW_UNVERIFIED_CODE",
+							Value: "False",
 						},
 						{
 							Name:  "HF_DATASETS_OFFLINE",
@@ -1625,6 +1653,10 @@ func Test_OfflineMode(t *testing.T) {
 							Value: "0",
 						},
 						{
+							Name:  "UNITXT_ALLOW_UNVERIFIED_CODE",
+							Value: "False",
+						},
+						{
 							Name:  "HF_DATASETS_OFFLINE",
 							Value: "1",
 						},
@@ -1733,6 +1765,10 @@ func Test_ProtectedVars(t *testing.T) {
 							Name:  "TRUST_REMOTE_CODE",
 							Value: "1",
 						},
+						{
+							Name:  "UNITXT_ALLOW_UNVERIFIED_CODE",
+							Value: "True",
+						},
 					},
 				},
 			},
@@ -1810,6 +1846,10 @@ func Test_ProtectedVars(t *testing.T) {
 						{
 							Name:  "HF_DATASETS_TRUST_REMOTE_CODE",
 							Value: "0",
+						},
+						{
+							Name:  "UNITXT_ALLOW_UNVERIFIED_CODE",
+							Value: "False",
 						},
 						{
 							Name:  "HF_DATASETS_OFFLINE",
@@ -1983,6 +2023,10 @@ func Test_OnlineModeDisabled(t *testing.T) {
 							Value: "0",
 						},
 						{
+							Name:  "UNITXT_ALLOW_UNVERIFIED_CODE",
+							Value: "False",
+						},
+						{
 							Name:  "HF_DATASETS_OFFLINE",
 							Value: "1",
 						},
@@ -2149,6 +2193,10 @@ func Test_OnlineMode(t *testing.T) {
 							Name:  "HF_DATASETS_TRUST_REMOTE_CODE",
 							Value: "0",
 						},
+						{
+							Name:  "UNITXT_ALLOW_UNVERIFIED_CODE",
+							Value: "False",
+						},
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
@@ -2294,6 +2342,20 @@ func Test_AllowCodeOnlineMode(t *testing.T) {
 							},
 						},
 					},
+					Env: []corev1.EnvVar{
+						{
+							Name:  "TRUST_REMOTE_CODE",
+							Value: "1",
+						},
+						{
+							Name:  "HF_DATASETS_TRUST_REMOTE_CODE",
+							Value: "1",
+						},
+						{
+							Name:  "UNITXT_ALLOW_UNVERIFIED_CODE",
+							Value: "True",
+						},
+					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "shared",
@@ -2437,6 +2499,18 @@ func Test_AllowCodeOfflineMode(t *testing.T) {
 						},
 					},
 					Env: []corev1.EnvVar{
+						{
+							Name:  "TRUST_REMOTE_CODE",
+							Value: "1",
+						},
+						{
+							Name:  "HF_DATASETS_TRUST_REMOTE_CODE",
+							Value: "1",
+						},
+						{
+							Name:  "UNITXT_ALLOW_UNVERIFIED_CODE",
+							Value: "True",
+						},
 						{
 							Name:  "HF_DATASETS_OFFLINE",
 							Value: "1",
@@ -2604,6 +2678,10 @@ func Test_OfflineModeWithOutput(t *testing.T) {
 						{
 							Name:  "HF_DATASETS_TRUST_REMOTE_CODE",
 							Value: "0",
+						},
+						{
+							Name:  "UNITXT_ALLOW_UNVERIFIED_CODE",
+							Value: "False",
 						},
 						{
 							Name:  "HF_DATASETS_OFFLINE",


### PR DESCRIPTION
Allow unitxt code execution when LMEval code execution enabled.

Refer [RHOAIENG-17255](https://issues.redhat.com/browse/RHOAIENG-17255).