### PR TITLE
feat(LMES): Switch LMES driver to a container port

### DIFF
--- a/cmd/lmes_driver/main.go
+++ b/cmd/lmes_driver/main.go
@@ -57,6 +57,7 @@ var (
 	shutdown     = flag.Bool("shutdown", false, "Shutdown the driver")
 	outputPath   = flag.String("output-path", OutputPath, "output path")
 	detectDevice = flag.Bool("detect-device", false, "detect available device(s), CUDA or CPU")
+	commPort     = flag.Int("listen-port", driver.DefaultPort, "driver serves APIs on the port")
 	driverLog    = ctrl.Log.WithName("driver")
 )
 
@@ -112,6 +113,7 @@ func main() {
 		TaskRecipes:  taskRecipes,
 		CustomCards:  customCards,
 		Args:         args,
+		CommPort:     *commPort,
 	}
 
 	driver, err := driver.NewDriver(&driverOpt)

--- a/controllers/lmes/config.go
+++ b/controllers/lmes/config.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/trustyai-explainability/trustyai-service-operator/controllers/lmes/driver"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -39,6 +40,7 @@ var Options *serviceOptions = &serviceOptions{
 	DefaultBatchSize:    DefaultBatchSize,
 	AllowOnline:         false,
 	AllowCodeExecution:  false,
+	DriverPort:          driver.DefaultPort,
 }
 
 type serviceOptions struct {
@@ -51,6 +53,7 @@ type serviceOptions struct {
 	DetectDevice        bool
 	AllowOnline         bool
 	AllowCodeExecution  bool
+	DriverPort          int
 }
 
 func constructOptionsFromConfigMap(log *logr.Logger, configmap *corev1.ConfigMap) error {

--- a/controllers/lmes/constants.go
+++ b/controllers/lmes/constants.go
@@ -36,6 +36,7 @@ const (
 	DetectDeviceKey            = "lmes-detect-device"
 	AllowOnline                = "lmes-allow-online"
 	AllowCodeExecution         = "lmes-allow-code-execution"
+	DriverPort                 = "lmes-driver-port"
 	DefaultPodImage            = "quay.io/trustyai/ta-lmes-job:latest"
 	DefaultDriverImage         = "quay.io/trustyai/ta-lmes-driver:latest"
 	DefaultPodCheckingInterval = time.Second * 10

--- a/controllers/lmes/driver/driver.go
+++ b/controllers/lmes/driver/driver.go
@@ -42,8 +42,8 @@ var (
 )
 
 const (
-	// put the domain socket under /tmp. may move to emptydir to share across containers
-	socketPath             = "/tmp/ta-lmes-driver.sock"
+	// the default port for the driver to listen on
+	DefaultPort            = 18080
 	DefaultTaskRecipesPath = "/opt/app-root/src/my_tasks"
 	DefaultCatalogPath     = "/opt/app-root/src/my_catalogs"
 	TaskRecipePrefix       = "tr"
@@ -62,7 +62,7 @@ type DriverOption struct {
 	CustomCards     []string
 	Logger          logr.Logger
 	Args            []string
-	SocketPath      string
+	CommPort        int
 }
 
 type Driver interface {
@@ -76,7 +76,7 @@ type Driver interface {
 type driverComm struct {
 	connection chan int
 	server     *http.Server
-	path       string
+	port       int
 }
 
 type driverImpl struct {
@@ -104,8 +104,8 @@ func NewDriver(opt *DriverOption) (Driver, error) {
 		opt.CatalogPath = DefaultCatalogPath
 	}
 
-	if opt.SocketPath == "" {
-		opt.SocketPath = socketPath
+	if opt.CommPort == 0 {
+		opt.CommPort = DefaultPort
 	}
 
 	return &driverImpl{
@@ -143,8 +143,8 @@ func (d *driverImpl) Run() error {
 }
 
 func (d *driverImpl) GetStatus() (*lmesv1alpha1.LMEvalJobStatus, error) {
-	client := createClient(d.Option.SocketPath)
-	resp, err := client.Get(fmt.Sprintf("http://unix%s", GetStatusURI))
+	client := &http.Client{}
+	resp, err := client.Get(fmt.Sprintf("http://127.0.0.1:%d/%s", d.Option.CommPort, GetStatusURI))
 	if err != nil {
 		return nil, err
 	}
@@ -160,8 +160,8 @@ func (d *driverImpl) GetStatus() (*lmesv1alpha1.LMEvalJobStatus, error) {
 	return &status, err
 }
 func (d *driverImpl) Shutdown() error {
-	client := createClient(d.Option.SocketPath)
-	resp, err := client.Post(fmt.Sprintf("http://unix%s", ShutdownURI), "application/json", nil)
+	client := &http.Client{}
+	resp, err := client.Post(fmt.Sprintf("http://127.0.0.1:%d/%s", d.Option.CommPort, ShutdownURI), "application/json", nil)
 	if err != nil {
 		return err
 	}
@@ -222,7 +222,7 @@ func (d *driverImpl) setupComm() error {
 	d.comm = &driverComm{
 		server:     &http.Server{Handler: serve},
 		connection: make(chan int),
-		path:       d.Option.SocketPath,
+		port:       d.Option.CommPort,
 	}
 
 	// handle the `GetStatus` API: return the complete lmesv1alpha1.LMEvalJobStatus
@@ -249,22 +249,12 @@ func (d *driverImpl) setupComm() error {
 	return nil
 }
 
-func createClient(path string) *http.Client {
-	return &http.Client{
-		Transport: &http.Transport{
-			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-				return net.Dial("unix", path)
-			},
-		},
-	}
-}
-
 func (dc *driverComm) wait4Sutdownload() {
 	<-dc.connection
 }
 
 func (dc *driverComm) serve() error {
-	socket, err := net.Listen("unix", dc.path)
+	socket, err := net.Listen("tcp4", fmt.Sprintf("127.0.0.1:%d", dc.port))
 	if err != nil {
 		return err
 	}
@@ -276,7 +266,6 @@ func (dc *driverComm) close() {
 	if dc.server != nil && dc.connection != nil {
 		dc.server.Shutdown(context.Background())
 		close(dc.connection)
-		os.Remove(dc.path)
 	}
 }
 

--- a/controllers/lmes/driver/driver_test.go
+++ b/controllers/lmes/driver/driver_test.go
@@ -18,9 +18,8 @@ package driver
 
 import (
 	"context"
-	"crypto/rand"
 	"flag"
-	"fmt"
+	"math/rand"
 	"os"
 	"testing"
 	"time"
@@ -47,11 +46,10 @@ func TestMain(m *testing.M) {
 	m.Run()
 }
 
-func genRandomSocketPath() string {
-	b := make([]byte, 10)
-	rand.Read(b)
-	p := fmt.Sprintf("/tmp/ta-lmes-%x.sock", b)
-	return p
+// to support concurrent testing if needed, each test needs a
+// dedicated port
+func genRandomPort() int {
+	return rand.Intn(1000) + 18080
 }
 
 func runDriverAndWait4Complete(t *testing.T, driver Driver, returnError bool) (progressMsgs []string, results string) {
@@ -84,7 +82,7 @@ func Test_Driver(t *testing.T) {
 		OutputPath: ".",
 		Logger:     driverLog,
 		Args:       []string{"sh", "-ec", "echo tttttttttttttttttttt"},
-		SocketPath: genRandomSocketPath(),
+		CommPort:   genRandomPort(),
 	})
 	assert.Nil(t, err)
 
@@ -101,7 +99,7 @@ func Test_Wait4Shutdown(t *testing.T) {
 		OutputPath: ".",
 		Logger:     driverLog,
 		Args:       []string{"sh", "-ec", "echo test"},
-		SocketPath: genRandomSocketPath(),
+		CommPort:   genRandomPort(),
 	})
 	assert.Nil(t, err)
 
@@ -116,7 +114,7 @@ func Test_Wait4Shutdown(t *testing.T) {
 	assert.Nil(t, driver.Shutdown())
 
 	_, err = driver.GetStatus()
-	assert.ErrorContains(t, err, "no such file or directory")
+	assert.ErrorContains(t, err, "connection refused")
 
 	assert.Nil(t, os.Remove("./stderr.log"))
 	assert.Nil(t, os.Remove("./stdout.log"))
@@ -128,7 +126,7 @@ func Test_ProgressUpdate(t *testing.T) {
 		OutputPath: ".",
 		Logger:     driverLog,
 		Args:       []string{"sh", "-ec", "sleep 2; echo 'testing progress: 100%|' >&2; sleep 4"},
-		SocketPath: genRandomSocketPath(),
+		CommPort:   genRandomPort(),
 	})
 	assert.Nil(t, err)
 
@@ -152,7 +150,7 @@ func Test_DetectDeviceError(t *testing.T) {
 		DetectDevice: true,
 		Logger:       driverLog,
 		Args:         []string{"sh", "-ec", "python -m lm_eval --output_path ./output --model test --model_args arg1=value1 --tasks task1,task2"},
-		SocketPath:   genRandomSocketPath(),
+		CommPort:     genRandomPort(),
 	})
 	assert.Nil(t, err)
 
@@ -211,8 +209,8 @@ func Test_TaskRecipes(t *testing.T) {
 			"card=unitxt.card1,template=unitxt.template,metrics=[unitxt.metric1,unitxt.metric2],format=unitxt.format,num_demos=5,demos_pool_size=10",
 			"card=unitxt.card2,template=unitxt.template2,metrics=[unitxt.metric3,unitxt.metric4],format=unitxt.format,num_demos=5,demos_pool_size=10",
 		},
-		Args:       []string{"sh", "-ec", "sleep 2; echo 'testing progress: 100%|' >&2; sleep 4"},
-		SocketPath: genRandomSocketPath(),
+		Args:     []string{"sh", "-ec", "sleep 2; echo 'testing progress: 100%|' >&2; sleep 4"},
+		CommPort: genRandomPort(),
 	})
 	assert.Nil(t, err)
 
@@ -257,8 +255,8 @@ func Test_CustomCards(t *testing.T) {
 		CustomCards: []string{
 			`{ "__type__": "task_card", "loader": { "__type__": "load_hf", "path": "wmt16", "name": "de-en" }, "preprocess_steps": [ { "__type__": "copy", "field": "translation/en", "to_field": "text" }, { "__type__": "copy", "field": "translation/de", "to_field": "translation" }, { "__type__": "set", "fields": { "source_language": "english", "target_language": "deutch" } } ], "task": "tasks.translation.directed", "templates": "templates.translation.directed.all" }`,
 		},
-		Args:       []string{"sh", "-ec", "sleep 1; echo 'testing progress: 100%|' >&2; sleep 3"},
-		SocketPath: genRandomSocketPath(),
+		Args:     []string{"sh", "-ec", "sleep 1; echo 'testing progress: 100%|' >&2; sleep 3"},
+		CommPort: genRandomPort(),
 	})
 	assert.Nil(t, err)
 
@@ -299,7 +297,7 @@ func Test_ProgramError(t *testing.T) {
 		OutputPath: ".",
 		Logger:     driverLog,
 		Args:       []string{"sh", "-ec", "sleep 1; exit 1"},
-		SocketPath: genRandomSocketPath(),
+		CommPort:   genRandomPort(),
 	})
 	assert.Nil(t, err)
 

--- a/controllers/lmes/lmevaljob_controller.go
+++ b/controllers/lmes/lmevaljob_controller.go
@@ -70,6 +70,7 @@ var (
 		"DetectDevice":        DetectDeviceKey,
 		"AllowOnline":         AllowOnline,
 		"AllowCodeExecution":  AllowCodeExecution,
+		"DriverPort":          DriverPort,
 	}
 
 	labelFilterPrefixes       = []string{}
@@ -846,6 +847,11 @@ func CreatePod(svcOpts *serviceOptions, job *lmesv1alpha1.LMEvalJob, log logr.Lo
 			SecurityContext: mainSecurityContext,
 			VolumeMounts:    volumeMounts,
 			Resources:       *resources,
+			Ports: []corev1.ContainerPort{
+				{
+					ContainerPort: int32(svcOpts.DriverPort),
+				},
+			},
 		},
 	}
 	containers = append(containers, job.Spec.Pod.GetSideCards()...)
@@ -1061,6 +1067,10 @@ func generateCmd(svcOpts *serviceOptions, job *lmesv1alpha1.LMEvalJob) []string 
 
 	if svcOpts.DetectDevice {
 		cmds = append(cmds, "--detect-device")
+	}
+
+	if svcOpts.DriverPort != 0 && svcOpts.DriverPort != driver.DefaultPort {
+		cmds = append(cmds, "--listen-port", fmt.Sprintf("%d", svcOpts.DriverPort))
 	}
 
 	cr_idx := 0

--- a/controllers/lmes/lmevaljob_controller_test.go
+++ b/controllers/lmes/lmevaljob_controller_test.go
@@ -116,6 +116,11 @@ func Test_SimplePod(t *testing.T) {
 							MountPath: "/opt/app-root/src/bin",
 						},
 					},
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: int32(svcOpts.DriverPort),
+						},
+					},
 					Env: []corev1.EnvVar{
 						{
 							Name:  "HF_HUB_DISABLE_TELEMETRY",
@@ -324,7 +329,11 @@ func Test_WithCustomPod(t *testing.T) {
 						RunAsUser:  &runAsUser,
 						RunAsGroup: &runAsGroup,
 					},
-
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: int32(svcOpts.DriverPort),
+						},
+					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "shared",
@@ -535,6 +544,11 @@ func Test_EnvSecretsPod(t *testing.T) {
 					Name:            "main",
 					Image:           svcOpts.PodImage,
 					ImagePullPolicy: svcOpts.ImagePullPolicy,
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: int32(svcOpts.DriverPort),
+						},
+					},
 					Env: []corev1.EnvVar{
 						{
 							Name: "my_env",
@@ -715,6 +729,11 @@ func Test_FileSecretsPod(t *testing.T) {
 					ImagePullPolicy: svcOpts.ImagePullPolicy,
 					Command:         generateCmd(svcOpts, job),
 					Args:            generateArgs(svcOpts, job, log),
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: int32(svcOpts.DriverPort),
+						},
+					},
 					SecurityContext: defaultSecurityContext,
 					Env: []corev1.EnvVar{
 						{
@@ -1184,6 +1203,11 @@ func Test_ManagedPVC(t *testing.T) {
 					ImagePullPolicy: svcOpts.ImagePullPolicy,
 					Command:         generateCmd(svcOpts, job),
 					Args:            generateArgs(svcOpts, job, log),
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: int32(svcOpts.DriverPort),
+						},
+					},
 					SecurityContext: defaultSecurityContext,
 					Env: []corev1.EnvVar{
 						{
@@ -1343,6 +1367,11 @@ func Test_ExistingPVC(t *testing.T) {
 					ImagePullPolicy: svcOpts.ImagePullPolicy,
 					Command:         generateCmd(svcOpts, job),
 					Args:            generateArgs(svcOpts, job, log),
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: int32(svcOpts.DriverPort),
+						},
+					},
 					SecurityContext: defaultSecurityContext,
 					Env: []corev1.EnvVar{
 						{
@@ -1512,6 +1541,11 @@ func Test_PVCPreference(t *testing.T) {
 					ImagePullPolicy: svcOpts.ImagePullPolicy,
 					Command:         generateCmd(svcOpts, job),
 					Args:            generateArgs(svcOpts, job, log),
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: int32(svcOpts.DriverPort),
+						},
+					},
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: &allowPrivilegeEscalation,
 						Capabilities: &corev1.Capabilities{
@@ -1719,6 +1753,11 @@ func Test_OfflineMode(t *testing.T) {
 					ImagePullPolicy: svcOpts.ImagePullPolicy,
 					Command:         generateCmd(svcOpts, job),
 					Args:            generateArgs(svcOpts, job, log),
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: int32(svcOpts.DriverPort),
+						},
+					},
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: &allowPrivilegeEscalation,
 						Capabilities: &corev1.Capabilities{
@@ -1922,6 +1961,11 @@ func Test_ProtectedVars(t *testing.T) {
 					ImagePullPolicy: svcOpts.ImagePullPolicy,
 					Command:         generateCmd(svcOpts, job),
 					Args:            generateArgs(svcOpts, job, log),
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: int32(svcOpts.DriverPort),
+						},
+					},
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: &allowPrivilegeEscalation,
 						Capabilities: &corev1.Capabilities{
@@ -2114,6 +2158,11 @@ func Test_OnlineModeDisabled(t *testing.T) {
 					ImagePullPolicy: svcOpts.ImagePullPolicy,
 					Command:         generateCmd(svcOpts, job),
 					Args:            generateArgs(svcOpts, job, log),
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: int32(svcOpts.DriverPort),
+						},
+					},
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: &allowPrivilegeEscalation,
 						Capabilities: &corev1.Capabilities{
@@ -2297,6 +2346,11 @@ func Test_OnlineMode(t *testing.T) {
 					ImagePullPolicy: svcOpts.ImagePullPolicy,
 					Command:         generateCmd(svcOpts, job),
 					Args:            generateArgs(svcOpts, job, log),
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: int32(svcOpts.DriverPort),
+						},
+					},
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: &allowPrivilegeEscalation,
 						Capabilities: &corev1.Capabilities{
@@ -2463,6 +2517,11 @@ func Test_AllowCodeOnlineMode(t *testing.T) {
 					ImagePullPolicy: svcOpts.ImagePullPolicy,
 					Command:         generateCmd(svcOpts, job),
 					Args:            generateArgs(svcOpts, job, log),
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: int32(svcOpts.DriverPort),
+						},
+					},
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: &allowPrivilegeEscalation,
 						Capabilities: &corev1.Capabilities{
@@ -2627,6 +2686,11 @@ func Test_AllowCodeOfflineMode(t *testing.T) {
 					ImagePullPolicy: svcOpts.ImagePullPolicy,
 					Command:         generateCmd(svcOpts, job),
 					Args:            generateArgs(svcOpts, job, log),
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: int32(svcOpts.DriverPort),
+						},
+					},
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: &allowPrivilegeEscalation,
 						Capabilities: &corev1.Capabilities{
@@ -2811,6 +2875,11 @@ func Test_OfflineModeWithOutput(t *testing.T) {
 					ImagePullPolicy: svcOpts.ImagePullPolicy,
 					Command:         generateCmd(svcOpts, job),
 					Args:            generateArgs(svcOpts, job, log),
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: int32(svcOpts.DriverPort),
+						},
+					},
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: &allowPrivilegeEscalation,
 						Capabilities: &corev1.Capabilities{


### PR DESCRIPTION
Originally, the LMES driver used a Unix domain socket to serve the APIs which are used by the LMES controller to retrieve the job status. Switch to a container port to allow other containers in the same job pod to access the APIs as well.