### PR TITLE
RHOAIENG-26004: Add system instruction and chat template support to lmes

### DIFF
--- a/api/lmes/v1alpha1/lmevaljob_types.go
+++ b/api/lmes/v1alpha1/lmevaljob_types.go
@@ -531,6 +531,13 @@ type LMEvalJobSpec struct {
 	// +optional
 	// +kubebuilder:default:=false
 	AllowCodeExecution *bool `json:"allowCodeExecution,omitempty"`
+	// SystemInstruction will set the system instruction for all prompts passed to the evaluated model
+	// +optional
+	SystemInstruction string `json:"systemInstruction,omitempty"`
+	// ApplyChatTemplate will apply the specified chat template to prompts. This is required for chat-completions models.
+	// +optional
+	// +kubebuilder:default:=false
+	ApplyChatTemplate string `json:"applyChatTemplate,omitempty"`
 }
 
 // IsOffline returns whether this LMEvalJob is configured to run offline

--- a/api/lmes/v1alpha1/lmevaljob_types.go
+++ b/api/lmes/v1alpha1/lmevaljob_types.go
@@ -536,7 +536,6 @@ type LMEvalJobSpec struct {
 	SystemInstruction string `json:"systemInstruction,omitempty"`
 	// ApplyChatTemplate will apply the specified chat template to prompts. This is required for chat-completions models.
 	// +optional
-	// +kubebuilder:default:=false
 	ApplyChatTemplate string `json:"applyChatTemplate,omitempty"`
 }
 

--- a/config/crd/bases/trustyai.opendatahub.io_lmevaljobs.yaml
+++ b/config/crd/bases/trustyai.opendatahub.io_lmevaljobs.yaml
@@ -53,6 +53,10 @@ spec:
                 description: AllowOnly specifies whether the LMEvalJob can directly
                   download remote code, datasets and metrics. Default is false.
                 type: boolean
+              applyChatTemplate:
+                description: ApplyChatTemplate will apply the specified chat template
+                  to prompts. This is required for chat-completions models.
+                type: string
               batchSize:
                 description: |-
                   Batch size for the evaluation. This is used by the models that run and are loaded
@@ -4718,6 +4722,10 @@ spec:
                 description: Suspend keeps the job but without pods. This is intended
                   to be used by the Kueue integration
                 type: boolean
+              systemInstruction:
+                description: SystemInstruction will set the system instruction for
+                  all prompts passed to the evaluated model
+                type: string
               taskList:
                 description: Evaluation task list
                 properties:

--- a/controllers/lmes/lmevaljob_controller.go
+++ b/controllers/lmes/lmevaljob_controller.go
@@ -1256,7 +1256,24 @@ func generateArgs(svcOpts *serviceOptions, job *lmesv1alpha1.LMEvalJob, log logr
 		batchSize = validateBatchSize(*job.Spec.BatchSize, svcOpts.MaxBatchSize, log)
 	}
 
-	cmd.WriteString("--batch_size " + batchSize)
+	cmd.WriteString("--batch_size " + batchSize + " ")
+
+	// --system_instruction
+	if job.Spec.SystemInstruction != "" {
+		cmd.WriteString("--system_instruction " + job.Spec.SystemInstruction + " ")
+	}
+
+	// --apply_chat_template
+	// check for the default string value of "false"
+	if job.Spec.ApplyChatTemplate != "" {
+		if job.Spec.ApplyChatTemplate == "false" {
+
+		} else if job.Spec.ApplyChatTemplate == "true" {
+			cmd.WriteString("--apply_chat_template")
+		} else {
+			cmd.WriteString("--apply_chat_template " + job.Spec.ApplyChatTemplate)
+		}
+	}
 
 	return []string{"sh", "-ec", cmd.String()}
 }

--- a/controllers/lmes/lmevaljob_controller.go
+++ b/controllers/lmes/lmevaljob_controller.go
@@ -1260,7 +1260,7 @@ func generateArgs(svcOpts *serviceOptions, job *lmesv1alpha1.LMEvalJob, log logr
 
 	// --system_instruction
 	if job.Spec.SystemInstruction != "" {
-		cmd.WriteString("--system_instruction " + job.Spec.SystemInstruction + " ")
+		cmd.WriteString("--system_instruction \"" + job.Spec.SystemInstruction + "\" ")
 	}
 
 	// --apply_chat_template

--- a/controllers/lmes/lmevaljob_controller_test.go
+++ b/controllers/lmes/lmevaljob_controller_test.go
@@ -176,8 +176,8 @@ func Test_SimplePod(t *testing.T) {
 			Volumes: []corev1.Volume{
 				{
 					Name: "shared", VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{},
-					},
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
 				},
 			},
 			RestartPolicy: corev1.RestartPolicyNever,
@@ -411,8 +411,8 @@ func Test_WithCustomPod(t *testing.T) {
 			Volumes: []corev1.Volume{
 				{
 					Name: "shared", VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{},
-					},
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
 				},
 				{
 					Name: "additionalVolume",
@@ -624,8 +624,8 @@ func Test_EnvSecretsPod(t *testing.T) {
 			Volumes: []corev1.Volume{
 				{
 					Name: "shared", VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{},
-					},
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
 				},
 			},
 			RestartPolicy: corev1.RestartPolicyNever,
@@ -801,8 +801,8 @@ func Test_FileSecretsPod(t *testing.T) {
 			Volumes: []corev1.Volume{
 				{
 					Name: "shared", VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{},
-					},
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
 				},
 				{
 					Name: "secVol1",
@@ -979,7 +979,14 @@ func Test_SystemInstruction(t *testing.T) {
 	job.Spec.SystemInstruction = "something"
 	assert.Equal(t, []string{
 		"sh", "-ec",
-		"python -m lm_eval --output_path /opt/app-root/src/output --model test --model_args arg1=value1 --tasks task1,task2 --include_path /opt/app-root/src/my_tasks --batch_size " + svcOpts.DefaultBatchSize + " --system_instruction something ",
+		"python -m lm_eval --output_path /opt/app-root/src/output --model test --model_args arg1=value1 --tasks task1,task2 --include_path /opt/app-root/src/my_tasks --batch_size " + svcOpts.DefaultBatchSize + " --system_instruction \"something\" ",
+	}, generateArgs(svcOpts, job, log))
+
+	// system instruction == something with spaces
+	job.Spec.SystemInstruction = "something with spaces"
+	assert.Equal(t, []string{
+		"sh", "-ec",
+		"python -m lm_eval --output_path /opt/app-root/src/output --model test --model_args arg1=value1 --tasks task1,task2 --include_path /opt/app-root/src/my_tasks --batch_size " + svcOpts.DefaultBatchSize + " --system_instruction \"something with spaces\" ",
 	}, generateArgs(svcOpts, job, log))
 }
 
@@ -1753,16 +1760,16 @@ func Test_ManagedPVC(t *testing.T) {
 			Volumes: []corev1.Volume{
 				{
 					Name: "shared", VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{},
-					},
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
 				},
 				{
 					Name: "outputs", VolumeSource: corev1.VolumeSource{
-						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-							ClaimName: jobName + "-pvc",
-							ReadOnly:  false,
-						},
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: jobName + "-pvc",
+						ReadOnly:  false,
 					},
+				},
 				},
 			},
 			RestartPolicy: corev1.RestartPolicyNever,
@@ -1916,16 +1923,16 @@ func Test_ExistingPVC(t *testing.T) {
 			Volumes: []corev1.Volume{
 				{
 					Name: "shared", VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{},
-					},
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
 				},
 				{
 					Name: "outputs", VolumeSource: corev1.VolumeSource{
-						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-							ClaimName: pvcName,
-							ReadOnly:  false,
-						},
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: pvcName,
+						ReadOnly:  false,
 					},
+				},
 				},
 			},
 			RestartPolicy: corev1.RestartPolicyNever,
@@ -2102,16 +2109,16 @@ func Test_PVCPreference(t *testing.T) {
 			Volumes: []corev1.Volume{
 				{
 					Name: "shared", VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{},
-					},
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
 				},
 				{
 					Name: "outputs", VolumeSource: corev1.VolumeSource{
-						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-							ClaimName: jobName + "-pvc",
-							ReadOnly:  false,
-						},
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: jobName + "-pvc",
+						ReadOnly:  false,
 					},
+				},
 				},
 			},
 			RestartPolicy: corev1.RestartPolicyNever,
@@ -2314,16 +2321,16 @@ func Test_OfflineMode(t *testing.T) {
 			Volumes: []corev1.Volume{
 				{
 					Name: "shared", VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{},
-					},
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
 				},
 				{
 					Name: "offline", VolumeSource: corev1.VolumeSource{
-						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-							ClaimName: pvcName,
-							ReadOnly:  false,
-						},
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: pvcName,
+						ReadOnly:  false,
 					},
+				},
 				},
 			},
 			RestartPolicy: corev1.RestartPolicyNever,
@@ -2527,16 +2534,16 @@ func Test_ProtectedVars(t *testing.T) {
 			Volumes: []corev1.Volume{
 				{
 					Name: "shared", VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{},
-					},
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
 				},
 				{
 					Name: "offline", VolumeSource: corev1.VolumeSource{
-						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-							ClaimName: pvcName,
-							ReadOnly:  false,
-						},
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: pvcName,
+						ReadOnly:  false,
 					},
+				},
 				},
 			},
 			RestartPolicy: corev1.RestartPolicyNever,
@@ -2719,16 +2726,16 @@ func Test_OnlineModeDisabled(t *testing.T) {
 			Volumes: []corev1.Volume{
 				{
 					Name: "shared", VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{},
-					},
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
 				},
 				{
 					Name: "offline", VolumeSource: corev1.VolumeSource{
-						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-							ClaimName: pvcName,
-							ReadOnly:  false,
-						},
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: pvcName,
+						ReadOnly:  false,
 					},
+				},
 				},
 			},
 			RestartPolicy: corev1.RestartPolicyNever,
@@ -2887,16 +2894,16 @@ func Test_OnlineMode(t *testing.T) {
 			Volumes: []corev1.Volume{
 				{
 					Name: "shared", VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{},
-					},
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
 				},
 				{
 					Name: "offline", VolumeSource: corev1.VolumeSource{
-						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-							ClaimName: pvcName,
-							ReadOnly:  false,
-						},
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: pvcName,
+						ReadOnly:  false,
 					},
+				},
 				},
 			},
 			RestartPolicy: corev1.RestartPolicyNever,
@@ -3058,16 +3065,16 @@ func Test_AllowCodeOnlineMode(t *testing.T) {
 			Volumes: []corev1.Volume{
 				{
 					Name: "shared", VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{},
-					},
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
 				},
 				{
 					Name: "offline", VolumeSource: corev1.VolumeSource{
-						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-							ClaimName: pvcName,
-							ReadOnly:  false,
-						},
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: pvcName,
+						ReadOnly:  false,
 					},
+				},
 				},
 			},
 			RestartPolicy: corev1.RestartPolicyNever,
@@ -3247,16 +3254,16 @@ func Test_AllowCodeOfflineMode(t *testing.T) {
 			Volumes: []corev1.Volume{
 				{
 					Name: "shared", VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{},
-					},
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
 				},
 				{
 					Name: "offline", VolumeSource: corev1.VolumeSource{
-						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-							ClaimName: pvcName,
-							ReadOnly:  false,
-						},
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: pvcName,
+						ReadOnly:  false,
 					},
+				},
 				},
 			},
 			RestartPolicy: corev1.RestartPolicyNever,
@@ -3440,24 +3447,24 @@ func Test_OfflineModeWithOutput(t *testing.T) {
 			Volumes: []corev1.Volume{
 				{
 					Name: "shared", VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{},
-					},
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
 				},
 				{
 					Name: "outputs", VolumeSource: corev1.VolumeSource{
-						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-							ClaimName: outputPvcName,
-							ReadOnly:  false,
-						},
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: outputPvcName,
+						ReadOnly:  false,
 					},
+				},
 				},
 				{
 					Name: "offline", VolumeSource: corev1.VolumeSource{
-						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-							ClaimName: offlinePvcName,
-							ReadOnly:  false,
-						},
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: offlinePvcName,
+						ReadOnly:  false,
 					},
+				},
 				},
 			},
 			RestartPolicy: corev1.RestartPolicyNever,


### PR DESCRIPTION
Adds:

* `systemInstruction: string`
* `applyChatTemplate: string` 

args to the CR, corresponding to the lm-evaluation-harness CLI args `--system_instruction` and `--apply_chat_template`

## Summary by Sourcery

Add support for `systemInstruction` and `applyChatTemplate` fields in LMEvalJob specs, update the argument builder to include the corresponding `--system_instruction` and `--apply_chat_template` flags, and expand tests to cover their behavior.

New Features:
- Introduce `SystemInstruction` field to LMEvalJob spec to pass the `--system_instruction` flag.
- Introduce `ApplyChatTemplate` field to LMEvalJob spec to pass the `--apply_chat_template` flag.

Enhancements:
- Update `generateArgs` to append new flags only when set and ensure consistent spacing.
- Expand controller tests to validate chat template and system instruction flag handling.