### PR TITLE
fix(RHOAIENG-20116): Use correct ConfigMap for orchestrator image config

### DIFF
--- a/controllers/gorch/configmap.go
+++ b/controllers/gorch/configmap.go
@@ -14,15 +14,15 @@ func (r *GuardrailsOrchestratorReconciler) getImageFromConfigMap(ctx context.Con
 	err := r.Get(ctx, types.NamespacedName{Name: configMapName, Namespace: namespace}, configMap)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			return "", nil
+			return "", fmt.Errorf("could not find configmap %s on namespace %s", configMapName, namespace)
 		}
-		return "", fmt.Errorf("error reading configmap %s", configMapName)
+		return "", fmt.Errorf("error reading configmap %s on namespace %s", configMapName, namespace)
 	}
 
 	containerImage, ok := configMap.Data[configMapKey]
 
 	if !ok {
-		return "", fmt.Errorf("configmap %s does not contain necessary keys", configMapName)
+		return "", fmt.Errorf("configmap %s on namespace %s does not contain necessary keys", configMapName, namespace)
 	}
 	return containerImage, nil
 }

--- a/controllers/gorch/deployment.go
+++ b/controllers/gorch/deployment.go
@@ -37,23 +37,26 @@ type DeploymentConfig struct {
 func (r *GuardrailsOrchestratorReconciler) createDeployment(ctx context.Context, orchestrator *gorchv1alpha1.GuardrailsOrchestrator) *appsv1.Deployment {
 	var containerImages ContainerImages
 	// Get orchestrator image
+	orchestratorConfigMapName := orchestrator.Name + "-config"
 	orchestratorImage, err := r.getImageFromConfigMap(ctx, orchestratorImageKey, constants.ConfigMap, r.Namespace)
 	if orchestratorImage == "" || err != nil {
 		log.FromContext(ctx).Error(err, "Error getting container image from ConfigMap.")
 	}
 	containerImages.OrchestratorImage = orchestratorImage
-
+	log.FromContext(ctx).Info("using orchestratorImage " + orchestratorImage + "from config map " + r.Namespace + ":" + constants.ConfigMap)
 	// Check if the vLLM gateway is enabled
 	if orchestrator.Spec.VLLMGatewayConfig != nil {
 		//  Get the gateway and regex detector container images
-		vllmGatewayImage, err := r.getImageFromConfigMap(ctx, vllmGatewayImageKey, orchestratorName+"-config", orchestrator.Namespace)
+		vllmGatewayImage, err := r.getImageFromConfigMap(ctx, vllmGatewayImageKey, orchestratorConfigMapName, orchestrator.Namespace)
 		if vllmGatewayImage == "" || err != nil {
 			log.FromContext(ctx).Error(err, "Error getting vLLM gateway image from ConfigMap.")
 		}
-		regexDetectorImage, err := r.getImageFromConfigMap(ctx, regexDetectorImageKey, orchestratorName+"-config", orchestrator.Namespace)
+		log.FromContext(ctx).Info("using vLLM gateway image " + vllmGatewayImage + "from config map " + orchestrator.Namespace + ":" + orchestratorConfigMapName)
+		regexDetectorImage, err := r.getImageFromConfigMap(ctx, regexDetectorImageKey, orchestratorConfigMapName, orchestrator.Namespace)
 		if regexDetectorImage == "" || err != nil {
 			log.FromContext(ctx).Error(err, "Error getting regex detectors image from ConfigMap.")
 		}
+		log.FromContext(ctx).Info("using regex detectors image " + regexDetectorImage + "from config map " + orchestrator.Namespace + ":" + orchestratorConfigMapName)
 		containerImages.GatewayImage = vllmGatewayImage
 		containerImages.RegexDetectorImage = regexDetectorImage
 	}


### PR DESCRIPTION
Refer to [RHOAIENG-20116](https://issues.redhat.com/browse/RHOAIENG-20116).

Orchestrator's image configuration is now correctly retrieved from a ConfigMap in the user namespace called `${orch-name}-config`.