### PR TITLE
chore(RHOAIENG-26969): Align orchestrator image manifest with 0.10.0

### DIFF
--- a/Dockerfile.orchestrator
+++ b/Dockerfile.orchestrator
@@ -5,7 +5,7 @@ ARG CONFIG_FILE=config/config.yaml
 ARG ORCH_REPO=/midstream
 ## Rust builder ################################################################
 # Specific debian version so that compatible glibc version is used
-FROM rust:1.85.1-bullseye AS rust-builder
+FROM rust:1.87.0 AS rust-builder
 ARG PROTOC_VERSION
 ARG ORCH_REPO=/midstream
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
@@ -18,8 +18,17 @@ RUN curl -L https://github.com/trustyai-explainability/fms-guardrails-orchestrat
 
 # Install protoc, no longer included in prost crate
 RUN cd /tmp && \
-    curl -L -O https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip && \
-    unzip protoc-*.zip -d /usr/local && rm protoc-*.zip
+    if [ "$(uname -m)" = "s390x" ]; then \
+        apt update && \
+        apt install -y cmake clang libclang-dev curl unzip && \
+        curl -L -O https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-s390_64.zip; \
+    else \
+        curl -L -O https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip; \
+    fi && \
+    unzip protoc-*.zip -d /usr/local && \
+    rm protoc-*.zip
+
+ENV LIBCLANG_PATH=/usr/lib/llvm-14/lib/
 
 WORKDIR /app
 


### PR DESCRIPTION
Align orchestrator image manifest with upstream's 0.10.0

## Summary by Sourcery

Chores:
- Update the orchestrator Dockerfile manifest to match upstream version 0.10.0