### PR TITLE
fix: Use final Kustomize deployment name for operator image

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -33,6 +33,6 @@ replacements:
       - select:
           group: apps
           kind: Deployment
-          name: controller-manager
+          name: trustyai-service-operator-controller-manager
         fieldPaths:
           - spec.template.spec.containers.0.image


### PR DESCRIPTION
Kustomize is not replacing the operator's deployment image (as specified in `params.env`) correctly, since the final Kustomize name was not being used.

Refer to: [RHOAIENG-21663](https://issues.redhat.com/browse/RHOAIENG-21663)