### PR TITLE
Autoconfig: Force autoconfig port discovery to use ISVC + ServingRuntime ports

### DIFF
--- a/controllers/gorch/config_generation.go
+++ b/controllers/gorch/config_generation.go
@@ -187,7 +187,8 @@ func (r *GuardrailsOrchestratorReconciler) extractInferenceServiceInfo(ctx conte
 	// find the predictor service that matches the ISVC
 	targetService := isvc.Name + "-predictor"
 	svc, err := getServiceByName(ctx, r.Client, targetService, namespace)
-	if err == nil {
+	if false && err == nil {
+		// to-do: dynamically chose whether we pick port from the service or Servingruntime depending on the headless/headed field of the inference config
 		port = fmt.Sprintf("%d", svc.Spec.Ports[0].Port) //warning: assumes the predictor service only has one port!
 	} else {
 		log.Error(err, fmt.Sprintf("could not find service by name %s in namespace %s, falling back to legacy URL and port extraction logic", targetService, namespace))


### PR DESCRIPTION
## Summary by Sourcery

Force autoconfig to bypass service-based port discovery and always fall back to legacy URL and port extraction logic while leaving a placeholder for future dynamic port selection

Enhancements:
- Disable predictor service port discovery to always use legacy URL and port extraction logic
- Add TODO to enable future dynamic port selection based on inference config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved port resolution for inference services to prioritize the InferenceService URL port and fall back to the matching ServingRuntime configuration when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->