### PR TITLE
fix(ci): enable Trivy cache to prevent binary download failures

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -49,7 +49,7 @@ jobs:
           cache: "true"
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: "trivy-results.sarif"

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -26,7 +26,7 @@ jobs:
           go-version-file: "go.mod"
 
       - name: Run Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        uses: aquasecurity/trivy-action@v0.36.0 # v0.35.0
         with:
           scan-type: "fs"
           scan-ref: "."
@@ -38,7 +38,7 @@ jobs:
           cache: "true"
 
       - name: Check for critical and high vulnerabilities
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        uses: aquasecurity/trivy-action@v0.36.0 # v0.35.0
         with:
           scan-type: "fs"
           scan-ref: "."

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -26,7 +26,7 @@ jobs:
           go-version-file: "go.mod"
 
       - name: Run Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@v0.36.0 # v0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: "fs"
           scan-ref: "."

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -37,7 +37,7 @@ jobs:
           cache: "true"
 
       - name: Check for critical and high vulnerabilities
-        uses: aquasecurity/trivy-action@v0.36.0 # v0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: "fs"
           scan-ref: "."

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -47,7 +47,7 @@ jobs:
           cache: "true"
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         if: always()
         with:
           sarif_file: "trivy-results.sarif"

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -35,7 +35,7 @@ jobs:
           severity: "CRITICAL,HIGH,MEDIUM,LOW"
           exit-code: "0"
           version: "v0.68.2"
-          cache: "false"
+          cache: "true"
 
       - name: Check for critical and high vulnerabilities
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
@@ -46,7 +46,7 @@ jobs:
           severity: "CRITICAL,HIGH"
           exit-code: "1"
           version: "v0.68.2"
-          cache: "false"
+          cache: "true"
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -34,7 +34,6 @@ jobs:
           output: "trivy-results.sarif"
           severity: "CRITICAL,HIGH,MEDIUM,LOW"
           exit-code: "0"
-          version: "v0.68.2"
           cache: "true"
 
       - name: Check for critical and high vulnerabilities
@@ -45,7 +44,6 @@ jobs:
           format: "table"
           severity: "CRITICAL,HIGH"
           exit-code: "1"
-          version: "v0.68.2"
           cache: "true"
 
       - name: Upload Trivy scan results to GitHub Security tab


### PR DESCRIPTION
## What and why

The Trivy Security Scan job was failing on every run with exit code 1 during binary installation. The `install.sh` script successfully resolved the version metadata from the GitHub API but failed when downloading the asset. Pinning `version: v0.68.2` forced this download path on every run with no fallback.

Fix: remove the hardcoded `version` pin from both `trivy-action` steps so the action uses its own default, and enable `cache: true` so the DB is cached between runs. The `upload-sarif` action is updated from `@v3` to `@v4` ahead of the December 2026 deprecation deadline.

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tested manually (CI passing on PR #717)

## Breaking changes

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning workflow actions to latest versions and enabled caching for improved CI/CD pipeline performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->