### PR TITLE
chore: Add ragas-provider-image to ODH params.env

### DIFF
--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -14,3 +14,4 @@ lmes-allow-code-execution=true
 guardrails-orchestrator-image=quay.io/opendatahub/ta-guardrails-orchestrator:latest
 guardrails-built-in-detector-image=quay.io/opendatahub/odh-built-in-detector:latest
 guardrails-sidecar-gateway-image=quay.io/opendatahub/vllm-orchestrator-gateway:latest
+ragas-provider-image=quay.io/opendatahub/llama-stack-provider-ragas:latest


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Add ragas-provider-image variable to config/overlays/odh/params.env