### PR TITLE
fix: followup to #703 align tests

### DIFF
--- a/controllers/evalhub/rbac_manifests_test.go
+++ b/controllers/evalhub/rbac_manifests_test.go
@@ -14,7 +14,7 @@ import (
 func TestEvalHubJobConfigClusterRoleVerbsAreMinimalAndSufficient(t *testing.T) {
 	// EvalHub sets ConfigMap ownerReferences after creating the Job:
 	// it does a Get+Update on the ConfigMap (see eval-hub/internal/runtimes/k8s/k8s_helper.go:SetConfigMapOwner).
-	// Therefore the job-config ClusterRole must include: create,get,update,delete.
+	// Therefore the job-config ClusterRole must include: create,get,list,update,delete.
 	_, thisFile, _, ok := runtime.Caller(0)
 	if !ok {
 		t.Fatal("runtime.Caller failed")
@@ -51,7 +51,7 @@ func TestEvalHubJobConfigClusterRoleVerbsAreMinimalAndSufficient(t *testing.T) {
 		t.Fatalf("expected %s to contain a policy rule for resource 'configmaps'", manifestPath)
 	}
 
-	wantVerbs := []string{"create", "delete", "get", "update"}
+	wantVerbs := []string{"create", "delete", "get", "list", "update"}
 	sort.Strings(gotVerbs)
 	sort.Strings(wantVerbs)
 


### PR DESCRIPTION
the PR:

- https://github.com/trustyai-explainability/trustyai-service-operator/pull/703

> The evalhub-jobs-writer and evalhub-job-config ClusterRoles were missing the list verb. DeleteEvaluationJobResources uses a list-then-delete pattern (find Jobs/ConfigMaps by label selector, then delete each). Without list, the calls fail silently and cancelled/deleted jobs keep running until TTL expiry (1 hour default).

was merged with failing errors:

<img width="1139" height="66" alt="image" src="https://github.com/user-attachments/assets/51c7f121-fd6e-4278-acbe-cc584aa5a420" />

align tests to suit, the screenshot above was breaking in:

https://github.com/trustyai-explainability/trustyai-service-operator/actions/runs/24012326244/job/70025852637
