### PR TITLE
feat: Add subject to LMEval CRD's OCI outputs

### DIFF
--- a/api/lmes/v1alpha1/lmevaljob_types.go
+++ b/api/lmes/v1alpha1/lmevaljob_types.go
@@ -481,6 +481,7 @@ type OCISpec struct {
 	// Subject for the OCI artifact
 	// +optional
 	// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9._:/@-]*$`
+	// +kubebuilder:validation:MaxLength=255
 	Subject string `json:"subject,omitempty"`
 	// Username for registry authentication
 	// +optional

--- a/api/lmes/v1alpha1/lmevaljob_types.go
+++ b/api/lmes/v1alpha1/lmevaljob_types.go
@@ -478,6 +478,10 @@ type OCISpec struct {
 	// Path within the results to package as artifact
 	// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9._/-]*$`
 	Path string `json:"path"`
+	// Subject for the OCI artifact
+	// +optional
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9._:/@-]*$`
+	Subject string `json:"subject,omitempty"`
 	// Username for registry authentication
 	// +optional
 	UsernameRef *corev1.SecretKeySelector `json:"username,omitempty"`

--- a/config/crd/bases/trustyai.opendatahub.io_lmevaljobs.yaml
+++ b/config/crd/bases/trustyai.opendatahub.io_lmevaljobs.yaml
@@ -363,6 +363,10 @@ spec:
                         - key
                         type: object
                         x-kubernetes-map-type: atomic
+                      subject:
+                        description: Subject for the OCI artifact
+                        pattern: ^[a-zA-Z0-9._:/@-]*$
+                        type: string
                       tag:
                         description: Optional tag for the artifact (defaults to job
                           name if not specified)

--- a/controllers/lmes/lmevaljob_controller.go
+++ b/controllers/lmes/lmevaljob_controller.go
@@ -1124,7 +1124,7 @@ func CreatePod(svcOpts *serviceOptions, job *lmesv1alpha1.LMEvalJob, log logr.Lo
 	}
 
 	// Always add OCI env vars if configured, regardless of offline/online mode
-	if job.Spec.HasOCIOutput() {
+	if job.Spec.HasOCIOutput() && job.Spec.Outputs != nil && job.Spec.Outputs.OCISpec != nil {
 		ociEnvVars := []corev1.EnvVar{
 			{
 				Name: "OCI_REGISTRY",

--- a/controllers/lmes/lmevaljob_controller.go
+++ b/controllers/lmes/lmevaljob_controller.go
@@ -1162,6 +1162,14 @@ func CreatePod(svcOpts *serviceOptions, job *lmesv1alpha1.LMEvalJob, log logr.Lo
 			})
 		}
 
+		// Add subject if specified
+		if job.Spec.Outputs.OCISpec.Subject != "" {
+			ociEnvVars = append(ociEnvVars, corev1.EnvVar{
+				Name:  "OCI_SUBJECT",
+				Value: job.Spec.Outputs.OCISpec.Subject,
+			})
+		}
+
 		// Handle authentication - either username/password or token
 		if job.Spec.Outputs.OCISpec.HasUsernamePassword() {
 			ociAuthEnvVars := []corev1.EnvVar{


### PR DESCRIPTION
## Summary by Sourcery

Add support for an OCI subject in LMEvalJob outputs by extending the OCISpec type, updating the CRD schema, injecting the OCI_SUBJECT env var in pods, and adding a corresponding unit test

New Features:
- Introduce Subject field in OCISpec to allow specifying OCI artifact subjects
- Expose OCI_SUBJECT environment variable in pods when a Subject is provided

Documentation:
- Update CRD schema and documentation to include the optional Subject property

Tests:
- Add unit test to verify OCI_SUBJECT environment variable is correctly set