### PR TITLE
Feat: Add Guardrails usage metrics (depends on #513)

### DIFF
--- a/controllers/gorch/guardrailsorchestrator_controller.go
+++ b/controllers/gorch/guardrailsorchestrator_controller.go
@@ -69,6 +69,7 @@ func ControllerSetUp(mgr manager.Manager, ns, configmap string, recorder record.
 	}).SetupWithManager(mgr)
 }
 
+// createOrchestratorCreationMetrics collects and publishes metrics related to new-created Guardrails Orchestrators
 func createOrchestratorCreationMetrics(orchestrator *gorchv1alpha1.GuardrailsOrchestrator) {
 	// Update the Prometheus metrics for each task in the tasklist
 	labels := make(map[string]string)

--- a/controllers/gorch/guardrailsorchestrator_controller.go
+++ b/controllers/gorch/guardrailsorchestrator_controller.go
@@ -18,6 +18,8 @@ package gorch
 
 import (
 	"context"
+	"github.com/trustyai-explainability/trustyai-service-operator/controllers/metrics"
+	"strconv"
 	"time"
 
 	routev1 "github.com/openshift/api/route/v1"
@@ -67,6 +69,18 @@ func ControllerSetUp(mgr manager.Manager, ns, configmap string, recorder record.
 	}).SetupWithManager(mgr)
 }
 
+func createOrchestratorCreationMetrics(orchestrator *gorchv1alpha1.GuardrailsOrchestrator) {
+	// Update the Prometheus metrics for each task in the tasklist
+	labels := make(map[string]string)
+	labels["orchestrator_namespace"] = orchestrator.Namespace
+	labels["using_built_in_detectors"] = strconv.FormatBool(orchestrator.Spec.EnableBuiltInDetectors)
+	labels["using_sidecar_gateway"] = strconv.FormatBool(orchestrator.Spec.SidecarGatewayConfig != nil)
+
+	// create/update metric counter
+	counter := metrics.GetOrCreateGuardrailsOrchestratorCounter(labels)
+	counter.Inc()
+}
+
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 // TODO(user): Modify the Reconcile function to compare the state specified by
@@ -103,6 +117,8 @@ func (r *GuardrailsOrchestratorReconciler) Reconcile(ctx context.Context, req ct
 			log.Error(err, "Failed to update GuardrailsOrchestrator status during initialization")
 			return ctrl.Result{}, err
 		}
+
+		createOrchestratorCreationMetrics(orchestrator)
 	}
 
 	if !controllerutil.ContainsFinalizer(orchestrator, finalizerName) {

--- a/controllers/metrics/metrics.go
+++ b/controllers/metrics/metrics.go
@@ -39,6 +39,10 @@ func GetOrCreateEvalCounter(labels map[string]string) prometheus.Counter {
 	return getOrCreateCounter("eval", "Number of times this task has been scheduled", labels)
 }
 
+func GetOrCreateGuardrailsOrchestratorCounter(labels map[string]string) prometheus.Counter {
+	return getOrCreateCounter("guardrails_orchestrators", "Number of guardrails orchestrators that have been created", labels)
+}
+
 // GetOrCreateCounter returns a prometheus.Counter with the given name, help, and labels.
 // If a counter with that name and labels already exists, it returns the existing one.
 // Otherwise, it creates, registers, and returns a new counter.


### PR DESCRIPTION
<img width="1531" alt="Screenshot 2025-07-03 at 3 50 05 PM" src="https://github.com/user-attachments/assets/8f272a20-adba-4067-9c36-6e668d54c0a3" />

## Summary by Sourcery

Track Guardrails Orchestrator creations by publishing a new Prometheus counter with relevant labels

New Features:
- Add a Prometheus counter to record Guardrails Orchestrator creation events

Enhancements:
- Annotate orchestrator creation metrics with namespace, built-in detectors status, and sidecar gateway usage