### PR TITLE
refactor(RHOAIENG-35045): Update service account creation to use kube-rbac-proxy

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -35,13 +35,13 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.trustyaiOperatorImage
-  - name: oauthProxyImage
+  - name: kubeRBACProxyImage
     objref:
       kind: ConfigMap
       name: config
       apiVersion: v1
     fieldref:
-      fieldpath: data.oauthProxyImage
+      fieldpath: data.kubeRBACProxyImage
   - name: kServeServerless
     objref:
       kind: ConfigMap

--- a/controllers/tas/service_accounts.go
+++ b/controllers/tas/service_accounts.go
@@ -7,7 +7,6 @@ import (
 	"github.com/trustyai-explainability/trustyai-service-operator/controllers/constants"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/json"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -21,46 +20,14 @@ func generateServiceAccountName(instance *trustyaiopendatahubiov1alpha1.TrustyAI
 	return instance.Name + "-proxy"
 }
 
-// createServiceAccount creates a service account for this instance's OAuth proxy
+// createServiceAccount creates a service account for this instance's kube-rbac-proxy
 func (r *TrustyAIServiceReconciler) createServiceAccount(ctx context.Context, instance *trustyaiopendatahubiov1alpha1.TrustyAIService) error {
-	routeName := instance.Name
 	serviceAccountName := generateServiceAccountName(instance)
-
-	// Define the OAuth redirect reference
-	oauthRedirectRef := struct {
-		Kind       string `json:"kind"`
-		APIVersion string `json:"apiVersion"`
-		Reference  struct {
-			Kind string `json:"kind"`
-			Name string `json:"name"`
-		} `json:"reference"`
-	}{
-		Kind:       "OAuthRedirectReference",
-		APIVersion: "v1",
-		Reference: struct {
-			Kind string `json:"kind"`
-			Name string `json:"name"`
-		}{
-			Kind: "Route",
-			Name: routeName,
-		},
-	}
-
-	// Marshal the struct into JSON format for the annotation
-	oauthRedirectRefJSON, err := json.Marshal(oauthRedirectRef)
-
-	if err != nil {
-		// Handle error
-		return err
-	}
 
 	sa := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceAccountName,
 			Namespace: instance.Namespace,
-			Annotations: map[string]string{
-				"serviceaccounts.openshift.io/oauth-redirectreference.primary": string(oauthRedirectRefJSON),
-			},
 			Labels: map[string]string{
 				"app":                        componentName,
 				"app.kubernetes.io/name":     serviceAccountName,


### PR DESCRIPTION
Refer to [RHOAIENG-35045](https://issues.redhat.com/browse/RHOAIENG-35045).

## Summary by Sourcery

Refactor the service account setup to support kube-rbac-proxy by stripping out OAuth redirect logic and update kustomization variables accordingly

Enhancements:
- Refactor service account creation to use kube-rbac-proxy instead of OpenShift OAuth proxy by removing OAuth redirect annotations and related imports
- Rename kustomize variable oauthProxyImage to kubeRBACProxyImage in base configuration