### PR TITLE
Bugfix: Fix logging bug in Guardrails AutoConfig ServingRuntime fetch logs

### DIFF
--- a/controllers/gorch/config_generation.go
+++ b/controllers/gorch/config_generation.go
@@ -152,10 +152,12 @@ func (r *GuardrailsOrchestratorReconciler) getInferenceServicesAndServingRuntime
 	if err := r.List(ctx, &servingRuntimes, &client.ListOptions{
 		Namespace: namespace,
 	}); err != nil || len(servingRuntimes.Items) == 0 {
-		log.FromContext(ctx).Error(err, "could not list all ServingRuntimes in namespace %s", namespace)
+		if len(servingRuntimes.Items) == 0 {
+			err = fmt.Errorf("no ServingRuntimes found in namespace %s", namespace)
+		}
+		log.FromContext(ctx).Error(err, "could not list all ServingRuntimes in", "namespace", namespace)
 		return kservev1beta1.InferenceServiceList{}, v1alpha1.ServingRuntimeList{}, fmt.Errorf("could not automatically find serving runtimes: %w", err)
 	}
-
 	return inferenceServices, servingRuntimes, nil
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Differentiate between empty ServingRuntimes and list failures in error logs when fetching ServingRuntimes in a namespace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved diagnostic logging when listing runtime resources, including a clearer logged error when no ServingRuntimes are found.
  * Minor adjustments to error reporting paths to make empty-result conditions more explicit for troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->