### PR TITLE
chore: Upgrade orchestrator component to 0.9.4

### DIFF
--- a/config/component_metadata.yaml
+++ b/config/component_metadata.yaml
@@ -12,7 +12,7 @@ releases:
     version: v0.4.6
     repoUrl: https://github.com/EleutherAI/lm-evaluation-harness
   - name: TrustyAI Guardrails orchestrator
-    version: 0.9.3
+    version: 0.9.4
     repoUrl: https://github.com/foundation-model-stack/fms-guardrails-orchestrator
   - name: TrustyAI builtin detectors
     version: v0.1.0


### PR DESCRIPTION
Follow-up to https://github.com/trustyai-explainability/trustyai-service-operator/issues/449

## Summary by Sourcery

Enhancements:
- Bump orchestrator version from 0.9.3 to 0.9.4 in component_metadata.yaml