### PR TITLE
feat: Add DSC eval configuration support

### DIFF
--- a/controllers/dsc/config.go
+++ b/controllers/dsc/config.go
@@ -1,0 +1,114 @@
+package dsc
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// DSCConfigMapName is the name of the ConfigMap created by OpenDataHub operator
+	DSCConfigMapName = "trustyai-dsc-config"
+
+	// DSC Configuration keys
+	DSCPermitOnlineKey        = "eval.lmeval.permitOnline"
+	DSCPermitCodeExecutionKey = "eval.lmeval.permitCodeExecution"
+)
+
+// DSCConfig represents the configuration values from the DSC ConfigMap
+type DSCConfig struct {
+	AllowOnline        bool
+	AllowCodeExecution bool
+}
+
+// DSCConfigReader reads configuration from the DSC ConfigMap created by OpenDataHub operator
+type DSCConfigReader struct {
+	Client    client.Client
+	Namespace string
+}
+
+// ReadDSCConfig reads configuration values from the trustyai-dsc-config ConfigMap
+func (r *DSCConfigReader) ReadDSCConfig(ctx context.Context, log *logr.Logger) (*DSCConfig, error) {
+	if r.Namespace == "" {
+		log.V(1).Info("No namespace specified, skipping DSC config reading")
+		return &DSCConfig{}, nil
+	}
+
+	configMapKey := types.NamespacedName{
+		Namespace: r.Namespace,
+		Name:      DSCConfigMapName,
+	}
+
+	var cm corev1.ConfigMap
+	if err := r.Client.Get(ctx, configMapKey, &cm); err != nil {
+		if errors.IsNotFound(err) {
+			log.V(1).Info("DSC ConfigMap not found, using default configuration",
+				"configmap", configMapKey)
+			return &DSCConfig{}, nil
+		}
+		return nil, fmt.Errorf("error reading DSC ConfigMap %s: %w", configMapKey, err)
+	}
+
+	log.V(1).Info("Found DSC ConfigMap, processing configuration",
+		"configmap", configMapKey)
+
+	// Process DSC-specific configuration
+	config, err := r.processDSCConfig(&cm, log)
+	if err != nil {
+		return nil, fmt.Errorf("error processing DSC configuration: %w", err)
+	}
+
+	return config, nil
+}
+
+// processDSCConfig processes the DSC ConfigMap data and returns configuration
+func (r *DSCConfigReader) processDSCConfig(cm *corev1.ConfigMap, log *logr.Logger) (*DSCConfig, error) {
+	config := &DSCConfig{}
+	var msgs []string
+
+	// Process permitOnline setting
+	if permitOnlineStr, found := cm.Data[DSCPermitOnlineKey]; found {
+		permitOnline, err := strconv.ParseBool(permitOnlineStr)
+		if err != nil {
+			msgs = append(msgs, fmt.Sprintf("invalid DSC setting for %s: %s, using default",
+				DSCPermitOnlineKey, permitOnlineStr))
+		} else {
+			config.AllowOnline = permitOnline
+			log.V(1).Info("Read PermitOnline from DSC config",
+				"key", DSCPermitOnlineKey, "value", permitOnline)
+		}
+	}
+
+	// Process permitCodeExecution setting
+	if permitCodeExecutionStr, found := cm.Data[DSCPermitCodeExecutionKey]; found {
+		permitCodeExecution, err := strconv.ParseBool(permitCodeExecutionStr)
+		if err != nil {
+			msgs = append(msgs, fmt.Sprintf("invalid DSC setting for %s: %s, using default",
+				DSCPermitCodeExecutionKey, permitCodeExecutionStr))
+		} else {
+			config.AllowCodeExecution = permitCodeExecution
+			log.V(1).Info("Read PermitCodeExecution from DSC config",
+				"key", DSCPermitCodeExecutionKey, "value", permitCodeExecution)
+		}
+	}
+
+	if len(msgs) > 0 && log != nil {
+		log.Error(fmt.Errorf("some DSC settings are invalid"), fmt.Sprintf("DSC config errors: %v", msgs))
+	}
+
+	return config, nil
+}
+
+// NewDSCConfigReader creates a new DSCConfigReader instance
+func NewDSCConfigReader(client client.Client, namespace string) *DSCConfigReader {
+	return &DSCConfigReader{
+		Client:    client,
+		Namespace: namespace,
+	}
+}

--- a/controllers/dsc/config_test.go
+++ b/controllers/dsc/config_test.go
@@ -1,0 +1,198 @@
+package dsc
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestDSCConfigReader_ReadDSCConfig(t *testing.T) {
+	tests := []struct {
+		name           string
+		namespace      string
+		configMapData  map[string]string
+		expectError    bool
+		expectedOnline bool
+		expectedCode   bool
+	}{
+		{
+			name:           "ConfigMap not found - should use defaults",
+			namespace:      "test-namespace",
+			configMapData:  nil,
+			expectError:    false,
+			expectedOnline: false, // Default value
+			expectedCode:   false, // Default value
+		},
+		{
+			name:      "Valid configuration with both settings enabled",
+			namespace: "test-namespace",
+			configMapData: map[string]string{
+				DSCPermitOnlineKey:        "true",
+				DSCPermitCodeExecutionKey: "true",
+			},
+			expectError:    false,
+			expectedOnline: true,
+			expectedCode:   true,
+		},
+		{
+			name:      "Valid configuration with both settings disabled",
+			namespace: "test-namespace",
+			configMapData: map[string]string{
+				DSCPermitOnlineKey:        "false",
+				DSCPermitCodeExecutionKey: "false",
+			},
+			expectError:    false,
+			expectedOnline: false,
+			expectedCode:   false,
+		},
+		{
+			name:      "Partial configuration - only permitOnline",
+			namespace: "test-namespace",
+			configMapData: map[string]string{
+				DSCPermitOnlineKey: "true",
+			},
+			expectError:    false,
+			expectedOnline: true,
+			expectedCode:   false, // Should remain default
+		},
+		{
+			name:      "Invalid boolean values - should use defaults",
+			namespace: "test-namespace",
+			configMapData: map[string]string{
+				DSCPermitOnlineKey:        "invalid",
+				DSCPermitCodeExecutionKey: "also-invalid",
+			},
+			expectError:    false, // Should not fail, just log error
+			expectedOnline: false, // Should remain default
+			expectedCode:   false, // Should remain default
+		},
+		{
+			name:           "Empty namespace - should skip reading",
+			namespace:      "",
+			configMapData:  nil,
+			expectError:    false,
+			expectedOnline: false, // Should remain default
+			expectedCode:   false, // Should remain default
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create fake client
+			var objects []client.Object
+			if tt.configMapData != nil {
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      DSCConfigMapName,
+						Namespace: tt.namespace,
+					},
+					Data: tt.configMapData,
+				}
+				objects = append(objects, configMap)
+			}
+
+			scheme := runtime.NewScheme()
+			require.NoError(t, corev1.AddToScheme(scheme))
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+
+			// Create DSCConfigReader
+			reader := NewDSCConfigReader(fakeClient, tt.namespace)
+
+			// Create a test logger
+			log := logr.Discard()
+
+			// Test ReadDSCConfig
+			dscConfig, err := reader.ReadDSCConfig(context.Background(), &log)
+
+			// Assert error expectations
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			// Assert configuration values
+			assert.Equal(t, tt.expectedOnline, dscConfig.AllowOnline, "AllowOnline should match expected value")
+			assert.Equal(t, tt.expectedCode, dscConfig.AllowCodeExecution, "AllowCodeExecution should match expected value")
+		})
+	}
+}
+
+func TestDSCConfigReader_ReadDSCConfig_ConfigMapNotFound(t *testing.T) {
+	// Create fake client without any ConfigMaps
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	// Create DSCConfigReader
+	reader := NewDSCConfigReader(fakeClient, "test-namespace")
+
+	// Create a test logger
+	log := logr.Discard()
+
+	// Test ReadDSCConfig
+	dscConfig, err := reader.ReadDSCConfig(context.Background(), &log)
+
+	// Should not return error when ConfigMap is not found
+	assert.NoError(t, err)
+
+	// Values should be at defaults
+	assert.False(t, dscConfig.AllowOnline)
+	assert.False(t, dscConfig.AllowCodeExecution)
+}
+
+func TestDSCConfigReader_ReadDSCConfig_ClientError(t *testing.T) {
+	// Create a mock client that returns an error
+	mockClient := &mockClient{shouldError: true}
+
+	// Create DSCConfigReader
+	reader := NewDSCConfigReader(mockClient, "test-namespace")
+
+	// Create a test logger
+	log := logr.Discard()
+
+	// Test ReadDSCConfig
+	_, err := reader.ReadDSCConfig(context.Background(), &log)
+
+	// Should return error when client fails
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "error reading DSC ConfigMap")
+}
+
+// mockClient is a simple mock that can simulate client errors
+type mockClient struct {
+	client.Client
+	shouldError bool
+}
+
+func (m *mockClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if m.shouldError {
+		return errors.NewInternalError(fmt.Errorf("mock client error"))
+	}
+	return nil
+}
+
+func TestNewDSCConfigReader(t *testing.T) {
+	// Create a fake client
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	// Test NewDSCConfigReader
+	reader := NewDSCConfigReader(fakeClient, "test-namespace")
+
+	// Assert reader is properly initialised
+	assert.NotNil(t, reader)
+	assert.Equal(t, fakeClient, reader.Client)
+	assert.Equal(t, "test-namespace", reader.Namespace)
+}

--- a/controllers/lmes/config.go
+++ b/controllers/lmes/config.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/trustyai-explainability/trustyai-service-operator/controllers/dsc"
 	"github.com/trustyai-explainability/trustyai-service-operator/controllers/lmes/driver"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -114,4 +115,12 @@ func constructOptionsFromConfigMap(log *logr.Logger, configmap *corev1.ConfigMap
 	}
 
 	return nil
+}
+
+// ApplyDSCConfig applies DSC configuration to the LMES Options
+func ApplyDSCConfig(dscConfig *dsc.DSCConfig) {
+	if dscConfig != nil {
+		Options.AllowOnline = dscConfig.AllowOnline
+		Options.AllowCodeExecution = dscConfig.AllowCodeExecution
+	}
 }

--- a/controllers/lmes/dsc_config_test.go
+++ b/controllers/lmes/dsc_config_test.go
@@ -1,0 +1,268 @@
+package lmes
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/trustyai-explainability/trustyai-service-operator/controllers/dsc"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestDSCConfigReader_ReadDSCConfig(t *testing.T) {
+	tests := []struct {
+		name           string
+		namespace      string
+		configMapData  map[string]string
+		expectError    bool
+		expectedOnline bool
+		expectedCode   bool
+	}{
+		{
+			name:           "ConfigMap not found - should use defaults",
+			namespace:      "test-namespace",
+			configMapData:  nil,
+			expectError:    false,
+			expectedOnline: false, // Default value
+			expectedCode:   false, // Default value
+		},
+		{
+			name:      "Valid configuration with both settings enabled",
+			namespace: "test-namespace",
+			configMapData: map[string]string{
+				dsc.DSCPermitOnlineKey:        "true",
+				dsc.DSCPermitCodeExecutionKey: "true",
+			},
+			expectError:    false,
+			expectedOnline: true,
+			expectedCode:   true,
+		},
+		{
+			name:      "Valid configuration with both settings disabled",
+			namespace: "test-namespace",
+			configMapData: map[string]string{
+				dsc.DSCPermitOnlineKey:        "false",
+				dsc.DSCPermitCodeExecutionKey: "false",
+			},
+			expectError:    false,
+			expectedOnline: false,
+			expectedCode:   false,
+		},
+		{
+			name:      "Partial configuration - only permitOnline",
+			namespace: "test-namespace",
+			configMapData: map[string]string{
+				dsc.DSCPermitOnlineKey: "true",
+			},
+			expectError:    false,
+			expectedOnline: true,
+			expectedCode:   false, // Should remain default
+		},
+		{
+			name:      "Invalid boolean values - should use defaults",
+			namespace: "test-namespace",
+			configMapData: map[string]string{
+				dsc.DSCPermitOnlineKey:        "invalid",
+				dsc.DSCPermitCodeExecutionKey: "also-invalid",
+			},
+			expectError:    false, // Should not fail, just log error
+			expectedOnline: false, // Should remain default
+			expectedCode:   false, // Should remain default
+		},
+		{
+			name:           "Empty namespace - should skip reading",
+			namespace:      "",
+			configMapData:  nil,
+			expectError:    false,
+			expectedOnline: false, // Should remain default
+			expectedCode:   false, // Should remain default
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset Options to default values
+			Options.AllowOnline = false
+			Options.AllowCodeExecution = false
+
+			// Create fake client
+			var objects []client.Object
+			if tt.configMapData != nil {
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      dsc.DSCConfigMapName,
+						Namespace: tt.namespace,
+					},
+					Data: tt.configMapData,
+				}
+				objects = append(objects, configMap)
+			}
+
+			scheme := runtime.NewScheme()
+			require.NoError(t, corev1.AddToScheme(scheme))
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+
+			// Create DSCConfigReader
+			reader := dsc.NewDSCConfigReader(fakeClient, tt.namespace)
+
+			// Create a test logger
+			log := logr.Discard()
+
+			// Test ReadDSCConfig
+			dscConfig, err := reader.ReadDSCConfig(context.Background(), &log)
+
+			// Assert error expectations
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			// Apply DSC config to Options for testing
+			if dscConfig != nil {
+				ApplyDSCConfig(dscConfig)
+			}
+
+			// Assert configuration values
+			assert.Equal(t, tt.expectedOnline, Options.AllowOnline, "AllowOnline should match expected value")
+			assert.Equal(t, tt.expectedCode, Options.AllowCodeExecution, "AllowCodeExecution should match expected value")
+		})
+	}
+}
+
+func TestDSCConfigReader_ReadDSCConfig_ConfigMapNotFound(t *testing.T) {
+	// Reset Options to default values
+	Options.AllowOnline = false
+	Options.AllowCodeExecution = false
+
+	// Create fake client without any ConfigMaps
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	// Create DSCConfigReader
+	reader := dsc.NewDSCConfigReader(fakeClient, "test-namespace")
+
+	// Create a test logger
+	log := logr.Discard()
+
+	// Test ReadDSCConfig
+	dscConfig, err := reader.ReadDSCConfig(context.Background(), &log)
+
+	// Should not return error when ConfigMap is not found
+	assert.NoError(t, err)
+
+	// Apply DSC config to Options for testing
+	if dscConfig != nil {
+		ApplyDSCConfig(dscConfig)
+	}
+
+	// Values should remain at defaults
+	assert.False(t, Options.AllowOnline)
+	assert.False(t, Options.AllowCodeExecution)
+}
+
+func TestDSCConfigReader_ReadDSCConfig_ClientError(t *testing.T) {
+	// Reset Options to default values
+	Options.AllowOnline = false
+	Options.AllowCodeExecution = false
+
+	// Create a mock client that returns an error
+	mockClient := &mockClient{shouldError: true}
+
+	// Create DSCConfigReader
+	reader := dsc.NewDSCConfigReader(mockClient, "test-namespace")
+
+	// Create a test logger
+	log := logr.Discard()
+
+	// Test ReadDSCConfig
+	_, err := reader.ReadDSCConfig(context.Background(), &log)
+
+	// Should return error when client fails
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "error reading DSC ConfigMap")
+
+	// Values should remain at defaults
+	assert.False(t, Options.AllowOnline)
+	assert.False(t, Options.AllowCodeExecution)
+}
+
+// mockClient is a simple mock that can simulate client errors
+type mockClient struct {
+	client.Client
+	shouldError bool
+}
+
+func (m *mockClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if m.shouldError {
+		return errors.NewInternalError(fmt.Errorf("mock client error"))
+	}
+	return nil
+}
+
+func TestApplyDSCConfig(t *testing.T) {
+	tests := []struct {
+		name           string
+		dscConfig      *dsc.DSCConfig
+		expectedOnline bool
+		expectedCode   bool
+	}{
+		{
+			name: "Valid DSC config with both settings enabled",
+			dscConfig: &dsc.DSCConfig{
+				AllowOnline:        true,
+				AllowCodeExecution: true,
+			},
+			expectedOnline: true,
+			expectedCode:   true,
+		},
+		{
+			name: "Valid DSC config with both settings disabled",
+			dscConfig: &dsc.DSCConfig{
+				AllowOnline:        false,
+				AllowCodeExecution: false,
+			},
+			expectedOnline: false,
+			expectedCode:   false,
+		},
+		{
+			name: "Partial DSC config - only permitOnline",
+			dscConfig: &dsc.DSCConfig{
+				AllowOnline:        true,
+				AllowCodeExecution: false,
+			},
+			expectedOnline: true,
+			expectedCode:   false,
+		},
+		{
+			name:           "Nil DSC config - should not change defaults",
+			dscConfig:      nil,
+			expectedOnline: false, // Should remain default
+			expectedCode:   false, // Should remain default
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset Options to default values
+			Options.AllowOnline = false
+			Options.AllowCodeExecution = false
+
+			// Apply DSC config
+			ApplyDSCConfig(tt.dscConfig)
+
+			// Assert configuration values
+			assert.Equal(t, tt.expectedOnline, Options.AllowOnline, "AllowOnline should match expected value")
+			assert.Equal(t, tt.expectedCode, Options.AllowCodeExecution, "AllowCodeExecution should match expected value")
+		})
+	}
+}

--- a/controllers/lmes/lmevaljob_controller.go
+++ b/controllers/lmes/lmevaljob_controller.go
@@ -53,6 +53,7 @@ import (
 
 	"github.com/go-logr/logr"
 	lmesv1alpha1 "github.com/trustyai-explainability/trustyai-service-operator/api/lmes/v1alpha1"
+	"github.com/trustyai-explainability/trustyai-service-operator/controllers/dsc"
 	"github.com/trustyai-explainability/trustyai-service-operator/controllers/lmes/driver"
 )
 
@@ -274,6 +275,15 @@ func (r *LMEvalJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}
 		if err := constructOptionsFromConfigMap(&log, &cm); err != nil {
 			return err
+		}
+
+		// Read DSC configuration if available
+		dscReader := dsc.NewDSCConfigReader(r.Client, r.Namespace)
+		if dscConfig, err := dscReader.ReadDSCConfig(ctx, &log); err != nil {
+			log.Error(err, "failed to read DSC configuration, continuing with defaults")
+			// Don't return error here as DSC config is optional
+		} else {
+			ApplyDSCConfig(dscConfig)
 		}
 
 		return nil


### PR DESCRIPTION
Refer to [RHOAIENG-30963](https://issues.redhat.com/browse/RHOAIENG-30963).

## Summary by Sourcery

Add support for dynamic security control (DSC) configuration in LM evaluation jobs by reading an optional DSC ConfigMap and merging its permitOnline and permitCodeExecution settings into the evaluation options.

New Features:
- Introduce DSCConfigReader to fetch and parse DSC settings from a ConfigMap
- Add ApplyDSCConfig to apply DSCConfig values to LMES options
- Integrate DSC configuration reading into LME eval job controller setup

Enhancements:
- Treat DSC config as optional and continue with defaults on missing or invalid ConfigMap

Tests:
- Add unit tests for DSCConfigReader processing various ConfigMap scenarios
- Add tests for ApplyDSCConfig behavior
- Add integration tests for DSC config support in the LME package