### PR TITLE
fix: Correct sidecar gateway image name

### DIFF
--- a/config/overlays/rhoai/params.env
+++ b/config/overlays/rhoai/params.env
@@ -13,4 +13,4 @@ lmes-allow-online=false
 lmes-allow-code-execution=false
 guardrails-orchestrator-image=quay.io/trustyai/ta-guardrails-orchestrator:latest
 guardrails-built-in-detector-image=quay.io/trustyai/regex-detector:latest
-guardrails-sidecar-gateway-image=quay.io/trustyai/vllm-orchestrator-gateway:latest
+guardrails-sidecar-gateway-image=quay.io/trustyai/guardrails-sidecar-gateway:latest


### PR DESCRIPTION
Correct sidecar gateway image name

## Summary by Sourcery

Deployment:
- Corrected the sidecar gateway image name in the environment parameters