### PR TITLE
Feat: Add env variable specification to GuardrailsOrch API

### DIFF
--- a/api/gorch/v1alpha1/guardrailsorchestrator_types.go
+++ b/api/gorch/v1alpha1/guardrailsorchestrator_types.go
@@ -70,6 +70,8 @@ type GuardrailsOrchestratorSpec struct {
 	// Define TLS secrets to be mounted to the orchestrator. Secrets will be mounted at /etc/tls/$SECRET_NAME
 	// +optional
 	TLSSecrets *[]string `json:"tlsSecrets,omitempty"`
+	// Define environment variables. These will be added to the orchestrator, gateway, and built-in detector pods.
+	EnvVars *[]corev1.EnvVar `json:"env,omitempty"`
 }
 
 // OTelExporter defines the environment variables for configuring the OTLP exporter.

--- a/api/gorch/v1alpha1/zz_generated.deepcopy.go
+++ b/api/gorch/v1alpha1/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -196,6 +197,17 @@ func (in *GuardrailsOrchestratorSpec) DeepCopyInto(out *GuardrailsOrchestratorSp
 			in, out := *in, *out
 			*out = make([]string, len(*in))
 			copy(*out, *in)
+		}
+	}
+	if in.EnvVars != nil {
+		in, out := &in.EnvVars, &out.EnvVars
+		*out = new([]v1.EnvVar)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make([]v1.EnvVar, len(*in))
+			for i := range *in {
+				(*in)[i].DeepCopyInto(&(*out)[i])
+			}
 		}
 	}
 }

--- a/config/crd/bases/trustyai.opendatahub.io_guardrailsorchestrators.yaml
+++ b/config/crd/bases/trustyai.opendatahub.io_guardrailsorchestrators.yaml
@@ -68,6 +68,117 @@ spec:
                 description: Boolean flag to enable/disable the guardrails sidecar
                   gateway
                 type: boolean
+              env:
+                description: Define environment variables. These will be added to
+                  the orchestrator, gateway, and built-in detector pods.
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
               guardrailsGatewayConfig:
                 description: ' Name of the configmap containing guadrails sidecar
                   gateway arguments'


### PR DESCRIPTION
Adds `env` field to the GuardrailsOrchestrator, that lets you create environment variables in the Orchestrator, Gateway, and built-in detectors pods. This is useful for specifying API tokens in the new Guardrails Orchestrator config, for example. 

```
apiVersion: trustyai.opendatahub.io/v1alpha1
kind: GuardrailsOrchestrator
metadata:
  name: custom-guardrails
  annotations:
    security.opendatahub.io/enable-auth: 'true'
spec:
  enableBuiltInDetectors: true
  enableGuardrailsGateway: true
  orchestratorConfig: orchestrator-config-custom-detectors
  guardrailsGatewayConfig: orchestrator-gateway-config-custom-detectors
  customDetectorsConfig: custom-detectors
  replicas: 1
  env:
    - name: MODEL_TOKEN
      valueFrom:
        secretKeyRef:
          name: api-token-secret
          key: token

```

## Summary by Sourcery

Enable users to specify environment variables for the GuardrailsOrchestrator, injecting them into orchestrator, gateway, and detector pods.

New Features:
- Add EnvVars (env) field to GuardrailsOrchestratorSpec and CRD schema to define custom environment variables

Enhancements:
- Extend the reconciler to append specified environment variables to all containers except kube-rbac-proxy
- Update deepcopy functions and API types to support the new EnvVars field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring environment variables in GuardrailsOrchestrator pods. Users can now specify environment variables with values from direct inputs, ConfigMaps, Secrets, or Kubernetes field references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->