### PR TITLE
fix: Remove default (false) permissions from LMEval tests

### DIFF
--- a/controllers/lmes/lmevaljob_controller_test.go
+++ b/controllers/lmes/lmevaljob_controller_test.go
@@ -3125,6 +3125,11 @@ func Test_AllowCodeOfflineMode(t *testing.T) {
 		AllowCodeExecution: true,
 	}
 
+	permConfig := &PermissionConfig{
+		AllowOnline:        false,
+		AllowCodeExecution: true,
+	}
+
 	jobName := "test"
 	pvcName := "my-pvc"
 	allowCode := true
@@ -3204,7 +3209,7 @@ func Test_AllowCodeOfflineMode(t *testing.T) {
 					Name:            "main",
 					Image:           svcOpts.PodImage,
 					ImagePullPolicy: svcOpts.ImagePullPolicy,
-					Command:         generateCmd(svcOpts, job, NewDefaultPermissionConfig()),
+					Command:         generateCmd(svcOpts, job, permConfig),
 					Args:            generateArgs(svcOpts, job, log),
 					Ports: []corev1.ContainerPort{
 						{
@@ -3302,7 +3307,7 @@ func Test_AllowCodeOfflineMode(t *testing.T) {
 		},
 	}
 
-	newPod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), log)
+	newPod := CreatePod(svcOpts, job, permConfig, log)
 
 	assert.Equal(t, expect, newPod)
 }


### PR DESCRIPTION
Fix case where online tests for LMEval were using default permissions (offline).

## Summary by Sourcery

Update LMEval controller tests to explicitly configure online permissions instead of using the default offline configuration

Bug Fixes:
- Fix Test_OnlineMode and Test_AllowCodeOnlineMode to use explicit PermissionConfig allowing online (and code execution where needed) rather than NewDefaultPermissionConfig()

Tests:
- Add permConfig declarations and replace generateCmd and CreatePod calls to use the new PermissionConfig in relevant tests