### PR TITLE
Add manifest generation makefile rule and update README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,3 +263,14 @@ catalog-build: opm ## Build a catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
+
+# Generate the full set of manifests to deploy the TrustyAI operator, with a customizable deployment namespace and operator image
+OPERATOR_IMAGE ?= quay.io/trustyai/trustyai-service-operator:latest
+.PHONY: manifest-gen
+manifest-gen: kustomize
+	@echo "Usage: make manifest-gen NAMESPACE=<namespace> OPERATOR_IMAGE=<image>"
+	@echo "Example: make manifest-gen NAMESPACE=my-namespace OPERATOR_IMAGE=quay.io/myorg/trustyai-service-operator:latest"
+	mkdir -p release
+	@if [ -z "$(NAMESPACE)" ]; then echo "Error: NAMESPACE argument is required"; exit 1; fi
+	$(KUSTOMIZE) build config/base | sed "s|namespace: system|namespace: $(NAMESPACE)|g" | sed "s|quay.io/trustyai/trustyai-service-operator:latest|$(OPERATOR_IMAGE)|g" > release/trustyai_bundle.yaml
+	@echo "Release manifest generated at release/trustyai_bundle.yaml with namespace '$(NAMESPACE)' and operator image '$(OPERATOR_IMAGE)'"


### PR DESCRIPTION
## Summary by Sourcery

Add a makefile target to generate a deployable operator manifest and update the README to reflect the new installation and usage flow for the TrustyAI Kubernetes Operator and related components.

New Features:
- Introduce a manifest generation make target that outputs a single release bundle with configurable namespace and operator image.

Enhancements:
- Revise the README to describe managing multiple TrustyAI-related components and to document the new manifest-based installation workflow while delegating detailed usage to external OpenDataHub documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a make target to generate a pre-built operator bundle (use make manifest-gen) and a configurable operator image variable for the bundle.

* **Documentation**
  * Expanded scope to describe TrustyAI Service, FMS-Guardrails, and LM-Eval with brief role summaries.
  * Streamlined installation to a bundle-based workflow and redirected usage examples to external documentation.

* **Chores**
  * Improved build tooling to produce release manifest bundles.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->