### PR TITLE
Fix: ServiceMonitor conflict and TLS issues

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -4,7 +4,7 @@ metadata:
   name: controller-manager
   namespace: system
   labels:
-    control-plane: controller-manager
+    control-plane: trustyai-service-operator
     app.kubernetes.io/name: deployment
     app.kubernetes.io/instance: trustyai-service-operator-controller-manager
     app.kubernetes.io/component: manager
@@ -14,14 +14,14 @@ metadata:
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: trustyai-service-operator
   replicas: 1
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: controller-manager
+        control-plane: trustyai-service-operator
     spec:
       securityContext:
         runAsNonRoot: true

--- a/config/prometheus/metrics-service.yaml
+++ b/config/prometheus/metrics-service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: trustyai-service-operator
     app.kubernetes.io/instance: metrics-service
     app.kubernetes.io/created-by: trustyai-service-operator
     app.kubernetes.io/part-of: trustyai
@@ -16,4 +16,4 @@ spec:
       protocol: TCP
       targetPort: 8080
   selector:
-    app.kubernetes.io/part-of: trustyai
+    control-plane: trustyai-service-operator

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: trustyai-service-operator
     app.kubernetes.io/name: servicemonitor
     app.kubernetes.io/instance: controller-manager-metrics-monitor
     app.kubernetes.io/component: metrics
@@ -21,4 +21,4 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: trustyai-service-operator

--- a/config/prometheus/operator-service-monitor.yaml
+++ b/config/prometheus/operator-service-monitor.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: trustyai-service-operator
     app.kubernetes.io/instance: service-monitor
     app.kubernetes.io/component: metrics
     app.kubernetes.io/created-by: trustyai-service-operator
@@ -16,4 +16,4 @@ spec:
       port: metrics
   selector:
     matchLabels:
-      app.kubernetes.io/part-of: trustyai
+      control-plane: trustyai-service-operator

--- a/config/rbac-base/auth_proxy_service.yaml
+++ b/config/rbac-base/auth_proxy_service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: trustyai-service-operator
     app.kubernetes.io/name: service
     app.kubernetes.io/instance: controller-manager-metrics-service
     app.kubernetes.io/component: kube-rbac-proxy
@@ -18,4 +18,4 @@ spec:
       protocol: TCP
       targetPort: https
   selector:
-    control-plane: controller-manager
+    control-plane: trustyai-service-operator

--- a/controllers/tas/monitor_test.go
+++ b/controllers/tas/monitor_test.go
@@ -51,6 +51,7 @@ var _ = Describe("Service Monitor Reconciliation", func() {
 			Expect(endpoint.HonorLabels).To(BeTrue())
 
 			Expect(endpoint.Path).To(Equal("/q/metrics"))
+			Expect(endpoint.Port).To(Equal("http"))
 			Expect(endpoint.Scheme).To(Equal("http"))
 			Expect(endpoint.Params["match[]"]).To(ConsistOf("{__name__= \"trustyai_spd\"}", "{__name__= \"trustyai_dir\"}"))
 
@@ -90,6 +91,7 @@ var _ = Describe("Service Monitor Reconciliation", func() {
 			Expect(endpoint.HonorLabels).To(BeTrue())
 
 			Expect(endpoint.Path).To(Equal("/q/metrics"))
+			Expect(endpoint.Port).To(Equal("http"))
 			Expect(endpoint.Scheme).To(Equal("http"))
 			Expect(endpoint.Params["match[]"]).To(ConsistOf("{__name__= \"trustyai_spd\"}", "{__name__= \"trustyai_dir\"}"))
 

--- a/controllers/tas/templates/service/service-monitor-central.tmpl.yaml
+++ b/controllers/tas/templates/service/service-monitor-central.tmpl.yaml
@@ -21,6 +21,7 @@ spec:
                   - '{__name__= "trustyai_spd"}'
                   - '{__name__= "trustyai_dir"}'
           path: /q/metrics
+          port: http
           scheme: http
     namespaceSelector:
         any: true

--- a/controllers/tas/templates/service/service-monitor-local.tmpl.yaml
+++ b/controllers/tas/templates/service/service-monitor-local.tmpl.yaml
@@ -21,6 +21,7 @@ spec:
                   - '{__name__= "trustyai_spd"}'
                   - '{__name__= "trustyai_dir"}'
           path: /q/metrics
+          port: http
           scheme: http
     namespaceSelector:
         matchNames:

--- a/tests/smoke/test_smoke.sh
+++ b/tests/smoke/test_smoke.sh
@@ -24,7 +24,7 @@ log_failure() {
     echo "❌ $message"
 
     # Dump operator logs if the pod exists
-    OPERATOR_POD=$(kubectl get pods -n system -l control-plane=controller-manager -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+    OPERATOR_POD=$(kubectl get pods -n system -l control-plane=trustyai-service-operator -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
     if [[ -n "$OPERATOR_POD" ]]; then
         echo ""
         echo "========== Operator Pod Logs =========="


### PR DESCRIPTION
Addresses [RHOAIENG-54605](https://redhat.atlassian.net/browse/RHOAIENG-54605) andR HOAIENG-61424:
- Operator servicemonitors no longer clash with TrustyAI services - they now look for `control-plane: trustyai-service-operator`
- TrustyAIService servicemonitors now only scrape http endpoints, prevent scrape failure on TLS ports  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized control-plane label value across deployments, services, and monitoring configs to ensure consistent targeting.
  * Updated service selectors so metrics traffic and service routing align with the new label.

* **Bug Fixes**
  * Ensured ServiceMonitor targets match the updated labels to restore reliable metrics scraping.

* **Tests**
  * Adjusted smoke and unit tests to validate the updated label selectors and explicit metrics port configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->