### PR TITLE
Bugfix: Ensure serviceaccount name is consistent in orchestrator cluster role

### DIFF
--- a/controllers/gorch/guardrailsorchestrator_controller.go
+++ b/controllers/gorch/guardrailsorchestrator_controller.go
@@ -204,7 +204,7 @@ func (r *GuardrailsOrchestratorReconciler) Reconcile(ctx context.Context, req ct
 		}
 	}
 
-	err = utils.ReconcileServiceAccount(ctx, r.Client, orchestrator, orchestrator.Name+"-serviceaccount", serviceAccountTemplatePath, templateParser.ParseResource)
+	err = utils.ReconcileServiceAccount(ctx, r.Client, orchestrator, getServiceAccountName(orchestrator), serviceAccountTemplatePath, templateParser.ParseResource)
 	if err != nil {
 		r.handleReconciliationError(ctx, log, orchestrator, err, utils.ReconcileFailed, "Failed to get reconcile serviceAccount")
 		return ctrl.Result{}, err
@@ -213,7 +213,7 @@ func (r *GuardrailsOrchestratorReconciler) Reconcile(ctx context.Context, req ct
 	clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
 	err = r.Get(ctx, types.NamespacedName{Name: getClusterRoleName(orchestrator), Namespace: orchestrator.Namespace}, clusterRoleBinding)
 	if err != nil && errors.IsNotFound(err) {
-		clusterRoleBinding = r.createClusterRoleBinding(orchestrator, orchestrator.GetName())
+		clusterRoleBinding = r.createClusterRoleBinding(orchestrator)
 	}
 	err = utils.ReconcileClusterRoleBinding(ctx, r.Client, clusterRoleBinding)
 	if err != nil {

--- a/controllers/gorch/role.go
+++ b/controllers/gorch/role.go
@@ -15,8 +15,13 @@ func getClusterRoleName(orchestrator *gorchv1alpha1.GuardrailsOrchestrator) stri
 	return orchestrator.Name + "-" + orchestrator.Namespace + "-auth-delegator"
 }
 
+// getServiceAccountName creates a service account name from the orchestrator name
+func getServiceAccountName(orchestrator *gorchv1alpha1.GuardrailsOrchestrator) string {
+	return orchestrator.Name + "-serviceaccount"
+}
+
 // createClusterRoleBinding creates a cluster role binding for the orchestrator oauth service account
-func (r *GuardrailsOrchestratorReconciler) createClusterRoleBinding(orchestrator *gorchv1alpha1.GuardrailsOrchestrator, serviceAccountName string) *rbacv1.ClusterRoleBinding {
+func (r *GuardrailsOrchestratorReconciler) createClusterRoleBinding(orchestrator *gorchv1alpha1.GuardrailsOrchestrator) *rbacv1.ClusterRoleBinding {
 	crb := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: getClusterRoleName(orchestrator),
@@ -29,7 +34,7 @@ func (r *GuardrailsOrchestratorReconciler) createClusterRoleBinding(orchestrator
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
-				Name:      serviceAccountName,
+				Name:      getServiceAccountName(orchestrator),
 				Namespace: orchestrator.Namespace,
 			},
 		},


### PR DESCRIPTION
## Summary by Sourcery

Ensure consistent derivation and use of the orchestrator service account name across service account reconciliation and cluster role binding creation.

Bug Fixes:
- Fix mismatch between the service account name used in service account reconciliation and the name referenced in the cluster role binding subjects.

Enhancements:
- Introduce a helper function to generate the orchestrator service account name and reuse it in reconciliation logic to centralize naming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of ServiceAccount naming and ClusterRoleBinding construction to centralize name derivation and simplify binding creation. No changes to behavior or error handling; reconciliation flow remains unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->