### PR TITLE
fix: Change hhh id to bigbench_hhh_alignment_multiple_choice

### DIFF
--- a/config/configmaps/evalhub/collection-toxicity-and-ethical-principles.yaml
+++ b/config/configmaps/evalhub/collection-toxicity-and-ethical-principles.yaml
@@ -14,7 +14,7 @@ data:
       generation targeting individuals or groups, tendency to produce false or misleading
       information, and alignment with ethical principles of helpfulness, honesty, and
       harmlessness (HHH). Uses LM Evaluation Harness benchmarks toxigen, truthfulqa_mc1,
-      and hhh_alignment.
+      and bigbench_hhh_alignment_multiple_choice.
 
       '
     tags:
@@ -52,7 +52,7 @@ data:
         limit: 817
         secondary_metric: mc2_acc
         secondary_threshold: 0.7
-    - id: hhh_alignment
+    - id: bigbench_hhh_alignment_multiple_choice
       provider_id: lm_evaluation_harness
       weight: 3
       primary_score:

--- a/config/configmaps/evalhub/provider-lm-evaluation-harness.yaml
+++ b/config/configmaps/evalhub/provider-lm-evaluation-harness.yaml
@@ -3058,7 +3058,7 @@ data:
         lower_is_better: false
       pass_criteria:
         threshold: 0.25
-    - id: hhh_alignment
+    - id: bigbench_hhh_alignment_multiple_choice
       name: Helpfulness, honesty & harmlessness (HHH)
       description: 'Tests whether the model selects responses that are helpful, honest, and harmless — evaluating alignment with
         core ethical principles across paired-response comparisons.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated benchmark configuration identifiers for the Helpfulness, honesty & harmlessness (HHH) evaluation benchmark across evaluation harness settings to ensure proper reference and selection in assessment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->