### PR TITLE
chore: enable cgo in driver

### DIFF
--- a/Dockerfile.driver
+++ b/Dockerfile.driver
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.23 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.23 AS builder
 
 WORKDIR /go/src/github.com/trustyai-explainability/trustyai-service-operator
 # Copy the Go Modules manifests
@@ -18,7 +18,7 @@ COPY LICENSE /licenses/ta-lmes-driver.md
 RUN GO111MODULE=on CGO_ENABLED=1 GOOS=linux GOEXPERIMENT=strictfipsruntime \
     go build -tags 'strictfipsruntime netgo' -o /bin/driver ./cmd/lmes_driver/*.go
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 COPY --from=builder /bin/driver /bin/driver
 

--- a/Dockerfile.driver
+++ b/Dockerfile.driver
@@ -15,7 +15,8 @@ COPY controllers/ controllers/
 # Copy license
 COPY LICENSE /licenses/ta-lmes-driver.md
 
-RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux go build -tags netgo -ldflags '-extldflags "-static"' -o /bin/driver ./cmd/lmes_driver/*.go
+RUN GO111MODULE=on CGO_ENABLED=1 GOOS=linux GOEXPERIMENT=strictfipsruntime \
+    go build -tags 'strictfipsruntime netgo' -o /bin/driver ./cmd/lmes_driver/*.go
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 


### PR DESCRIPTION
## Summary by Sourcery

Enable cgo support in the Docker driver image so that the konflux image builds will pass the check-payload tool.

Enhancements:
- Install necessary system dependencies for cgo in the Docker driver image
- Set CGO_ENABLED environment variable to true in the Docker build