### PR TITLE
fix: Remove Trivy scan from build-and-push.yaml

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -117,24 +117,6 @@ jobs:
       - name: Push Guardrails orchestrator image to Quay
         run: docker push ${{ env.ORCH_IMAGE_NAME }}:$TAG
 
-      # Run Trivy scan before cleaning up git repository
-      - name: Trivy scan
-        uses: aquasecurity/trivy-action@0.28.0
-        with:
-          scan-type: 'image'
-          image-ref: "${{ env.IMAGE_NAME }}:${{ env.TAG }}"
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          severity: 'MEDIUM,HIGH,CRITICAL'
-          exit-code: '0'
-          ignore-unfixed: false
-          vuln-type: 'os,library'
-
-      - name: Update Security tab
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: 'trivy-results.sarif'
-
       # Create CI Manifests
       - name: Set up manifests for CI
         if: env.BUILD_CONTEXT == 'ci'


### PR DESCRIPTION
## Summary by Sourcery

Remove the Trivy vulnerability scan and SARIF upload steps from the build-and-push GitHub Actions workflow.

Chores:
- Delete the Trivy scan step from build-and-push.yaml
- Remove the SARIF upload step for updating the Security tab