### PR TITLE
Fix: Tune NeMo Readiness Probe for better responsiveness

### DIFF
--- a/controllers/nemo_guardrails/templates/deployment.tmpl.yaml
+++ b/controllers/nemo_guardrails/templates/deployment.tmpl.yaml
@@ -87,11 +87,11 @@ spec:
             path: /
             port: 8000
             scheme: HTTP
-          initialDelaySeconds: 10
-          timeoutSeconds: 10
-          periodSeconds: 20
+          initialDelaySeconds: 5
+          timeoutSeconds: 2
+          periodSeconds: 5
           successThreshold: 1
-          failureThreshold: 3
+          failureThreshold: 12
         ports:
         - containerPort: 8000
       {{ if .UseAuthProxy }}


### PR DESCRIPTION
The NeMo Guardrails server is typically up and running 10-30 seconds before the readiness probe 'realizes' - this PR tunes the readiness probe intervals to fix this. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined container health check configuration to improve startup readiness detection speed and reduce deployment latency. Enhanced failure tolerance thresholds increase system resilience during failover and recovery operations. These adjustments optimize cluster scaling performance and strengthen service stability during infrastructure changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->