### PR TITLE
Nit: Fix repeating manual-orchestrator config message

### DIFF
--- a/controllers/gorch/guardrailsorchestrator_controller.go
+++ b/controllers/gorch/guardrailsorchestrator_controller.go
@@ -256,7 +256,6 @@ func (r *GuardrailsOrchestratorReconciler) Reconcile(ctx context.Context, req ct
 			tlsMounts = getTLSInfo(*orchestrator)
 		}
 	} else {
-		log.Info("Using manually-configured OrchestratorConfig")
 		existingConfigMap := &corev1.ConfigMap{}
 		err = r.Get(ctx, types.NamespacedName{Name: *orchestrator.Spec.OrchestratorConfig, Namespace: orchestrator.Namespace}, existingConfigMap)
 		if err != nil {


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Remove repeated log.Info call for manually-configured OrchestratorConfig in the reconciler