### PR TITLE
fix(evalhub): prevent reconcile-loop thrashing from ServiceMonitor status updates (#713 follow-up)

### DIFF
--- a/controllers/evalhub/evalhub_controller.go
+++ b/controllers/evalhub/evalhub_controller.go
@@ -221,14 +221,15 @@ func (r *EvalHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	// Reconcile monitoring resources (ServiceMonitor).
 	// Monitoring failures are non-fatal: log, set a degraded condition, and continue.
+	// The condition is set in memory only — updateStatus() at the end of the loop
+	// persists the full status in a single write, avoiding mid-reconcile status
+	// updates that would trigger unnecessary re-reconciles.
 	if r.isServiceMonitorSupported() {
 		if err := r.reconcileServiceMonitor(ctx, instance); err != nil {
 			log.Error(err, "Failed to reconcile ServiceMonitor")
 			instance.SetStatus("MonitoringDegraded", "ServiceMonitorFailed", fmt.Sprintf("Failed to reconcile ServiceMonitor: %v", err), corev1.ConditionTrue)
-			r.Status().Update(ctx, instance)
 		} else {
 			instance.SetStatus("MonitoringDegraded", "MonitoringReady", "", corev1.ConditionFalse)
-			r.Status().Update(ctx, instance)
 		}
 	} else {
 		log.Info("ServiceMonitor CRD not available on this cluster, skipping monitoring reconciliation")

--- a/controllers/evalhub/servicemonitor.go
+++ b/controllers/evalhub/servicemonitor.go
@@ -84,6 +84,10 @@ func (r *EvalHubReconciler) buildServiceMonitor(instance *evalhubv1alpha1.EvalHu
 	}
 }
 
+// reconcileServiceMonitor ensures a ServiceMonitor exists for the EvalHub instance.
+// The ServiceMonitor spec is fully derived from immutable CR fields (name, namespace),
+// so it is created once and never updated in place. If the CR is deleted, the
+// ServiceMonitor is garbage-collected via its owner reference.
 func (r *EvalHubReconciler) reconcileServiceMonitor(ctx context.Context, instance *evalhubv1alpha1.EvalHub) error {
 	log := log.FromContext(ctx)
 	log.Info("Reconciling ServiceMonitor", "name", serviceMonitorName(instance))
@@ -103,9 +107,5 @@ func (r *EvalHubReconciler) reconcileServiceMonitor(ctx context.Context, instanc
 		return err
 	}
 
-	found.Spec.Endpoints = desired.Spec.Endpoints
-	found.Spec.Selector = desired.Spec.Selector
-	found.Spec.NamespaceSelector = desired.Spec.NamespaceSelector
-	log.Info("Updating ServiceMonitor", "name", found.Name)
-	return r.Update(ctx, found)
+	return nil
 }

--- a/controllers/evalhub/unit_test.go
+++ b/controllers/evalhub/unit_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/trustyai-explainability/trustyai-service-operator/api/common"
@@ -18,7 +19,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/yaml"
 )
 
@@ -2186,4 +2189,46 @@ func TestEvalHubReconciler_reconcileTenantNamespaces(t *testing.T) {
 		}, sa)
 		require.NoError(t, err, "active tenant SA should not be deleted")
 	})
+}
+
+func TestEvalHubReconciler_reconcileServiceMonitor_NoOpUpdate(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, evalhubv1alpha1.AddToScheme(scheme))
+	require.NoError(t, monitoringv1.AddToScheme(scheme))
+
+	ctx := context.Background()
+	evalHub := &evalhubv1alpha1.EvalHub{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"},
+	}
+
+	var smUpdateCount int
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(evalHub).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				if _, ok := obj.(*monitoringv1.ServiceMonitor); ok {
+					smUpdateCount++
+				}
+				return c.Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	reconciler := &EvalHubReconciler{
+		Client:        fakeClient,
+		Scheme:        scheme,
+		Namespace:     "ns",
+		EventRecorder: record.NewFakeRecorder(10),
+	}
+
+	// First call: creates the ServiceMonitor (Create, not Update)
+	require.NoError(t, reconciler.reconcileServiceMonitor(ctx, evalHub))
+	assert.Equal(t, 0, smUpdateCount, "first call should Create, not Update")
+
+	// Second call: spec unchanged — should NOT call Update
+	require.NoError(t, reconciler.reconcileServiceMonitor(ctx, evalHub))
+	assert.Equal(t, 0, smUpdateCount,
+		"reconcileServiceMonitor should not update when spec is unchanged")
 }


### PR DESCRIPTION
## What and why                                                                                                                                                                   
                                                            
PR #713 introduced ServiceMonitor auto-discovery for EvalHub. Two issues in that PR caused a tight reconcile loop (~3s cycle) that prevented the EvalHub deployment from reaching ready state, timing out all NetworkPolicy and ServiceMonitor ODH tests:
                                                                                                                                                                                 
1. `reconcileServiceMonitor()` unconditionally called `r.Update()` on every reconcile, even when the ServiceMonitor spec hadn't changed. Since the ServiceMonitor spec is derived entirely from immutable CR fields (name, namespace), it never needs to be updated in place, create-only is sufficient.
2. Mid-reconcile `r.Status().Update()` calls on both the success and error paths of ServiceMonitor reconciliation bumped the EvalHub CR's resourceVersion on every loop, triggering immediate re-reconciles that bypassed the 30-second `RequeueWithDelay`.

Refer to [RHOAIENG-61189](https://redhat.atlassian.net/browse/RHOAIENG-61189)

## Changes                                                                                                                                                                        
                                                            
- `servicemonitor.go`: Switch to create-only. Ff the ServiceMonitor already exists, return nil. The ServiceMonitor is garbage-collected via owner reference when the CR is deleted, so no update path is needed.                     
- `evalhub_controller.go`: Remove mid-reconcile `r.Status().Update()` calls from the monitoring block. The `MonitoringDegraded` condition is still set in memory via `instance.SetStatus()` and persisted by the single `updateStatus()` call at the end of the reconcile loop.                                                                         
- `unit_test.go`: Add `TestEvalHubReconciler_reconcileServiceMonitor_NoOpUpdate` . Verifies that calling `reconcileServiceMonitor` twice with the same inputs produces zero `Update` calls.                                                                                                                                                                         
                                                            
## Type                                                                                                                                                                           
                                                            
- [x] fix                                              
                                                            
## Testing

- Tests added or updated                                                                                                                                                       
- Tested manually
                                                                                                                                                                                 
Unit tests: `go test -v ./controllers/evalhub/...` all pass.                                                                                                                   
  
Cluster validation: confirmed via operator logs that the ServiceMonitor is created once (no "Updating ServiceMonitor" lines), the deployment reaches Ready within ~17s, and the reconcile loop settles to the expected 5-minute interval after reaching steady state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized ServiceMonitor reconciliation to defer status updates instead of making mid-reconcile API calls, improving performance and stability.
  * Removed in-place update logic for ServiceMonitor; now created once based on immutable configuration fields.

* **Tests**
  * Added test coverage for ServiceMonitor reconciliation to verify creation and no-op behavior on subsequent calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->