### PR TITLE
chore: Upgrade orchestrator component to 0.10.0

### DIFF
--- a/config/component_metadata.yaml
+++ b/config/component_metadata.yaml
@@ -12,7 +12,7 @@ releases:
     version: v0.4.8
     repoUrl: https://github.com/EleutherAI/lm-evaluation-harness
   - name: TrustyAI Guardrails orchestrator
-    version: 0.9.4
+    version: 0.10.0
     repoUrl: https://github.com/foundation-model-stack/fms-guardrails-orchestrator
   - name: TrustyAI builtin detectors
     version: v0.2.0


### PR DESCRIPTION
Follow-up to #487

## Summary by Sourcery

Chores:
- Bump TrustyAI Guardrails orchestrator version from 0.9.4 to 0.10.0 in component_metadata.yaml