### PR TITLE
RHOAIENG-23547: Decouple vllm-gateway and regex detector

### DIFF
--- a/api/gorch/v1alpha1/guardrailsorchestrator_types.go
+++ b/api/gorch/v1alpha1/guardrailsorchestrator_types.go
@@ -34,9 +34,15 @@ type GuardrailsOrchestratorSpec struct {
 	Replicas int32 `json:"replicas"`
 	// Name of configmap containing generator,detector,and chunker arguments
 	OrchestratorConfig *string `json:"orchestratorConfig"`
-	//  Name of the configmap containg vLLM gateway arguments
+	// Boolean flag to enable/disable built-in detectors
 	// +optional
-	VLLMGatewayConfig *string `json:"vllmGatewayConfig,omitempty"`
+	EnableBuiltInDetectors bool `json:"enableBuiltInDetectors,omitempty"`
+	// Boolean flag to enable/disable the guardrails sidecar gateway
+	// +optional
+	EnableGuardrailsGateway bool `json:"enableGuardrailsGateway,omitempty"`
+	//  Name of the configmap containing guadrails sidecar gateway arguments
+	// +optional
+	SidecarGatewayConfig *string `json:"guardrailsGatewayConfig,omitempty"`
 	// List of orchestrator enviroment variables for configuring the OTLP exporter
 	// +optional
 	OtelExporter OtelExporter `json:"otelExporter,omitempty"`

--- a/api/gorch/v1alpha1/zz_generated.deepcopy.go
+++ b/api/gorch/v1alpha1/zz_generated.deepcopy.go
@@ -107,8 +107,8 @@ func (in *GuardrailsOrchestratorSpec) DeepCopyInto(out *GuardrailsOrchestratorSp
 		*out = new(string)
 		**out = **in
 	}
-	if in.VLLMGatewayConfig != nil {
-		in, out := &in.VLLMGatewayConfig, &out.VLLMGatewayConfig
+	if in.SidecarGatewayConfig != nil {
+		in, out := &in.SidecarGatewayConfig, &out.SidecarGatewayConfig
 		*out = new(string)
 		**out = **in
 	}

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -12,3 +12,5 @@ lmes-detect-device=true
 lmes-allow-online=true
 lmes-allow-code-execution=true
 guardrails-orchestrator-image=quay.io/trustyai/ta-guardrails-orchestrator:latest
+guardrails-built-in-detector-image=quay.io/trustyai/regex-detector:latest
+guardrails-sidecar-gateway-image=quay.io/trustyai/vllm-orchestrator-gateway:latest

--- a/config/crd/bases/trustyai.opendatahub.io_guardrailsorchestrators.yaml
+++ b/config/crd/bases/trustyai.opendatahub.io_guardrailsorchestrators.yaml
@@ -40,6 +40,17 @@ spec:
           spec:
             description: GuardrailsOrchestratorSpec defines the desired state of GuardrailsOrchestrator.
             properties:
+              enableBuiltInDetectors:
+                description: Boolean flag to enable/disable built-in detectors
+                type: boolean
+              enableGuardrailsGateway:
+                description: Boolean flag to enable/disable the guardrails sidecar
+                  gateway
+                type: boolean
+              guardrailsGatewayConfig:
+                description: ' Name of the configmap containing guadrails sidecar
+                  gateway arguments'
+                type: string
               orchestratorConfig:
                 description: Name of configmap containing generator,detector,and chunker
                   arguments
@@ -74,9 +85,6 @@ spec:
                 description: Number of replicas
                 format: int32
                 type: integer
-              vllmGatewayConfig:
-                description: ' Name of the configmap containg vLLM gateway arguments'
-                type: string
             required:
             - orchestratorConfig
             - replicas

--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -12,3 +12,5 @@ lmes-detect-device=true
 lmes-allow-online=true
 lmes-allow-code-execution=true
 guardrails-orchestrator-image=quay.io/trustyai/ta-guardrails-orchestrator:latest
+guardrails-built-in-detector-image=quay.io/trustyai/regex-detector:latest
+guardrails-sidecar-gateway-image=quay.io/trustyai/vllm-orchestrator-gateway:latest

--- a/config/overlays/rhoai/params.env
+++ b/config/overlays/rhoai/params.env
@@ -12,3 +12,5 @@ lmes-detect-device=true
 lmes-allow-online=false
 lmes-allow-code-execution=false
 guardrails-orchestrator-image=quay.io/trustyai/ta-guardrails-orchestrator:latest
+guardrails-built-in-detector-image=quay.io/trustyai/regex-detector:latest
+guardrails-sidecar-gateway-image=quay.io/trustyai/vllm-orchestrator-gateway:latest

--- a/controllers/gorch/constants.go
+++ b/controllers/gorch/constants.go
@@ -1,11 +1,11 @@
 package gorch
 
 const (
-	orchestratorName      = "guardrails-orchestrator"
-	finalizerName         = "trustyai.opendatahub.io/gorch-finalizer"
-	configMapName         = "gorch-config"
-	orchestratorImageKey  = "guardrails-orchestrator-image"
-	vllmGatewayImageKey   = "vllmGatewayImage"
-	regexDetectorImageKey = "regexDetectorImage"
-	ServiceName           = "GORCH"
+	orchestratorName     = "guardrails-orchestrator"
+	finalizerName        = "trustyai.opendatahub.io/gorch-finalizer"
+	configMapName        = "gorch-config"
+	orchestratorImageKey = "guardrails-orchestrator-image"
+	gatewayImageKey      = "guardrails-sidecar-gateway-image"
+	detectorImageKey     = "guardrails-built-in-detector-image"
+	ServiceName          = "GORCH"
 )

--- a/controllers/gorch/templates/deployment.tmpl.yaml
+++ b/controllers/gorch/templates/deployment.tmpl.yaml
@@ -39,10 +39,10 @@ spec:
           configMap:
             name: {{.Orchestrator.Spec.OrchestratorConfig}}
             defaultMode: 420
-        {{if .Orchestrator.Spec.VLLMGatewayConfig}}
-        - name: {{.Orchestrator.Name}}-vllm-config
+        {{if .Orchestrator.Spec.SidecarGatewayConfig}}
+        - name: {{.Orchestrator.Name}}-sidecar-gateway-config
           configMap:
-            name: {{.Orchestrator.Spec.VLLMGatewayConfig}}
+            name: {{.Orchestrator.Spec.SidecarGatewayConfig}}
             defaultMode: 420
         {{end}}
       serviceAccountName: {{.Orchestrator.Name}}-serviceaccount
@@ -52,7 +52,7 @@ spec:
           env:
             - name: ORCHESTRATOR_CONFIG
               value: /config/config.yaml
-            {{if .Orchestrator.Spec.VLLMGatewayConfig}}
+            {{if .Orchestrator.Spec.SidecarGatewayConfig}}
             - name: HTTP_PORT
               value: '8032'
             {{else}}
@@ -97,7 +97,7 @@ spec:
               mountPath: /config/config.yaml
               subPath: config.yaml
           ports:
-            {{if .Orchestrator.Spec.VLLMGatewayConfig}}
+            {{if .Orchestrator.Spec.SidecarGatewayConfig}}
             - name: http
               containerPort: 8032
               protocol: TCP
@@ -138,19 +138,21 @@ spec:
             terminationMessagePath: /dev/termination-log
             command:
               - /app/bin/fms-guardrails-orchestr8
-        {{if .Orchestrator.Spec.VLLMGatewayConfig}}
+        {{if .Orchestrator.Spec.EnableGuardrailsGateway}}
         - name: {{.Orchestrator.Name}}-gateway
-          image : {{.ContainerImages.GatewayImage}}
+          image : {{.ContainerImages.GuardrailsGatewayImage}}
           command: ["/app/bin/vllm-orchestrator-gateway"]
           volumeMounts:
-            - name: {{.Orchestrator.Name}}-vllm-config
+            - name: {{.Orchestrator.Name}}-sidecar-gateway-config
               readOnly: true
               mountPath: /config/config.yaml
               subPath: config.yaml
           env:
             - name: GATEWAY_CONFIG
               value: /config/config.yaml
+        {{end}}
+        {{if .Orchestrator.Spec.EnableBuiltInDetectors}}
         - name: {{.Orchestrator.Name}}-detectors
-          image : {{.ContainerImages.RegexDetectorImage}}
+          image : {{.ContainerImages.DetectorImage}}
           command: ["/app/bin/regex-detector"]
         {{end}}

--- a/controllers/gorch/templates/service.tmpl.yaml
+++ b/controllers/gorch/templates/service.tmpl.yaml
@@ -10,7 +10,7 @@ spec:
   ipFamilies:
     - IPv4
   ports:
-    {{if .Orchestrator.Spec.VLLMGatewayConfig}}
+    {{if .Orchestrator.Spec.SidecarGatewayConfig}}
     - name: http
       protocol: TCP
       port: 8032


### PR DESCRIPTION
This PR addresses [RHOAIENG-23547](https://issues.redhat.com/browse/RHOAIENG-23547) by making the following changes:

* Adds two new boolean flags to the GORCH CR to enable the regex detectors and vLLM gateway sidecars separately: `regexDetectors` and `vllmGateway`
* Adds the regex detectors and vLLM gateway image tags to `params.env`
* Reads the image references to both from the `trustyai-service-config` configmap
* Updates tests to reflect changes