### PR TITLE
fix: Replace guardrails sidecar gateway image

### DIFF
--- a/config/base/params.env
+++ b/config/base/params.env
@@ -13,4 +13,4 @@ lmes-allow-online=true
 lmes-allow-code-execution=true
 guardrails-orchestrator-image=quay.io/trustyai/ta-guardrails-orchestrator:latest
 guardrails-built-in-detector-image=quay.io/trustyai/regex-detector:latest
-guardrails-sidecar-gateway-image=quay.io/trustyai/vllm-orchestrator-gateway:latest
+guardrails-sidecar-gateway-image=quay.io/trustyai/guardrails-sidecar-gateway:latest

--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -13,4 +13,4 @@ lmes-allow-online=true
 lmes-allow-code-execution=true
 guardrails-orchestrator-image=quay.io/trustyai/ta-guardrails-orchestrator:latest
 guardrails-built-in-detector-image=quay.io/trustyai/regex-detector:latest
-guardrails-sidecar-gateway-image=quay.io/trustyai/vllm-orchestrator-gateway:latest
+guardrails-sidecar-gateway-image=quay.io/trustyai/guardrails-sidecar-gateway:latest


### PR DESCRIPTION
This PR corrects the Quay image reference for the Guardrails sidecar gateway from `quay.io/trustyai/vllm-orchestrator-gateway:latest` to `quay.io/trustyai/guardrails-sidecar-gateway:latest`

## Summary by Sourcery

Bug Fixes:
- Correct the Guardrails sidecar gateway image reference in environment parameter files to `quay.io/trustyai/guardrails-sidecar-gateway:latest`