### PR TITLE
feat(RHOAIENG-35043): Add kube-rbac-proxy configuration templates for orchestrator and gateway

### DIFF
--- a/controllers/gorch/templates/kube-rbac-proxy/gateway-config.tmpl.yaml
+++ b/controllers/gorch/templates/kube-rbac-proxy/gateway-config.tmpl.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Orchestrator.Name }}-gateway-kube-rbac-config
+  namespace: {{ .Orchestrator.Namespace }}
+  labels:
+    app: {{ .Orchestrator.Name }}
+    app.kubernetes.io/instance: {{ .Orchestrator.Name }}
+    app.kubernetes.io/name: {{ .Orchestrator.Name }}
+    app.kubernetes.io/part-of: trustyai
+    app.kubernetes.io/component: kube-rbac-proxy
+    component: gateway
+data:
+  config.yaml: |
+    authorization:
+      resourceAttributes:
+        namespace: "{{ .Orchestrator.Namespace }}"
+        resource: "services"
+        resourceName: "{{ .Orchestrator.Name }}-gateway-service"
+        verb: "get"
+        apiGroup: ""
+    upstreamConfig:
+      url: "http://127.0.0.1:8090"
+      proxyTimeout: "30s"
+    tlsConfig:
+      minVersion: "VersionTLS12"
+      # FIPS 140-2 approved cipher suites only
+      cipherSuites:
+        - "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+        - "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+        - "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
+        - "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"
+        - "TLS_RSA_WITH_AES_128_GCM_SHA256"
+        - "TLS_RSA_WITH_AES_256_GCM_SHA384"

--- a/controllers/gorch/templates/kube-rbac-proxy/orchestrator-config.tmpl.yaml
+++ b/controllers/gorch/templates/kube-rbac-proxy/orchestrator-config.tmpl.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Orchestrator.Name }}-orchestrator-kube-rbac-config
+  namespace: {{ .Orchestrator.Namespace }}
+  labels:
+    app: {{ .Orchestrator.Name }}
+    app.kubernetes.io/instance: {{ .Orchestrator.Name }}
+    app.kubernetes.io/name: {{ .Orchestrator.Name }}
+    app.kubernetes.io/part-of: trustyai
+    app.kubernetes.io/component: kube-rbac-proxy
+    component: orchestrator
+data:
+  config.yaml: |
+    authorization:
+      resourceAttributes:
+        namespace: "{{ .Orchestrator.Namespace }}"
+        resource: "services"
+        resourceName: "{{ .Orchestrator.Name }}-service"
+        verb: "get"
+        apiGroup: ""
+    upstreamConfig:
+      url: "https://127.0.0.1:8032"
+      proxyTimeout: "30s"
+      upstreamCAFile: "/etc/tls/ca/service-ca.crt"
+    tlsConfig:
+      minVersion: "VersionTLS12"
+      # FIPS 140-2 approved cipher suites only
+      cipherSuites:
+        - "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+        - "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+        - "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
+        - "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"
+        - "TLS_RSA_WITH_AES_128_GCM_SHA256"
+        - "TLS_RSA_WITH_AES_256_GCM_SHA384"

--- a/controllers/tas/templates/kube-rbac-proxy/config.tmpl.yaml
+++ b/controllers/tas/templates/kube-rbac-proxy/config.tmpl.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Instance.Name }}-kube-rbac-config
+  namespace: {{ .Instance.Namespace }}
+  labels:
+    app: {{ .Instance.Name }}
+    app.kubernetes.io/instance: {{ .Instance.Name }}
+    app.kubernetes.io/name: {{ .Instance.Name }}
+    app.kubernetes.io/part-of: trustyai
+    app.kubernetes.io/version: {{ .Version }}
+    app.kubernetes.io/component: kube-rbac-proxy
+data:
+  config.yaml: |
+    authorization:
+      resourceAttributes:
+        namespace: "{{ .Instance.Namespace }}"
+        resource: "services"
+        resourceName: "{{ .Instance.Name }}"
+        verb: "get"
+        apiGroup: ""
+    upstreamConfig:
+      url: "http://127.0.0.1:8080"
+      proxyTimeout: "30s"
+    tlsConfig:
+      minVersion: "VersionTLS12"
+      # FIPS 140-2 approved cipher suites only
+      cipherSuites:
+        - "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+        - "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+        - "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
+        - "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"
+        - "TLS_RSA_WITH_AES_128_GCM_SHA256"
+        - "TLS_RSA_WITH_AES_256_GCM_SHA384"


### PR DESCRIPTION
Refer to [RHOAIENG-35043](https://issues.redhat.com/browse/RHOAIENG-35043).

Add kube-rbac-proxy configuration templates for orchestrator and gateway

## Summary by Sourcery

Add kube-rbac-proxy ConfigMap templates for orchestrator, gateway, and TAS controllers to enable RBAC proxying.

New Features:
- Provide kube-rbac-proxy ConfigMap template for the orchestrator component.
- Provide kube-rbac-proxy ConfigMap template for the gateway component.
- Provide kube-rbac-proxy ConfigMap template for the TAS controller.