### PR TITLE
chore(RHOAIENG-41993): Add missing Garak image to base and ODH overlays

### DIFF
--- a/config/base/params.env
+++ b/config/base/params.env
@@ -14,4 +14,5 @@ lmes-allow-code-execution=true
 guardrails-orchestrator-image=quay.io/trustyai/ta-guardrails-orchestrator:latest
 guardrails-built-in-detector-image=quay.io/trustyai/guardrails-detector-built-in:latest
 guardrails-sidecar-gateway-image=quay.io/trustyai/guardrails-sidecar-gateway:latest
+garak-provider-image=quay.io/trustyai/llama-stack-provider-trustyai-garak:latest
 nemo-guardrails-image=quay.io/trustyai/nemo-guardrails-server:latest

--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -15,4 +15,5 @@ guardrails-orchestrator-image=quay.io/opendatahub/ta-guardrails-orchestrator:lat
 guardrails-built-in-detector-image=quay.io/opendatahub/odh-built-in-detector:latest
 guardrails-sidecar-gateway-image=quay.io/opendatahub/vllm-orchestrator-gateway:latest
 ragas-provider-image=quay.io/opendatahub/llama-stack-provider-ragas:latest
+garak-provider-image=quay.io/trustyai/llama-stack-provider-trustyai-garak:latest
 nemo-guardrails-image=quay.io/trustyai/nemo-guardrails-server:latest


### PR DESCRIPTION
## Summary by Sourcery

Add configuration entries for the Garak image to both the base and ODH overlay parameter files.

Deployment:
- Configure the Garak container image in base deployment parameters and propagate it to the ODH overlay parameters.

Chores:
- Align image parameter files by including the missing Garak image definition in base and ODH overlays.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new configurable environment variable for provider image management across base and environment-specific configurations, enabling flexible customization of deployment components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->