### PR TITLE
FIX: AutoConfig TLS now a toggleable option, default is false

### DIFF
--- a/api/gorch/v1alpha1/guardrailsorchestrator_types.go
+++ b/api/gorch/v1alpha1/guardrailsorchestrator_types.go
@@ -35,6 +35,11 @@ type AutoConfig struct {
 	*/
 	// +optional
 	DetectorServiceLabelToMatch string `json:"detectorServiceLabelToMatch,omitempty"`
+
+	// Whether the autoconfig should set up TLS connections to detectors and the generative model
+	// TLS connections are not currently supported if using kube-rbac-proxy to authenticate to the orchestrator.
+	// +optional
+	UseTLS bool `json:"useTLS,omitempty"`
 }
 
 // GuardrailsOrchestratorSpec defines the desired state of GuardrailsOrchestrator.

--- a/config/crd/bases/trustyai.opendatahub.io_guardrailsorchestrators.yaml
+++ b/config/crd/bases/trustyai.opendatahub.io_guardrailsorchestrators.yaml
@@ -54,6 +54,11 @@ spec:
                     description: The name of the inference service that provides the
                       vLLM generation model to-be-guardrailed
                     type: string
+                  useTLS:
+                    description: |-
+                      Whether the autoconfig should set up TLS connections to detectors and the generative model
+                      TLS connections are not currently supported if using kube-rbac-proxy to authenticate to the orchestrator.
+                    type: boolean
                 required:
                 - inferenceServiceToGuardrail
                 type: object


### PR DESCRIPTION
With the introduction of kube-rbac-proxy, all orchestrator -> client connections cannot use TLS if the orchestrator is authenticated via kube-rbac-proxy. This PR introduces a flag to the autoConfig field in the CR that lets users choose whether TLS is used in the auto config setup, with the default option set to false.

## Summary by Sourcery

Introduce a UseTLS toggle in the AutoConfig spec to control whether orchestrator-to-service connections use HTTPS, defaulting to false and enforcing HTTP when disabled

New Features:
- Add UseTLS boolean field to AutoConfig spec for toggling TLS usage

Enhancements:
- Extend extractInferenceServiceInfo to accept the orchestrator and enforce HTTP scheme when UseTLS is false

Documentation:
- Update CRD schema to include and document the useTLS field