### PR TITLE
fix(gorch): add HAProxy timeout annotations to prevent 504 errors

### DIFF
--- a/controllers/gorch/route.go
+++ b/controllers/gorch/route.go
@@ -22,6 +22,11 @@ func (r *GuardrailsOrchestratorReconciler) reconcileGatewayRoute(ctx context.Con
 		ServiceName: orchestrator.Name + "-service",
 		PortName:    "gateway",
 		Termination: utils.StringPointer(gatewayTermination),
+		Annotations: map[string]string{
+			// Fix for RHOAIENG-33054: Set HAProxy timeout to 5 minutes
+			// Gateway route handles LLM traffic that can exceed default 30s timeout
+			"haproxy.router.openshift.io/timeout": "5m",
+		},
 	}
 	err := utils.ReconcileRoute(ctx, r.Client, orchestrator, routeConfig, routeTemplatePath, templateParser.ParseResource)
 	return err
@@ -33,6 +38,11 @@ func (r *GuardrailsOrchestratorReconciler) reconcileOrchestratorRoute(ctx contex
 		ServiceName: orchestrator.Name + "-service",
 		PortName:    "https",
 		Termination: utils.StringPointer(utils.Reencrypt),
+		Annotations: map[string]string{
+			// Fix for RHOAIENG-33054: Set HAProxy timeout to 5 minutes
+			// LLM-based guardrails detection can take longer than the default 30s
+			"haproxy.router.openshift.io/timeout": "5m",
+		},
 	}
 	err := utils.ReconcileRoute(ctx, r.Client, orchestrator, routeConfig, routeTemplatePath, templateParser.ParseResource)
 	return err
@@ -48,6 +58,11 @@ func (r *GuardrailsOrchestratorReconciler) reconcileBuiltInDetectorRoute(ctx con
 		ServiceName: orchestrator.Name + "-service",
 		PortName:    "built-in-detector",
 		Termination: utils.StringPointer(termination),
+		Annotations: map[string]string{
+			// Fix for RHOAIENG-33054: Set HAProxy timeout to 5 minutes
+			// Built-in detector route handles LLM traffic that can exceed default 30s timeout
+			"haproxy.router.openshift.io/timeout": "5m",
+		},
 	}
 	err := utils.ReconcileRoute(ctx, r.Client, orchestrator, routeConfig, routeTemplatePath, templateParser.ParseResource)
 	return err

--- a/controllers/gorch/templates/route.tmpl.yaml
+++ b/controllers/gorch/templates/route.tmpl.yaml
@@ -6,6 +6,12 @@ metadata:
   labels:
     app: {{.Owner.Name}}
     component: {{.Owner.Name}}
+{{- if .Annotations}}
+  annotations:
+{{- range $key, $value := .Annotations}}
+    {{$key}}: {{$value}}
+{{- end}}
+{{- end}}
 spec:
   to:
     kind: Service

--- a/controllers/utils/route.go
+++ b/controllers/utils/route.go
@@ -20,6 +20,7 @@ type RouteConfig struct {
 	Owner       *metav1.Object
 	PortName    string
 	Termination *string
+	Annotations map[string]string // Fix for RHOAIENG-33054: HAProxy timeout annotations
 }
 
 const (


### PR DESCRIPTION
The Guardrails Orchestrator routes were returning 504 Gateway Timeout errors after 30 seconds when LLM-based guardrails detection took longer to process. This occurred because OpenShift's HAProxy router enforces a default 30-second timeout on routes without explicit annotations.

This fix adds a 5-minute timeout annotation to three LLM-facing routes:
- Orchestrator route (port 8032) - main API endpoint for chat/completions-detection
- Gateway route - handles sidecar gateway LLM traffic
- Built-in detector route - handles built-in detector LLM calls

Changes:
- Added Annotations field to RouteConfig struct (controllers/utils/route.go)
- Updated route template to conditionally render annotations (controllers/gorch/templates/route.tmpl.yaml)
- Set haproxy.router.openshift.io/timeout: 5m on three route reconciliation functions

The 5-minute timeout allows slow LLM inference to complete while preventing truly hung connections from lingering indefinitely. This is a backward-compatible change that takes effect when the operator reconciles existing GuardrailsOrchestrator resources.

Fixes [RHOAIENG-33054](https://redhat.atlassian.net/browse/RHOAIENG-33054)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended route configuration infrastructure to support custom metadata annotations, enabling greater flexibility in route behavior management and deployment configuration.
  * Implemented conditional annotation rendering in route templates to ensure proper handling of annotations during route deployment and reconciliation processes.
  * Added timeout configuration support for routes, allowing operators to fine-tune request handling behavior and improve overall system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->