### PR TITLE
Feat: Add servicemonitor for built-in detectors

### DIFF
--- a/controllers/gorch/constants.go
+++ b/controllers/gorch/constants.go
@@ -4,7 +4,6 @@ const (
 	orchestratorName     = "guardrails-orchestrator"
 	finalizerName        = "trustyai.opendatahub.io/gorch-finalizer"
 	configMapName        = "gorch-config"
-	serviceMonitorName   = "trustyai-guardrails-monitor"
 	orchestratorImageKey = "guardrails-orchestrator-image"
 	gatewayImageKey      = "guardrails-sidecar-gateway-image"
 	detectorImageKey     = "guardrails-built-in-detector-image"

--- a/controllers/gorch/guardrailsorchestrator_controller.go
+++ b/controllers/gorch/guardrailsorchestrator_controller.go
@@ -412,7 +412,7 @@ func (r *GuardrailsOrchestratorReconciler) Reconcile(ctx context.Context, req ct
 	}
 
 	existingSM := &monitoringv1.ServiceMonitor{}
-	err = r.Get(ctx, types.NamespacedName{Name: serviceMonitorName, Namespace: orchestrator.Namespace}, existingSM)
+	err = r.Get(ctx, types.NamespacedName{Name: orchestrator.Name + "-service-monitor", Namespace: orchestrator.Namespace}, existingSM)
 	if orchestrator.Spec.EnableBuiltInDetectors {
 		if err != nil && errors.IsNotFound(err) {
 			// Define a new route

--- a/controllers/gorch/templates/service-monitor.tmpl.yaml
+++ b/controllers/gorch/templates/service-monitor.tmpl.yaml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
     name: {{ .Orchestrator.Name }}-service-monitor
+    namespace: {{.Orchestrator.Namespace}}
     labels:
         component: {{ .Orchestrator.Name }}
 spec:

--- a/controllers/gorch/templates/service.tmpl.yaml
+++ b/controllers/gorch/templates/service.tmpl.yaml
@@ -45,4 +45,4 @@ spec:
   sessionAffinity: None
   selector:
     app: {{.Orchestrator.Name}}
-    component: {{ .ComponentName }}
+    component: {{.Orchestrator.Name}}


### PR DESCRIPTION
## Summary by Sourcery

Implement ServiceMonitor support for built-in detectors by creating ServiceMonitor resources in the reconciler when enabled and conditionally exposing a detector-metrics port; standardize component labels across templates for consistent resource selection.

New Features:
- Add ServiceMonitor creation logic in GuardrailsOrchestratorReconciler when EnableBuiltInDetectors is true
- Introduce a service-monitor template and createServiceMonitor helper function
- Conditionally expose a detector-metrics port on the service spec based on the built-in detectors flag

Enhancements:
- Standardize component labels to "trustyai-guardrails" across service, deployment, gateway, health, https-route, and CA bundle templates