### PR TITLE
chore: Use gotoolset 1.24 for the LMEval driver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.24 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.driver
+++ b/Dockerfile.driver
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 
 WORKDIR /go/src/github.com/trustyai-explainability/trustyai-service-operator
 # Copy the Go Modules manifests


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker builder images to more recent versions for improved compatibility and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->