### PR TITLE
fix(lmeval): Make lm-evaluation-harness source path consistent

### DIFF
--- a/Dockerfile.lmes-job
+++ b/Dockerfile.lmes-job
@@ -12,8 +12,7 @@ RUN mkdir -p /opt/app-root/src/my_catalogs/cards && chmod -R g+rwx /opt/app-root
 RUN mkdir -p /opt/app-root/src/.cache
 ENV PATH="/opt/app-root/bin:/opt/app-root/src/.local/bin/:/opt/app-root/src/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
-RUN git clone https://github.com/opendatahub-io/lm-evaluation-harness.git && \
-    cd lm-evaluation-harness &&  git checkout release-0.4.5 && \
+RUN git clone --depth 1 -b release-0.4.5 https://github.com/opendatahub-io/lm-evaluation-harness.git . && \
     pip install --no-cache-dir --user -e .[api,ibm_watsonx_ai]
 
 RUN python -c 'from lm_eval.tasks.unitxt import task; import os.path; print("class: !function " + task.__file__.replace("task.py", "task.Unitxt"))' > ./my_tasks/unitxt

--- a/Dockerfile.lmes-job
+++ b/Dockerfile.lmes-job
@@ -12,7 +12,10 @@ RUN mkdir -p /opt/app-root/src/my_catalogs/cards && chmod -R g+rwx /opt/app-root
 RUN mkdir -p /opt/app-root/src/.cache
 ENV PATH="/opt/app-root/bin:/opt/app-root/src/.local/bin/:/opt/app-root/src/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
-RUN git clone --depth 1 -b release-0.4.5 https://github.com/opendatahub-io/lm-evaluation-harness.git . && \
+RUN curl -L https://github.com/opendatahub-io/lm-evaluation-harness/archive/refs/heads/release-0.4.5.zip -o repo.zip && \
+    unzip repo.zip && \
+    cp -r lm-evaluation-harness-release-0.4.5/* . && \
+    rm -rf lm-evaluation-harness-release-0.4.5 repo.zip && \
     pip install --no-cache-dir --user -e .[api,ibm_watsonx_ai]
 
 RUN python -c 'from lm_eval.tasks.unitxt import task; import os.path; print("class: !function " + task.__file__.replace("task.py", "task.Unitxt"))' > ./my_tasks/unitxt


### PR DESCRIPTION
lm-evaluation-path to be made consistent with metrics path (https://github.com/opendatahub-io/lm-evaluation-harness/pull/16). Previously it was `/opt/app-root/src/lm-evaluation-harness` and this PR makes it `/opt/app-root/src`.