### PR TITLE
fix: rename external guardrails route

### DIFF
--- a/controllers/gorch/guardrailsorchestrator_controller.go
+++ b/controllers/gorch/guardrailsorchestrator_controller.go
@@ -196,10 +196,10 @@ func (r *GuardrailsOrchestratorReconciler) Reconcile(ctx context.Context, req ct
 	}
 
 	existingRoute := &routev1.Route{}
-	err = r.Get(ctx, types.NamespacedName{Name: orchestrator.Name + "-http", Namespace: orchestrator.Namespace}, existingRoute)
+	err = r.Get(ctx, types.NamespacedName{Name: orchestrator.Name, Namespace: orchestrator.Namespace}, existingRoute)
 	if err != nil && errors.IsNotFound(err) {
 		// Define a new route
-		httpRoute := r.createRoute(ctx, "http-route.tmpl.yaml", orchestrator)
+		httpRoute := r.createRoute(ctx, "https-route.tmpl.yaml", orchestrator)
 		log.Info("Creating a new Route", "Route.Namespace", httpRoute.Namespace, "Route.Name", httpRoute.Name)
 		err = r.Create(ctx, httpRoute)
 		if err != nil {

--- a/controllers/gorch/guardrailsorchestrator_controller_test.go
+++ b/controllers/gorch/guardrailsorchestrator_controller_test.go
@@ -189,7 +189,7 @@ func testCreateDeleteGuardrailsOrchestrator(namespaceName string) {
 			if err := routev1.AddToScheme(scheme.Scheme); err != nil {
 				return err
 			}
-			if err := k8sClient.Get(ctx, types.NamespacedName{Name: orchestratorName + "-http", Namespace: namespaceName}, route); err != nil {
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: orchestratorName, Namespace: namespaceName}, route); err != nil {
 				return err
 			}
 			if err := k8sClient.Get(ctx, types.NamespacedName{Name: orchestratorName + "-health", Namespace: namespaceName}, route); err != nil {
@@ -292,7 +292,7 @@ func testCreateDeleteGuardrailsOrchestratorSidecar(namespaceName string) {
 			if err := routev1.AddToScheme(scheme.Scheme); err != nil {
 				return err
 			}
-			if err := k8sClient.Get(ctx, types.NamespacedName{Name: orchestratorName + "-http", Namespace: namespaceName}, route); err != nil {
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: orchestratorName, Namespace: namespaceName}, route); err != nil {
 				return err
 			}
 			if err := k8sClient.Get(ctx, types.NamespacedName{Name: orchestratorName + "-health", Namespace: namespaceName}, route); err != nil {
@@ -390,7 +390,7 @@ func testCreateDeleteGuardrailsOrchestratorOtelExporter(namespaceName string) {
 			if err := routev1.AddToScheme(scheme.Scheme); err != nil {
 				return err
 			}
-			if err := k8sClient.Get(ctx, types.NamespacedName{Name: orchestratorName + "-http", Namespace: namespaceName}, route); err != nil {
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: orchestratorName, Namespace: namespaceName}, route); err != nil {
 				return err
 			}
 			if err := k8sClient.Get(ctx, types.NamespacedName{Name: orchestratorName + "-health", Namespace: namespaceName}, route); err != nil {
@@ -531,7 +531,7 @@ func testCreateTwoGuardrailsOrchestratorsInSameNamespace(namespaceName string) {
 
 		Eventually(func() error {
 			route1 := &routev1.Route{}
-			if err := k8sClient.Get(ctx, types.NamespacedName{Name: firstOrchestratorName + "-http", Namespace: namespaceName}, route1); err != nil {
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: firstOrchestratorName, Namespace: namespaceName}, route1); err != nil {
 				return err
 			}
 			if err := k8sClient.Get(ctx, types.NamespacedName{Name: firstOrchestratorName + "-health", Namespace: namespaceName}, route1); err != nil {
@@ -539,7 +539,7 @@ func testCreateTwoGuardrailsOrchestratorsInSameNamespace(namespaceName string) {
 			}
 
 			route2 := &routev1.Route{}
-			if err := k8sClient.Get(ctx, types.NamespacedName{Name: secondOrchestratorName + "-http", Namespace: namespaceName}, route2); err != nil {
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: secondOrchestratorName, Namespace: namespaceName}, route2); err != nil {
 				return err
 			}
 			if err := k8sClient.Get(ctx, types.NamespacedName{Name: secondOrchestratorName + "-health", Namespace: namespaceName}, route2); err != nil {

--- a/controllers/gorch/route.go
+++ b/controllers/gorch/route.go
@@ -22,11 +22,11 @@ type RouteConfig struct {
 }
 
 func (r *GuardrailsOrchestratorReconciler) createRoute(ctx context.Context, routeTemplatePath string, orchestrator *gorchv1alpha1.GuardrailsOrchestrator) *routev1.Route {
-	routeHttpConfig := RouteConfig{
+	routeHttpsConfig := RouteConfig{
 		Orchestrator: orchestrator,
 	}
 	var route *routev1.Route
-	route, err := templateParser.ParseResource[routev1.Route](routeTemplatePath, routeHttpConfig, reflect.TypeOf(&routev1.Route{}))
+	route, err := templateParser.ParseResource[routev1.Route](routeTemplatePath, routeHttpsConfig, reflect.TypeOf(&routev1.Route{}))
 
 	if err != nil {
 		log.FromContext(ctx).Error(err, "Failed to parse route template")

--- a/controllers/gorch/templates/https-route.tmpl.yaml
+++ b/controllers/gorch/templates/https-route.tmpl.yaml
@@ -1,7 +1,7 @@
 kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
-  name: {{.Orchestrator.Name}}-http
+  name: {{.Orchestrator.Name}}
   namespace: {{.Orchestrator.Namespace}}
   labels:
     app: {{.Orchestrator.Name}}


### PR DESCRIPTION
Renames the external guardrails route from `<GORCH_NAME>-http` to `<GORCH_NAME>`

## Summary by Sourcery

Remove the outdated "-http" suffix from the external guardrails Route across the controller, templates, and tests to ensure consistent naming.

Bug Fixes:
- Stop appending the "-http" suffix when fetching or creating the guardrails route in the reconciler.

Enhancements:
- Rename the HTTP route template to `https-route.tmpl.yaml` and update `createRoute` to use it.

Tests:
- Adjust controller tests to expect the route name without the "-http" suffix.