### PR TITLE
Mount and reference the service CA in orchestrator kube-rbac-proxy

### DIFF
--- a/controllers/gorch/templates/deployment.tmpl.yaml
+++ b/controllers/gorch/templates/deployment.tmpl.yaml
@@ -6,6 +6,7 @@
             - --config-file=/etc/kube-rbac-proxy/config.yaml
             - --tls-cert-file=/etc/tls/private/tls.crt
             - --tls-private-key-file=/etc/tls/private/tls.key
+            - --upstream-ca-file=/etc/tls/ca/service-ca.crt
             - --proxy-endpoints-port={{ .HealthPort }}
             - --v=0
           ports:
@@ -45,6 +46,9 @@
           volumeMounts:
             - name: tls-certs
               mountPath: /etc/tls/private
+              readOnly: true
+            - name: tls-ca-bundle
+              mountPath: /etc/tls/ca
               readOnly: true
             - name: kube-rbac-proxy-{{ .Suffix }}-config
               mountPath: /etc/kube-rbac-proxy


### PR DESCRIPTION
## Summary by Sourcery

Enable upstream TLS verification in the orchestrator kube-rbac-proxy by mounting and referencing the service CA bundle.

Enhancements:
- Mount the service CA bundle into the kube-rbac-proxy container
- Configure the kube-rbac-proxy to use the mounted service CA for upstream TLS validation