### PR TITLE
Remove istio injection from gorch

### DIFF
--- a/controllers/gorch/templates/deployment.tmpl.yaml
+++ b/controllers/gorch/templates/deployment.tmpl.yaml
@@ -3,8 +3,6 @@ apiVersion: apps/v1
 metadata:
   name: {{.Orchestrator.Name}}
   namespace: {{.Orchestrator.Namespace}}
-  annotations:
-      sidecar.istio.io/inject: "true"
   labels:
     app: {{.Orchestrator.Name}}
     component: {{.Orchestrator.Name}}


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Remove `sidecar.istio.io/inject` annotation from gorch deployment manifest