### PR TITLE
Move built in detector image to Python version

### DIFF
--- a/config/base/params.env
+++ b/config/base/params.env
@@ -12,5 +12,5 @@ lmes-detect-device=true
 lmes-allow-online=true
 lmes-allow-code-execution=true
 guardrails-orchestrator-image=quay.io/trustyai/ta-guardrails-orchestrator:latest
-guardrails-built-in-detector-image=quay.io/trustyai/regex-detector:latest
+guardrails-built-in-detector-image=quay.io/trustyai/guardrails-detector-built-in:latest
 guardrails-sidecar-gateway-image=quay.io/trustyai/guardrails-sidecar-gateway:latest

--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -12,5 +12,5 @@ lmes-detect-device=true
 lmes-allow-online=true
 lmes-allow-code-execution=true
 guardrails-orchestrator-image=quay.io/opendatahub/ta-guardrails-orchestrator:latest
-guardrails-built-in-detector-image=quay.io/opendatahub/regex-detector:latest
+guardrails-built-in-detector-image=quay.io/opendatahub/odh-built-in-detector:latest
 guardrails-sidecar-gateway-image=quay.io/opendatahub/vllm-orchestrator-gateway:latest

--- a/config/overlays/rhoai/params.env
+++ b/config/overlays/rhoai/params.env
@@ -12,5 +12,5 @@ lmes-detect-device=true
 lmes-allow-online=false
 lmes-allow-code-execution=false
 guardrails-orchestrator-image=quay.io/trustyai/ta-guardrails-orchestrator:latest
-guardrails-built-in-detector-image=quay.io/trustyai/regex-detector:latest
+guardrails-built-in-detector-image=quay.io/trustyai/guardrails-detector-built-in:latest
 guardrails-sidecar-gateway-image=quay.io/trustyai/guardrails-sidecar-gateway:latest


### PR DESCRIPTION
## Summary by Sourcery

Centralize the built-in detector image configuration and align it with the Python version across environments

Enhancements:
- Move the built-in detector image environment variable from overlay-specific configs into the base params.env
- Remove redundant detector image definitions from the odh and rhoai overlays
- Update the Python version reference used for the built-in detector image