### PR TITLE
fix(RHOAIENG-33645): Pass --confirm-run-unsafe-code arg when AllowCodeExecution is enabled

### DIFF
--- a/controllers/lmes/lmevaljob_controller.go
+++ b/controllers/lmes/lmevaljob_controller.go
@@ -928,6 +928,10 @@ func CreatePod(svcOpts *serviceOptions, job *lmesv1alpha1.LMEvalJob, log logr.Lo
 			Name:  "UNITXT_ALLOW_UNVERIFIED_CODE",
 			Value: "False",
 		},
+		{
+			Name:  "HF_ALLOW_CODE_EVAL",
+			Value: "0",
+		},
 	}
 	allowRemoteCodeEnvVars := []corev1.EnvVar{
 		{
@@ -941,6 +945,10 @@ func CreatePod(svcOpts *serviceOptions, job *lmesv1alpha1.LMEvalJob, log logr.Lo
 		{
 			Name:  "UNITXT_ALLOW_UNVERIFIED_CODE",
 			Value: "True",
+		},
+		{
+			Name:  "HF_ALLOW_CODE_EVAL",
+			Value: "1",
 		},
 	}
 
@@ -1361,6 +1369,12 @@ func generateArgs(svcOpts *serviceOptions, job *lmesv1alpha1.LMEvalJob, log logr
 		}
 	}
 
+	// --confirm_run_unsafe_code
+	log.Info("Enabling unsafe code execution for LMEvalJob", "jobName", job.Name, "namespace", job.Namespace)
+	if job.Spec.AllowCodeExecution != nil && *job.Spec.AllowCodeExecution {
+		cmds = append(cmds, "--confirm_run_unsafe_code")
+	}
+
 	return cmds
 }
 
@@ -1510,6 +1524,7 @@ var ProtectedEnvVarNames = []string{
 	"TRANSFORMERS_OFFLINE",
 	"HF_EVALUATE_OFFLINE",
 	"UNITXT_ALLOW_UNVERIFIED_CODE",
+	"HF_ALLOW_CODE_EVAL",
 }
 
 // removeProtectedEnvVars removes protected EnvVars from a list of EnvVars

--- a/controllers/lmes/lmevaljob_controller_test.go
+++ b/controllers/lmes/lmevaljob_controller_test.go
@@ -150,6 +150,10 @@ func Test_SimplePod(t *testing.T) {
 							Value: "False",
 						},
 						{
+							Name:  "HF_ALLOW_CODE_EVAL",
+							Value: "0",
+						},
+						{
 							Name:  "HF_DATASETS_OFFLINE",
 							Value: "1",
 						},
@@ -378,6 +382,10 @@ func Test_WithCustomPod(t *testing.T) {
 							Value: "False",
 						},
 						{
+							Name:  "HF_ALLOW_CODE_EVAL",
+							Value: "0",
+						},
+						{
 							Name:  "HF_DATASETS_OFFLINE",
 							Value: "1",
 						},
@@ -589,6 +597,10 @@ func Test_EnvSecretsPod(t *testing.T) {
 							Value: "False",
 						},
 						{
+							Name:  "HF_ALLOW_CODE_EVAL",
+							Value: "0",
+						},
+						{
 							Name:  "HF_DATASETS_OFFLINE",
 							Value: "1",
 						},
@@ -762,6 +774,10 @@ func Test_FileSecretsPod(t *testing.T) {
 						{
 							Name:  "UNITXT_ALLOW_UNVERIFIED_CODE",
 							Value: "False",
+						},
+						{
+							Name:  "HF_ALLOW_CODE_EVAL",
+							Value: "0",
 						},
 						{
 							Name:  "HF_DATASETS_OFFLINE",
@@ -1716,6 +1732,10 @@ func Test_ManagedPVC(t *testing.T) {
 							Value: "False",
 						},
 						{
+							Name:  "HF_ALLOW_CODE_EVAL",
+							Value: "0",
+						},
+						{
 							Name:  "HF_DATASETS_OFFLINE",
 							Value: "1",
 						},
@@ -1878,6 +1898,10 @@ func Test_ExistingPVC(t *testing.T) {
 						{
 							Name:  "UNITXT_ALLOW_UNVERIFIED_CODE",
 							Value: "False",
+						},
+						{
+							Name:  "HF_ALLOW_CODE_EVAL",
+							Value: "0",
 						},
 						{
 							Name:  "HF_DATASETS_OFFLINE",
@@ -2059,6 +2083,10 @@ func Test_PVCPreference(t *testing.T) {
 						{
 							Name:  "UNITXT_ALLOW_UNVERIFIED_CODE",
 							Value: "False",
+						},
+						{
+							Name:  "HF_ALLOW_CODE_EVAL",
+							Value: "0",
 						},
 						{
 							Name:  "HF_DATASETS_OFFLINE",
@@ -2246,6 +2274,10 @@ func Test_OfflineMode(t *testing.T) {
 							Value: "False",
 						},
 						{
+							Name:  "HF_ALLOW_CODE_EVAL",
+							Value: "0",
+						},
+						{
 							Name:  "HF_DATASETS_OFFLINE",
 							Value: "1",
 						},
@@ -2362,6 +2394,10 @@ func Test_ProtectedVars(t *testing.T) {
 							Name:  "UNITXT_ALLOW_UNVERIFIED_CODE",
 							Value: "True",
 						},
+						{
+							Name:  "HF_ALLOW_CODE_EVAL",
+							Value: "1",
+						},
 					},
 				},
 			},
@@ -2457,6 +2493,10 @@ func Test_ProtectedVars(t *testing.T) {
 						{
 							Name:  "UNITXT_ALLOW_UNVERIFIED_CODE",
 							Value: "False",
+						},
+						{
+							Name:  "HF_ALLOW_CODE_EVAL",
+							Value: "0",
 						},
 						{
 							Name:  "HF_DATASETS_OFFLINE",
@@ -2651,6 +2691,10 @@ func Test_OnlineModeDisabled(t *testing.T) {
 							Value: "False",
 						},
 						{
+							Name:  "HF_ALLOW_CODE_EVAL",
+							Value: "0",
+						},
+						{
 							Name:  "HF_DATASETS_OFFLINE",
 							Value: "1",
 						},
@@ -2838,6 +2882,10 @@ func Test_OnlineMode(t *testing.T) {
 							Name:  "UNITXT_ALLOW_UNVERIFIED_CODE",
 							Value: "False",
 						},
+						{
+							Name:  "HF_ALLOW_CODE_EVAL",
+							Value: "0",
+						},
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
@@ -3009,6 +3057,10 @@ func Test_AllowCodeOnlineMode(t *testing.T) {
 							Name:  "UNITXT_ALLOW_UNVERIFIED_CODE",
 							Value: "True",
 						},
+						{
+							Name:  "HF_ALLOW_CODE_EVAL",
+							Value: "1",
+						},
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
@@ -3177,6 +3229,10 @@ func Test_AllowCodeOfflineMode(t *testing.T) {
 						{
 							Name:  "UNITXT_ALLOW_UNVERIFIED_CODE",
 							Value: "True",
+						},
+						{
+							Name:  "HF_ALLOW_CODE_EVAL",
+							Value: "1",
 						},
 						{
 							Name:  "HF_DATASETS_OFFLINE",
@@ -3366,6 +3422,10 @@ func Test_OfflineModeWithOutput(t *testing.T) {
 						{
 							Name:  "UNITXT_ALLOW_UNVERIFIED_CODE",
 							Value: "False",
+						},
+						{
+							Name:  "HF_ALLOW_CODE_EVAL",
+							Value: "0",
 						},
 						{
 							Name:  "HF_DATASETS_OFFLINE",
@@ -3767,4 +3827,22 @@ func Test_ControllerIntegration(t *testing.T) {
 		assert.Greater(t, len(args), 0, "Should generate command arguments")
 		assert.Equal(t, "python", args[0], "Should start with python")
 	})
+}
+
+func Test_AllowCodeExecution(t *testing.T) {
+	ctx := context.Background()
+	log := log.FromContext(ctx)
+
+	svcOpts := &serviceOptions{DefaultBatchSize: "1"}
+	allowCode := true
+	job := &lmesv1alpha1.LMEvalJob{
+		Spec: lmesv1alpha1.LMEvalJobSpec{
+			Model:              "hf",
+			TaskList:           lmesv1alpha1.TaskList{TaskNames: []string{"task1"}},
+			AllowCodeExecution: &allowCode,
+		},
+	}
+
+	args := generateArgs(svcOpts, job, log)
+	assert.Contains(t, args, "--confirm_run_unsafe_code")
 }


### PR DESCRIPTION
This PR updates the LMEval controller and tests to pass in `--confirm-run-unsafe-code` as an argument when `AllowCodeExecution` is set to `true`. Additionally, to allow code execution during evaluation, we also pass in an env var `HF_ALLOW_CODE_EVAL` set to 1.

## Summary by Sourcery

Enable unsafe code execution in LMEvalJobs by adding the HF_ALLOW_CODE_EVAL environment variable and passing the --confirm_run_unsafe_code flag when the AllowCodeExecution option is enabled

New Features:
- Pass --confirm_run_unsafe_code argument to LMEval controller when AllowCodeExecution is true

Enhancements:
- Inject HF_ALLOW_CODE_EVAL environment variable into LMEval pods and add it to the protected env var list

Tests:
- Update existing tests to assert HF_ALLOW_CODE_EVAL values in different modes
- Add Test_AllowCodeExecution to verify the confirmation flag is included