### PR TITLE
CI: Add manual dispatch of build and push from main

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -19,6 +19,7 @@ on:
       - "**.adoc"
       - "*.txt"
     types: [labeled, opened, synchronize, reopened]
+  workflow_dispatch:
 jobs:
   # Ensure that tests pass before publishing a new image.
   build-and-push-ci:


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Add manual workflow_dispatch trigger to the build-and-push CI workflow