### PR TITLE
fix: Increase resource limits for the TrustyAI operator

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -58,8 +58,8 @@ spec:
             periodSeconds: 10
           resources:
             limits:
-              cpu: 500m
-              memory: 128Mi
+              cpu: 900m
+              memory: 700Mi
             requests:
               cpu: 10m
               memory: 64Mi


### PR DESCRIPTION
Increased from `cpu:500m,memory:128Mi` to `cpu:900m,memory:700Mi`

Refer to [RHOAIENG-18226](https://issues.redhat.com/browse/RHOAIENG-18226).