### PR TITLE
feat(RHOAIENG-33054): increase timeout of the orchestrator route

### DIFF
--- a/controllers/gorch/templates/https-route.tmpl.yaml
+++ b/controllers/gorch/templates/https-route.tmpl.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     app: {{.Orchestrator.Name}}
     component: {{.Orchestrator.Name}}
+  annotations:
+    haproxy.router.openshift.io/timeout: 5m
 spec:
   to:
     kind: Service


### PR DESCRIPTION
Please refer to [RHOAIENG-33054](https://issues.redhat.com/browse/RHOAIENG-33054) for a description of an issue

I have added timeout annotation (5m) in controllers/gorch/templates/https-route.tmpl.yaml

Let me know if you think this fix would work

## Summary by Sourcery

New Features:
- Add haproxy.router.openshift.io/timeout annotation set to 5m on the orchestrator route template