### PR TITLE
ci(workflow): run image build only on upstream

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -11,7 +11,7 @@ on:
       - "**.md"
       - "**.adoc"
       - "*.txt"
-  pull_request_target:
+  pull_request:
     paths-ignore:
       - "LICENSE"
       - "**/.gitignore"
@@ -47,12 +47,15 @@ jobs:
           mode: minimum
           count: 1
           labels: "ok-to-test, lgtm, approved"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: env.BUILD_CONTEXT == 'ci'
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/checkout@v3
+          persist-credentials: false
+      - uses: actions/checkout@v4
         if: env.BUILD_CONTEXT == 'main' ||  env.BUILD_CONTEXT == 'tag'
+        with:
+          persist-credentials: false
       #
       - name: Set main-branch/default environment
         run: |


### PR DESCRIPTION
## Summary by Sourcery

Adjust CI workflow triggers and checkout configuration for image build jobs.

CI:
- Run the image build workflow on pull_request events instead of pull_request_target.
- Upgrade checkout actions from v3 to v4 and disable credential persistence for CI, main, and tag contexts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow with latest action versions and enhanced security improvements to minimize credential exposure during builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->