### PR TITLE
bug: Config patching not inducing a re-deploy of the NeMo Guardrails server

### DIFF
--- a/controllers/nemo_guardrails/deployment.go
+++ b/controllers/nemo_guardrails/deployment.go
@@ -2,7 +2,11 @@ package nemo_guardrails
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
+	"reflect"
+	"sort"
+
 	nemoguardrailsv1alpha1 "github.com/trustyai-explainability/trustyai-service-operator/api/nemo_guardrails/v1alpha1"
 	"github.com/trustyai-explainability/trustyai-service-operator/controllers/constants"
 	templateParser "github.com/trustyai-explainability/trustyai-service-operator/controllers/nemo_guardrails/templates"
@@ -10,7 +14,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -64,6 +67,9 @@ func (r *NemoGuardrailsReconciler) mountNemoConfigs(ctx context.Context, nemoGua
 	var defaultConfig string
 	defaultAlreadyChosen := false
 
+	// Accumulate a hash of all ConfigMap names and data to detect content changes
+	hasher := sha256.New()
+
 	for idx, nemoConfig := range nemoGuardrails.Spec.NemoConfigs {
 		// Take the first config as default for now. If any config manually specifies default-ness, we'll override this
 		if idx == 0 {
@@ -79,6 +85,19 @@ func (r *NemoGuardrailsReconciler) mountNemoConfigs(ctx context.Context, nemoGua
 				utils.LogErrorRetrieving(ctx, err, "configmap", configCM, deployment.Namespace)
 				return err
 			}
+
+			// Include ConfigMap name and data in hash for change detection
+			hasher.Write([]byte(configCM))
+			keys := make([]string, 0, len(configmap.Data))
+			for k := range configmap.Data {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			for _, k := range keys {
+				hasher.Write([]byte(k))
+				hasher.Write([]byte(configmap.Data[k]))
+			}
+
 			volumeName := fmt.Sprintf("%s-%s-volume", nemoConfig.Name, configCM)
 			utils.MountConfigMapToDeployment(configmap, volumeName, deployment)
 			volumeMount := corev1.VolumeMount{
@@ -107,6 +126,13 @@ func (r *NemoGuardrailsReconciler) mountNemoConfigs(ctx context.Context, nemoGua
 	if !defaultAlreadyChosen {
 		log.FromContext(ctx).Info(fmt.Sprintf("no NemoConfigs were marked as default, using '%s' as default", defaultConfig))
 	}
+
+	// Set ConfigMap content hash as a pod template annotation to trigger rollout on changes
+	configHash := fmt.Sprintf("%x", hasher.Sum(nil))
+	if deployment.Spec.Template.Annotations == nil {
+		deployment.Spec.Template.Annotations = make(map[string]string)
+	}
+	deployment.Spec.Template.Annotations["trustyai.opendatahub.io/nemo-config-hash"] = configHash
 
 	// Set default config
 	deployment.Spec.Template.Spec.Containers[0].Env = append(

--- a/controllers/nemo_guardrails/nemoguardrail_controller.go
+++ b/controllers/nemo_guardrails/nemoguardrail_controller.go
@@ -25,15 +25,19 @@ import (
 	templateParser "github.com/trustyai-explainability/trustyai-service-operator/controllers/nemo_guardrails/templates"
 	"github.com/trustyai-explainability/trustyai-service-operator/controllers/utils"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 // NemoGuardrailReconciler reconciles a NemoGuardrails object
@@ -209,6 +213,40 @@ func (r *NemoGuardrailsReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 func (r *NemoGuardrailsReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&nemoguardrailsv1alpha1.NemoGuardrails{}).
+		// Watch for changes to ConfigMaps referenced by NemoGuardrails CRs.
+		// OnlyMetadata caches only object metadata (~1KB each) instead of full
+		// objects, preventing OOM when many ConfigMaps exist cluster-wide.
+		Watches(
+			&corev1.ConfigMap{},
+			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
+				var requests []ctrl.Request
+				var nemoGuardrailsList nemoguardrailsv1alpha1.NemoGuardrailsList
+				if err := r.List(ctx, &nemoGuardrailsList, &client.ListOptions{Namespace: obj.GetNamespace()}); err != nil {
+					return nil
+				}
+				for _, ng := range nemoGuardrailsList.Items {
+					for _, nemoConfig := range ng.Spec.NemoConfigs {
+						for _, cmName := range nemoConfig.ConfigMaps {
+							if cmName == obj.GetName() {
+								requests = append(requests, ctrl.Request{
+									NamespacedName: types.NamespacedName{
+										Name:      ng.Name,
+										Namespace: ng.Namespace,
+									},
+								})
+							}
+						}
+					}
+				}
+				return requests
+			}),
+			builder.WithPredicates(predicate.Or(
+				predicate.AnnotationChangedPredicate{},
+				predicate.ResourceVersionChangedPredicate{},
+				predicate.GenerationChangedPredicate{},
+			)),
+			builder.OnlyMetadata,
+		).
 		Complete(r)
 }
 

--- a/controllers/nemo_guardrails/nemoguardrail_controller_test.go
+++ b/controllers/nemo_guardrails/nemoguardrail_controller_test.go
@@ -310,6 +310,117 @@ var _ = Describe("NemoGuardrails Controller", func() {
 		}, time.Second*10, time.Millisecond*100).Should(Equal(int32(3)))
 	})
 
+	It("should set a config hash annotation on the deployment pod template", func() {
+		controllerReconciler := &NemoGuardrailsReconciler{
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			Namespace: operatorNamespace,
+		}
+		_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Checking if the Deployment has the config hash annotation")
+		Eventually(func() string {
+			deployment := &appsv1.Deployment{}
+			err := k8sClient.Get(ctx, typeNamespacedName, deployment)
+			if err != nil {
+				return ""
+			}
+			return deployment.Spec.Template.Annotations["trustyai.opendatahub.io/nemo-config-hash"]
+		}, time.Second*10, time.Millisecond*100).ShouldNot(BeEmpty())
+	})
+
+	It("should update the deployment when ConfigMap content changes", func() {
+		controllerReconciler := &NemoGuardrailsReconciler{
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			Namespace: operatorNamespace,
+		}
+
+		By("Performing initial reconciliation")
+		_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Recording the initial config hash")
+		var initialHash string
+		Eventually(func() string {
+			deployment := &appsv1.Deployment{}
+			err := k8sClient.Get(ctx, typeNamespacedName, deployment)
+			if err != nil {
+				return ""
+			}
+			initialHash = deployment.Spec.Template.Annotations["trustyai.opendatahub.io/nemo-config-hash"]
+			return initialHash
+		}, time.Second*10, time.Millisecond*100).ShouldNot(BeEmpty())
+
+		By("Updating the ConfigMap content")
+		configMap := &corev1.ConfigMap{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "nemo-config", Namespace: namespace}, configMap)).To(Succeed())
+		configMap.Data["config.yaml"] = "updated: config"
+		Expect(k8sClient.Update(ctx, configMap)).To(Succeed())
+
+		By("Reconciling again after ConfigMap change")
+		_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Checking that the config hash annotation has changed")
+		Eventually(func() bool {
+			deployment := &appsv1.Deployment{}
+			err := k8sClient.Get(ctx, typeNamespacedName, deployment)
+			if err != nil {
+				return false
+			}
+			newHash := deployment.Spec.Template.Annotations["trustyai.opendatahub.io/nemo-config-hash"]
+			return newHash != "" && newHash != initialHash
+		}, time.Second*10, time.Millisecond*100).Should(BeTrue())
+	})
+
+	It("should not update the deployment when ConfigMap content is unchanged", func() {
+		controllerReconciler := &NemoGuardrailsReconciler{
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			Namespace: operatorNamespace,
+		}
+
+		By("Performing initial reconciliation")
+		_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Recording the initial config hash and resource version")
+		var initialHash string
+		var initialResourceVersion string
+		Eventually(func() string {
+			deployment := &appsv1.Deployment{}
+			err := k8sClient.Get(ctx, typeNamespacedName, deployment)
+			if err != nil {
+				return ""
+			}
+			initialHash = deployment.Spec.Template.Annotations["trustyai.opendatahub.io/nemo-config-hash"]
+			initialResourceVersion = deployment.ResourceVersion
+			return initialHash
+		}, time.Second*10, time.Millisecond*100).ShouldNot(BeEmpty())
+
+		By("Reconciling again without any changes")
+		_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Checking that the deployment was not updated")
+		deployment := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, typeNamespacedName, deployment)).To(Succeed())
+		Expect(deployment.Spec.Template.Annotations["trustyai.opendatahub.io/nemo-config-hash"]).To(Equal(initialHash))
+		Expect(deployment.ResourceVersion).To(Equal(initialResourceVersion))
+	})
+
 	It("should create a ServiceAccount and ClusterRoleBinding and delete them when the instance is deleted", func() {
 		controllerReconciler := &NemoGuardrailsReconciler{
 			Client:    k8sClient,


### PR DESCRIPTION
This PR addresses [RHOAIENG-58156](https://redhat.atlassian.net/browse/RHOAIENG-58156)

The controller did not redeploy pods when referenced ConfigMap data changed, since the deployment spec remained identical. This adds a SHA256 hash of all ConfigMap names and content as a pod template annotation, and watches referenced ConfigMaps to trigger immediate reconciliation on changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployments now automatically detect ConfigMap content changes and trigger updates via hash-based tracking.

* **Tests**
  * Added test cases validating that Deployments update when ConfigMap content changes and remain stable when ConfigMaps are unmodified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->