### PR TITLE
refactor: Allow Tier 1/2 tests to run on all work branches

### DIFF
--- a/.github/workflows/controller-tests.yaml
+++ b/.github/workflows/controller-tests.yaml
@@ -1,4 +1,4 @@
-name: Controller Tests
+name: Tier 1 - Controller tests
 
 on: [push, pull_request]
 

--- a/.github/workflows/gosec.yaml
+++ b/.github/workflows/gosec.yaml
@@ -1,9 +1,9 @@
 ---
-name: Gosec Security Scan
+name: Tier 1 - Gosec security scan
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, incubation, stable]
 
 jobs:
   gosec:

--- a/.github/workflows/lint-yaml.yaml
+++ b/.github/workflows/lint-yaml.yaml
@@ -1,4 +1,4 @@
-name: YAML lint
+name: Tier 1 - YAML lint
 
 on: [push, pull_request]
 

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -1,5 +1,5 @@
 ---
-name: Security Scan
+name: Tier 1 - Security scan
 
 on:
   pull_request:

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -1,9 +1,11 @@
-name: Smoke test
+name: Tier 2 - Smoke test
 
 on:
   pull_request:
     branches:
       - main
+      - incubation
+      - stable
 
 jobs:
   deploy:


### PR DESCRIPTION
Change GitHub Actions workflows to run on PRs targeting incubation and stable branches in addition to main.

#### Changes

  - Trivy Security Scan: Added incubation, stable to PR/push triggers
  - Gosec Security Scan: Added incubation, stable to PR triggers
  - Smoke Test: Added incubation, stable to PR triggers

Security scans and smoke tests now run on PRs targeting all primary branches (main, incubation, stable) instead of only main.

## Summary by Sourcery

Expand CI workflows to run Tier 1 and Tier 2 checks across all primary branches.

CI:
- Run security scan workflow on pull requests and pushes targeting main, incubation, and stable branches instead of only main.
- Run Gosec security scan on pull requests targeting main, incubation, and stable branches.
- Run smoke tests on pull requests targeting main, incubation, and stable branches.
- Standardize workflow names to include their respective Tier designations for easier identification in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Reorganized GitHub Actions workflows with standardized naming conventions (Tier 1, Tier 2) for improved clarity
* Expanded automated testing coverage to additional development branches (incubation, stable) for enhanced quality assurance across the development pipeline

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->