### PR TITLE
bug(RHOAIENG-45571): Fix readinessProbe formatting & health port

### DIFF
--- a/controllers/gorch/templates/deployment.tmpl.yaml
+++ b/controllers/gorch/templates/deployment.tmpl.yaml
@@ -208,18 +208,18 @@ spec:
             allowPrivilegeEscalation: false
             seccompProfile:
               type: RuntimeDefault
-            readinessProbe:
-              httpGet:
-                path: /health
-                port: 8033
-                scheme: HTTP
-              initialDelaySeconds: 10
-              timeoutSeconds: 10
-              periodSeconds: 20
-              successThreshold: 1
-              failureThreshold: 3
-            terminationMessagePath: /dev/termination-log
-            command:
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8034
+              scheme: HTTP
+            initialDelaySeconds: 10
+            timeoutSeconds: 10
+            periodSeconds: 20
+            successThreshold: 1
+            failureThreshold: 3
+          terminationMessagePath: /dev/termination-log
+          command:
               - /app/bin/fms-guardrails-orchestr8
         {{- if .OrchestratorKubeRBACProxy }}
         - {{- template "kubeRBACProxy" .OrchestratorKubeRBACProxy }}


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct the readiness probe HTTP port and indentation for the gorch orchestrator container in the deployment template.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated health check port configuration in deployment settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->