### PR TITLE
fix: cgo permission denied on LMEval driver

### DIFF
--- a/Dockerfile.driver
+++ b/Dockerfile.driver
@@ -15,6 +15,7 @@ COPY controllers/ controllers/
 # Copy license
 COPY LICENSE /licenses/ta-lmes-driver.md
 
+USER root
 RUN GO111MODULE=on CGO_ENABLED=1 GOOS=linux GOEXPERIMENT=strictfipsruntime \
     go build -tags 'strictfipsruntime netgo' -o /bin/driver ./cmd/lmes_driver/*.go
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix CGO permission denied error in LMEval driver Docker image by updating file permissions in Dockerfile