### PR TITLE
chore: Update component metadata versions

### DIFF
--- a/config/component_metadata.yaml
+++ b/config/component_metadata.yaml
@@ -1,22 +1,22 @@
 releases:
   - name: TrustyAI operator
-    version: v1.35.0
+    version: v1.37.0
     repoUrl: https://github.com/trustyai-explainability/trustyai-service-operator
   - name: TrustyAI service
     version: v0.28.0
     repoUrl: https://github.com/trustyai-explainability/trustyai-explainability
   - name: TrustyAI LMEval driver
-    version: v1.35.0
+    version: v1.37.0
     repoUrl: https://github.com/trustyai-explainability/trustyai-service-operator
   - name: TrustyAI LMEval job
-    version: v0.4.6
+    version: v0.4.8
     repoUrl: https://github.com/EleutherAI/lm-evaluation-harness
   - name: TrustyAI Guardrails orchestrator
     version: 0.9.4
     repoUrl: https://github.com/foundation-model-stack/fms-guardrails-orchestrator
   - name: TrustyAI builtin detectors
-    version: v0.1.0
+    version: v0.2.0
     repoUrl: https://github.com/trustyai-explainability/guardrails-regex-detector
   - name: TrustyAI sidecar gateway
-    version: v0.1.0
+    version: v0.2.1
     repoUrl: https://github.com/trustyai-explainability/vllm-orchestrator-gateway


### PR DESCRIPTION
## Summary by Sourcery

Update component_metadata.yaml to bump versions for various TrustyAI components to the latest releases.

Chores:
- Bump TrustyAI operator and LMEval driver to v1.37.0
- Bump TrustyAI LMEval job to v0.4.8
- Bump TrustyAI builtin detectors to v0.2.0
- Bump TrustyAI sidecar gateway to v0.2.1