### PR TITLE
fix: Correct gateway port to 8090

### DIFF
--- a/controllers/gorch/guardrailsorchestrator_controller_test.go
+++ b/controllers/gorch/guardrailsorchestrator_controller_test.go
@@ -182,6 +182,8 @@ func testCreateDeleteGuardrailsOrchestrator(namespaceName string) {
 				return err
 			}
 			Expect(service.Namespace).Should(Equal(namespaceName))
+			Expect((service.Spec.Ports[0].Name)).Should(Equal("http"))
+			Expect((service.Spec.Ports[0].Port)).Should(Equal(int32(8033)))
 
 			route := &routev1.Route{}
 			if err := routev1.AddToScheme(scheme.Scheme); err != nil {
@@ -283,6 +285,8 @@ func testCreateDeleteGuardrailsOrchestratorSidecar(namespaceName string) {
 				return err
 			}
 			Expect(service.Namespace).Should(Equal(namespaceName))
+			Expect(service.Spec.Ports[0].Name).Should(Equal("http"))
+			Expect(service.Spec.Ports[0].Port).Should(Equal(int32(8090)))
 
 			route := &routev1.Route{}
 			if err := routev1.AddToScheme(scheme.Scheme); err != nil {

--- a/controllers/gorch/templates/service.tmpl.yaml
+++ b/controllers/gorch/templates/service.tmpl.yaml
@@ -10,11 +10,11 @@ spec:
   ipFamilies:
     - IPv4
   ports:
-    {{if .Orchestrator.Spec.SidecarGatewayConfig}}
+    {{if .Orchestrator.Spec.EnableGuardrailsGateway}}
     - name: http
       protocol: TCP
-      port: 8032
-      targetPort: 8032
+      port: 8090
+      targetPort: 8090
     {{else}}
     - name: http
       protocol: TCP


### PR DESCRIPTION
Address issue #470 by correcting the gateway port to 8090 when enableGuardrailsGateway is set to `True` in the CR.

## Summary by Sourcery

Correct the guardrails gateway configuration by using the appropriate flag and setting the service port to 8090, and update tests to verify the new behavior

Bug Fixes:
- Fix the guardrails gateway service port to 8090 when guardrails gateway is enabled

Enhancements:
- Switch the conditional flag from SidecarGatewayConfig to EnableGuardrailsGateway in the service template

Tests:
- Add assertions for HTTP port in orchestrator tests and update expected port to 8090 for the sidecar gateway