### PR TITLE
fix: Update urllib3 to 2.6.3

### DIFF
--- a/tests/Pipfile
+++ b/tests/Pipfile
@@ -7,7 +7,7 @@ verify_ssl = true
 
 [packages]
 selenium = "*"
-urllib3 = "==2.6.0"
+urllib3 = "==2.6.3"
 
 [requires]
 python_version = "3.12"

--- a/tests/Pipfile.lock
+++ b/tests/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "456395538d4e7b65f5e9463183efd43202a6636ef13c1d05e91dd8425aa24d0b"
+            "sha256": "a40534352bcf123898c62c41c1adfc9527e23aede7f02bbbf8834d94047d96da"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -118,12 +118,12 @@
                 "socks"
             ],
             "hashes": [
-                "sha256:c90f7a39f716c572c4e3e58509581ebd83f9b59cced005b7db7ad2d22b0db99f",
-                "sha256:cb9bcef5a4b345d5da5d145dc3e30834f58e8018828cbc724d30b4cb7d4d49f1"
+                "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed",
+                "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==2.6.0"
+            "version": "==2.6.3"
         },
         "websocket-client": {
             "hashes": [


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Bump urllib3 in the test environment Pipfile from 2.6.0 to 2.6.3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test dependencies to enhance stability and security of the testing environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->