### PR TITLE
fix(RHOAIENG-34218): Trusty AI Grants All Authenticated users to list…

### DIFF
--- a/config/rbac/non_admin_lmeval_role.yaml
+++ b/config/rbac/non_admin_lmeval_role.yaml
@@ -28,19 +28,3 @@ rules:
   - lmevaljobs/status
   verbs:
   - get
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - persistentvolumeclaims
-  verbs:
-  - get
-  - list
-  - watch


### PR DESCRIPTION
… pods in any namespace

Currently the non admin role and clusterrolebinding allows pods and pvcs in any namespace to be viewed by any authenticated user, breaking multi-tenancy. This commit removes just those permissions.

## Summary by Sourcery

Restrict non-admin role by removing pod and persistentvolumeclaim list/watch/get permissions to prevent unauthorized cross-namespace access

Bug Fixes:
- Remove pod get/list/watch permissions from non-admin role
- Remove persistentvolumeclaim get/list/watch permissions from non-admin role