### PR TITLE
feat: Add SERVICE_URL environment variable to operator deployment

### DIFF
--- a/controllers/evalhub/deployment.go
+++ b/controllers/evalhub/deployment.go
@@ -109,6 +109,10 @@ func (r *EvalHubReconciler) buildDeploymentSpec(ctx context.Context, instance *e
 			Name:  "PROVIDERS_CONFIG_PATH",
 			Value: "/etc/evalhub/providers.yaml",
 		},
+		{
+			Name:  "SERVICE_URL",
+			Value: fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", instance.Name, instance.Namespace),
+		},
 	}
 
 	// Merge environment variables with CR values taking precedence

--- a/controllers/evalhub/deployment_test.go
+++ b/controllers/evalhub/deployment_test.go
@@ -164,6 +164,7 @@ var _ = Describe("EvalHub Deployment", func() {
 			Expect(envVars["MAX_CONCURRENT_EVALUATIONS"]).To(Equal("10"))
 			Expect(envVars["DEFAULT_TIMEOUT_MINUTES"]).To(Equal("60"))
 			Expect(envVars["MAX_RETRY_ATTEMPTS"]).To(Equal("3"))
+			Expect(envVars["SERVICE_URL"]).To(Equal(fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", evalHubName, testNamespace)))
 		})
 
 		It("should include custom environment variables", func() {


### PR DESCRIPTION
Refer to [RHOAIENG-48376](https://issues.redhat.com/browse/RHOAIENG-48376).

## Summary by Sourcery

Add a SERVICE_URL environment variable to the EvalHub operator deployment and cover it with tests.

New Features:
- Expose a SERVICE_URL environment variable on the EvalHub deployment derived from the instance name and namespace.

Tests:
- Extend EvalHub deployment tests to verify the SERVICE_URL environment variable is set correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployments now automatically include a SERVICE_URL environment variable that provides internal cluster service discovery capabilities. This variable is automatically configured using the deployment's name and namespace, enabling applications to connect to services without manual configuration.
* **Tests**
  * Added test coverage to verify the SERVICE_URL environment variable is correctly configured in deployment default environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->