### PR TITLE
fix: e2e CI test timeout

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -27,6 +27,7 @@ COPY Pipfile Pipfile.lock $HOME/peak/
 ## Grab CI script from single-source-of-truth, modify for operator usage
 RUN wget -O installandtest.sh "https://raw.githubusercontent.com/trustyai-explainability/trustyai-explainability/refs/heads/main/tests/installandtest.sh" && \
     sed -i 's/$REPO_NAME != "trustyai-explainability"/$REPO_NAME != "trustyai-service-operator"/g' installandtest.sh && \
+    sed -i 's/$REPO_NAME == "trustyai-explainability"/$REPO_NAME == "trustyai-service-operator"/g' installandtest.sh && \
     sed -i 's%trustyai-explainability/pulls/%trustyai-service-operator/pulls/%g' installandtest.sh && \
     sed -i 's%tarball/service%tarball/operator%g' installandtest.sh && \
     cp installandtest.sh $HOME/peak


### PR DESCRIPTION
The e2e CI tests are currently failing for all PRs bc TrustyAI with custom manifests are not configured properly in the DSC:
```
INFO:__main__:Using manifests from 

'trustyai': {
  'managementState': 'Managed',
  'devFlags': {
    'manifests': [{'contextDir': 'config', 'sourcePath': '', 'uri': None}] # missing uri
  }
}
```

Upon investigation, it looks like the `tests/Dockerfile` is not passing the right repo name, `trustyai-service-operator`, to the `installandtest.sh` script:
```
# line 29 on tests/Dockerfile only modifies != condition:
# Line 29: s/$REPO_NAME != "trustyai-explainability"/$REPO_NAME != "trustyai-service-operator"/g

if [ ! -z $TRUSTYAI_MANIFESTS_REPO ]; then
    echo "Using provided TRUSTYAI_MANIFESTS_REPO"  
elif [ -z "$PULL_NUMBER" ] || [ $REPO_OWNER != "trustyai-explainability" ] || [ $REPO_NAME != "trustyai-service-operator" ]; then
  TRUSTYAI_MANIFESTS_REPO=https://github.com/.../tarball/main
else
  if [ $REPO_NAME == "trustyai-explainability" ]; then   # <-- STILL checks for trustyai-explainability!
    TRUSTYAI_MANIFESTS_REPO=https://api.github.com/.../tarball/operator-${BRANCH_SHA}
  fi
```

**TLDR:** This PR addresses this bug by adding another `sed` command to replace REPO_NAME == "trustyai-explainability" with REPO_NAME == "trustyai-service-operator" in the `else` statement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to support validation of additional components in the testing pipeline.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->