### PR TITLE
fix: Enable upstream CI builds only on upstream

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -23,6 +23,7 @@ on:
 jobs:
   # Ensure that tests pass before publishing a new image.
   build-and-push-ci:
+    if: github.repository == 'trustyai-explainability/trustyai-service-operator'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add an if condition to the build-and-push-ci job to run only when the repository is 'trustyai-explainability/trustyai-service-operator'