### PR TITLE
fix: Run PodExec against the main container

### DIFF
--- a/controllers/lmes/lmevaljob_controller.go
+++ b/controllers/lmes/lmevaljob_controller.go
@@ -345,10 +345,11 @@ func (r *LMEvalJobReconciler) remoteCommand(ctx context.Context, job *lmesv1alph
 		Name(job.GetName()).
 		SubResource("exec").
 		VersionedParams(&corev1.PodExecOptions{
-			Command: []string{"/bin/sh", "-c", command},
-			Stdin:   false,
-			Stdout:  true,
-			Stderr:  true,
+			Command:   []string{"/bin/sh", "-c", command},
+			Stdin:     false,
+			Stdout:    true,
+			Stderr:    true,
+			Container: "main",
 		}, scheme.ParameterCodec)
 
 	outBuff := &bytes.Buffer{}


### PR DESCRIPTION
When running the pod exec to call the driver APIs, it's better to specify the name of the main container. Otherwise, it would cause errors when there are multiple running containers.