### PR TITLE
CI: Only generate comments for PRs

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -143,12 +143,14 @@ jobs:
       - uses: peter-evans/find-comment@v3
         name: Find Comment
         id: fc
+        if: env.BUILD_CONTEXT == 'ci'
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
           body-includes: PR image build and manifest generation completed successfully
       - uses: peter-evans/create-or-update-comment@v4
         name: Generate/update success message comment
+        if: env.BUILD_CONTEXT == 'ci'
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add conditional checks to limit comment generation to CI build context