### PR TITLE
fix: Allow task names with parentheses in LMEval Job CR

### DIFF
--- a/controllers/lmes/patterns.go
+++ b/controllers/lmes/patterns.go
@@ -19,8 +19,8 @@ var (
 	// PatternLimit allows for integers, floats, and percentage in limit values
 	PatternLimit = regexp.MustCompile(`^(\d+(\.\d+)?|\d*\.\d+)$`)
 
-	// PatternTaskName allows for alphanumeric, hyphens and underscores in task names
-	PatternTaskName = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+	// PatternTaskName allows for alphanumeric, hyphens, underscores, parentheses in task names
+	PatternTaskName = regexp.MustCompile(`^[a-zA-Z0-9._()-]+$`)
 
 	// AllowedModels allows for a subset of model types
 	AllowedModels = map[string]struct{}{

--- a/controllers/lmes/validation.go
+++ b/controllers/lmes/validation.go
@@ -343,7 +343,7 @@ func ValidateTaskName(name string) error {
 	}
 
 	if !PatternTaskName.MatchString(name) {
-		return fmt.Errorf("task name contains invalid characters (only alphanumeric, ., _, - allowed)")
+		return fmt.Errorf("task name contains invalid characters (only alphanumeric, ., _, -, () allowed)")
 	}
 
 	return nil


### PR DESCRIPTION
Updates the `PatternTaskName` to allow for task names with parentheses.

## Summary by Sourcery

Bug Fixes:
- Extend PatternTaskName regex to permit parentheses in task names and update the validation error message accordingly