### PR TITLE
Derestrict the metrics collected by the built-in detector service monitor

### DIFF
--- a/controllers/gorch/templates/service-monitor.tmpl.yaml
+++ b/controllers/gorch/templates/service-monitor.tmpl.yaml
@@ -11,11 +11,6 @@ spec:
               key: ''
           honorLabels: true
           interval: 30s
-          metricRelabelings:
-              - action: keep
-                regex: trustyai_guardrails_.*
-                sourceLabels:
-                    - __name__
           path: /metrics
           scheme: http
           port: detector-metrics


### PR DESCRIPTION


## Summary by Sourcery

Enhancements:
- Remove the metricRelabelings filter from the service-monitor template to allow all metrics to be scraped from the detector service

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified metric collection configuration by removing name-based filtering rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->