### PR TITLE
Bug: Set OTEL export to default to false, fixing flag-overwriting bug

### DIFF
--- a/api/gorch/v1alpha1/guardrailsorchestrator_types.go
+++ b/api/gorch/v1alpha1/guardrailsorchestrator_types.go
@@ -86,11 +86,9 @@ type OTelExporter struct {
 	OTLPMetricsEndpoint string `json:"otlpMetricsEndpoint,omitempty"`
 	// Specifies whether to enable tracing data export
 	// +optional
-	// +kubebuilder:default=true
 	EnableTraces bool `json:"enableTraces,omitempty"`
 	// Specifies whether to enable metrics data export
 	// +optional
-	// +kubebuilder:default=true
 	EnableMetrics bool `json:"enableMetrics,omitempty"`
 }
 

--- a/api/gorch/v1alpha1/zz_generated.deepcopy.go
+++ b/api/gorch/v1alpha1/zz_generated.deepcopy.go
@@ -173,6 +173,11 @@ func (in *GuardrailsOrchestratorSpec) DeepCopyInto(out *GuardrailsOrchestratorSp
 		*out = new(AutoConfig)
 		**out = **in
 	}
+	if in.CustomDetectorsConfig != nil {
+		in, out := &in.CustomDetectorsConfig, &out.CustomDetectorsConfig
+		*out = new(string)
+		**out = **in
+	}
 	if in.SidecarGatewayConfig != nil {
 		in, out := &in.SidecarGatewayConfig, &out.SidecarGatewayConfig
 		*out = new(string)

--- a/config/crd/bases/trustyai.opendatahub.io_guardrailsorchestrators.yaml
+++ b/config/crd/bases/trustyai.opendatahub.io_guardrailsorchestrators.yaml
@@ -58,7 +58,8 @@ spec:
                 - inferenceServiceToGuardrail
                 type: object
               customDetectorsConfig:
-                description: Name of configmap containing user-defined Python detectors
+                description: Name of configmap containing user-defined Python detectors.
+                  This is only used if EnableBuiltInDetectors is true
                 type: string
               enableBuiltInDetectors:
                 description: Boolean flag to enable/disable built-in detectors
@@ -83,11 +84,9 @@ spec:
                   the OTLP exporter
                 properties:
                   enableMetrics:
-                    default: true
                     description: Specifies whether to enable metrics data export
                     type: boolean
                   enableTraces:
-                    default: true
                     description: Specifies whether to enable tracing data export
                     type: boolean
                   otlpMetricsEndpoint:


### PR DESCRIPTION
## Summary by Sourcery

Remove default-enable for OTEL exporter flags to false, add missing deepcopy for CustomDetectorsConfig, and update CRD documentation for customDetectorsConfig behaviour.

Bug Fixes:
- Remove default:true on EnableMetrics and EnableTraces to default them to false and fix flag-overwriting issue

Enhancements:
- Add deepcopy support for CustomDetectorsConfig in GuardrailsOrchestratorSpec

Documentation:
- Clarify CRD description for customDetectorsConfig to indicate its conditional use based on EnableBuiltInDetectors