### PR TITLE
fix: Update OAuth proxy image on rhoai overlay

### DIFF
--- a/config/overlays/rhoai/params.env
+++ b/config/overlays/rhoai/params.env
@@ -1,6 +1,6 @@
 trustyaiServiceImage=quay.io/trustyai/trustyai-service:latest
 trustyaiOperatorImage=quay.io/trustyai/trustyai-service-operator:latest
-oauthProxyImage=registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4f8d66597feeb32bb18699326029f9a71a5aca4a57679d636b876377c2e95695
+oauthProxyImage=registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:4e3130766b32ec945bbccc3c08c0de66581141d8a070ca9dabb968ebad56f053
 kServeServerless=enabled
 lmes-driver-image=quay.io/trustyai/ta-lmes-driver:latest
 lmes-pod-image=quay.io/trustyai/ta-lmes-job:latest


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Bump the OAuth proxy image tag in the rhoai overlay params.env