### PR TITLE
fix: Make orchestrator replicas configurable

### DIFF
--- a/api/gorch/v1alpha1/guardrailsorchestrator_types.go
+++ b/api/gorch/v1alpha1/guardrailsorchestrator_types.go
@@ -42,7 +42,9 @@ type GuardrailsOrchestratorSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 	// Number of replicas
-	Replicas int32 `json:"replicas"`
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:default=1
+	Replicas int32 `json:"replicas,omitempty"`
 	// Name of configmap containing generator, detector, and chunker arguments
 	// +optional
 	OrchestratorConfig *string `json:"orchestratorConfig,omitempty"`

--- a/config/crd/bases/trustyai.opendatahub.io_guardrailsorchestrators.yaml
+++ b/config/crd/bases/trustyai.opendatahub.io_guardrailsorchestrators.yaml
@@ -216,11 +216,13 @@ spec:
                     type: string
                 type: object
               replicas:
+                default: 1
                 description: |-
                   INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
                   Important: Run "make" to regenerate code after modifying this file
                   Number of replicas
                 format: int32
+                minimum: 1
                 type: integer
               tlsSecrets:
                 description: Define TLS secrets to be mounted to the orchestrator.
@@ -228,8 +230,6 @@ spec:
                 items:
                   type: string
                 type: array
-            required:
-            - replicas
             type: object
           status:
             properties:

--- a/controllers/gorch/templates/deployment.tmpl.yaml
+++ b/controllers/gorch/templates/deployment.tmpl.yaml
@@ -67,7 +67,7 @@ metadata:
     app.kubernetes.io/name: {{.Orchestrator.Name}}
     app.kubernetes.io/part-of: trustyai
 spec:
-  replicas: 1
+  replicas: {{.Orchestrator.Spec.Replicas}}
   selector:
     matchLabels:
       app: {{.Orchestrator.Name}}


### PR DESCRIPTION
This PR addresses #622 by making the orchestrator replicas configurable via the GORCH CR

## Summary by Sourcery

Make GuardrailsOrchestrator replica count configurable via the CRD and use it in the generated deployment.

New Features:
- Allow configuring the GuardrailsOrchestrator deployment replica count through the GuardrailsOrchestrator custom resource spec.

Enhancements:
- Set a default replica count of 1 with a minimum of 1 in the GuardrailsOrchestrator CRD schema and API type.
- Update the orchestrator deployment template to derive the replica count from the GuardrailsOrchestrator spec instead of hardcoding it to 1.

Tests:
- Add controller tests to verify that a GuardrailsOrchestrator with a custom replica count creates a deployment with the expected number of replicas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Orchestrator replica count is now optional, configurable, and defaults to 1 with validation enforcing a minimum of 1.

* **Improvements**
  * Deployments now use the configured replica count, preserve config annotations, apply TLS mounts consistently on create/update, and patch only when actual changes are detected.

* **Tests**
  * Added tests for custom replica counts, scaling behavior, and resource cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->