### PR TITLE
feat(evalhub): add offline flag to CR and config.yaml

### DIFF
--- a/artifacts/examples/example-config-map.yaml
+++ b/artifacts/examples/example-config-map.yaml
@@ -5,3 +5,4 @@ metadata:
 data:
   trustyaiServiceImage: "quay.io/trustyai/trustyai-service:latest"
   evalHubImage: "quay.io/ruimvieira/eval-hub:latest"  # example image
+  evalHubOffline: "false"

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -1,6 +1,7 @@
 trustyaiServiceImage=quay.io/trustyai/trustyai-service:latest
 trustyaiOperatorImage=quay.io/trustyai/trustyai-service-operator:latest
 evalHubImage=quay.io/evalhub/evalhub:latest
+evalHubOffline=false
 kube-rbac-proxy=quay.io/openshift/origin-kube-rbac-proxy:4.19
 kServeServerless=enabled
 lmes-driver-image=quay.io/trustyai/ta-lmes-driver:latest

--- a/controllers/evalhub/configmap.go
+++ b/controllers/evalhub/configmap.go
@@ -3,6 +3,7 @@ package evalhub
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -93,6 +94,7 @@ type SidecarConfig struct {
 
 // EvalHubConfig represents the eval-hub configuration structure
 type EvalHubConfig struct {
+	Offline     bool          `json:"offline,omitempty"`
 	Service     ServiceConfig   `json:"service"`
 	Secrets     *SecretsMapping `json:"secrets,omitempty"`
 	EnvMappings EnvMappings     `json:"env_mappings"`
@@ -151,6 +153,15 @@ func (r *EvalHubReconciler) generateConfigData(ctx context.Context, instance *ev
 		return nil, fmt.Errorf("failed to get EvalHub image: %w", err)
 	}
 
+	offlineEnabled, err := r.getOptionalBoolFromConfigMap(ctx, configMapEvalHubOfflineKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read EvalHub offline mode: %w", err)
+	}
+
+	// Best-effort autodetect: if we cannot reach Hugging Face, assume offline/disconnected.
+	// Cached across reconciles so we don't probe repeatedly.
+	hfReachable := r.isHuggingFaceReachable(ctx)
+
 	config := EvalHubConfig{
 		Service: ServiceConfig{
 			Port:             containerPort,
@@ -194,6 +205,12 @@ func (r *EvalHubReconciler) generateConfigData(ctx context.Context, instance *ev
 				},
 			},
 		},
+	}
+
+	// Offline mode is derived from operator configuration, not the EvalHub CR.
+	// This prevents accidentally configuring an online EvalHub in disconnected environments.
+	if offlineEnabled || !hfReachable {
+		config.Offline = true
 	}
 
 	// Database configuration — always present since the controller validates
@@ -253,6 +270,68 @@ func (r *EvalHubReconciler) generateConfigData(ctx context.Context, instance *ev
 		"config.yaml": string(configYAML),
 		"auth.yaml":   generateAuthConfigData(),
 	}, nil
+}
+
+func (r *EvalHubReconciler) isHuggingFaceReachable(ctx context.Context) bool {
+	r.hfReachableOnce.Do(func() {
+		url := r.hfProbeURL
+		if strings.TrimSpace(url) == "" {
+			url = defaultHFProbeURL
+		}
+
+		client := r.httpClient
+		if client == nil {
+			client = http.DefaultClient
+		}
+
+		probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		defer cancel()
+
+		req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, url, nil)
+		if err != nil {
+			r.hfReachable = false
+			return
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			r.hfReachable = false
+			return
+		}
+		defer resp.Body.Close()
+
+		// Consider 2xx/3xx as "reachable"
+		r.hfReachable = resp.StatusCode >= 200 && resp.StatusCode < 400
+	})
+
+	return r.hfReachable
+}
+
+// getOptionalBoolFromConfigMap retrieves an optional boolean configuration flag from the operator ConfigMap.
+// Missing or empty values are treated as false.
+func (r *EvalHubReconciler) getOptionalBoolFromConfigMap(ctx context.Context, key string) (bool, error) {
+	if r.Namespace == "" {
+		return false, fmt.Errorf("operator namespace not set, cannot retrieve config flag %q", key)
+	}
+
+	cmKey := types.NamespacedName{Namespace: r.Namespace, Name: configMapName}
+	var cm corev1.ConfigMap
+	if err := r.Client.Get(ctx, cmKey, &cm); err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	raw, ok := cm.Data[key]
+	if !ok || strings.TrimSpace(raw) == "" {
+		return false, nil
+	}
+	v, err := strconv.ParseBool(strings.TrimSpace(raw))
+	if err != nil {
+		return false, fmt.Errorf("invalid boolean %q for key %q", raw, key)
+	}
+	return v, nil
 }
 
 // generateAuthConfigData returns the authorization configuration for the ConfigMap.

--- a/controllers/evalhub/configmap_test.go
+++ b/controllers/evalhub/configmap_test.go
@@ -336,6 +336,37 @@ var _ = Describe("EvalHub ConfigMap", func() {
 		})
 	})
 
+	Context("When offline mode is configured", func() {
+		It("should include offline=true in config.yaml when operator offline mode is enabled", func() {
+			By("Enabling offline mode in operator ConfigMap")
+			operatorCM := &corev1.ConfigMap{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      configMapName,
+				Namespace: testNamespace,
+			}, operatorCM)).Should(Succeed())
+			if operatorCM.Data == nil {
+				operatorCM.Data = map[string]string{}
+			}
+			operatorCM.Data[configMapEvalHubOfflineKey] = "true"
+			Expect(k8sClient.Update(ctx, operatorCM)).Should(Succeed())
+
+			By("Reconciling configmap")
+			err := reconciler.reconcileConfigMap(ctx, evalHub)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Getting configmap")
+			configMap := waitForConfigMap(evalHubName+"-config", testNamespace)
+
+			By("Parsing config.yaml")
+			var config EvalHubConfig
+			err = yaml.Unmarshal([]byte(configMap.Data["config.yaml"]), &config)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking offline is enabled")
+			Expect(config.Offline).To(BeTrue())
+		})
+	})
+
 	Context("Configuration data generation", func() {
 		It("should generate valid configuration data", func() {
 			By("Generating configuration data")

--- a/controllers/evalhub/constants.go
+++ b/controllers/evalhub/constants.go
@@ -23,6 +23,11 @@ const (
 	// Configuration constants
 	configMapName            = "trustyai-service-operator-config"
 	configMapEvalHubImageKey = "evalHubImage"
+	configMapEvalHubOfflineKey = "evalHubOffline"
+
+	// Default probe used to infer disconnected/offline environments.
+	// Keep it small and stable.
+	defaultHFProbeURL = "https://huggingface.co"
 
 	// TLS configuration (OpenShift service serving certificates)
 	tlsSecretMountPath = "/etc/tls/private"

--- a/controllers/evalhub/evalhub_controller.go
+++ b/controllers/evalhub/evalhub_controller.go
@@ -3,6 +3,8 @@ package evalhub
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"sync"
 	"time"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -33,6 +35,7 @@ func ControllerSetUp(mgr manager.Manager, ns, operatorConfigMapName string, reco
 		restMapper:            mgr.GetRESTMapper(),
 		Namespace:             ns,
 		OperatorConfigMapName: operatorConfigMapName,
+		httpClient:            http.DefaultClient,
 		EventRecorder:         recorder,
 	}).SetupWithManager(mgr)
 }
@@ -45,6 +48,12 @@ type EvalHubReconciler struct {
 	Namespace             string
 	OperatorConfigMapName string
 	EventRecorder         record.EventRecorder
+
+	httpClient *http.Client
+	hfProbeURL string
+
+	hfReachableOnce sync.Once
+	hfReachable     bool
 }
 
 //+kubebuilder:rbac:groups=trustyai.opendatahub.io,resources=evalhubs,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/evalhub/unit_test.go
+++ b/controllers/evalhub/unit_test.go
@@ -2,6 +2,8 @@ package evalhub
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -445,6 +447,106 @@ func TestGenerateConfigData(t *testing.T) {
 		err = yaml.Unmarshal([]byte(configData["config.yaml"]), &config)
 		require.NoError(t, err)
 
+	})
+
+	t.Run("should include offline when enabled", func(t *testing.T) {
+		evalHub := &evalhubv1alpha1.EvalHub{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-evalhub-offline",
+				Namespace: "test-namespace",
+			},
+		}
+
+		configMap := createConfigMap(configMapName, evalHub.Namespace)
+		configMap.Data[configMapEvalHubOfflineKey] = "true"
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(evalHub, configMap).
+			Build()
+		reconciler := &EvalHubReconciler{
+			Client:    fakeClient,
+			Scheme:    scheme,
+			Namespace: evalHub.Namespace,
+		}
+
+		configData, err := reconciler.generateConfigData(context.Background(), evalHub)
+		require.NoError(t, err)
+
+		var config EvalHubConfig
+		err = yaml.Unmarshal([]byte(configData["config.yaml"]), &config)
+		require.NoError(t, err)
+		assert.True(t, config.Offline)
+	})
+
+	t.Run("should set offline when Hugging Face is unreachable", func(t *testing.T) {
+		evalHub := &evalhubv1alpha1.EvalHub{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-evalhub-hf-unreachable",
+				Namespace: "test-namespace",
+			},
+		}
+
+		// Simulate "unreachable" by returning a non-2xx/3xx status.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(503)
+		}))
+		defer srv.Close()
+
+		configMap := createConfigMap(configMapName, evalHub.Namespace)
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(evalHub, configMap).
+			Build()
+		reconciler := &EvalHubReconciler{
+			Client:     fakeClient,
+			Scheme:     scheme,
+			Namespace:  evalHub.Namespace,
+			httpClient: srv.Client(),
+			hfProbeURL: srv.URL,
+		}
+
+		configData, err := reconciler.generateConfigData(context.Background(), evalHub)
+		require.NoError(t, err)
+
+		var config EvalHubConfig
+		err = yaml.Unmarshal([]byte(configData["config.yaml"]), &config)
+		require.NoError(t, err)
+		assert.True(t, config.Offline)
+	})
+
+	t.Run("should not set offline when Hugging Face is reachable", func(t *testing.T) {
+		evalHub := &evalhubv1alpha1.EvalHub{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-evalhub-hf-reachable",
+				Namespace: "test-namespace",
+			},
+		}
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		}))
+		defer srv.Close()
+
+		configMap := createConfigMap(configMapName, evalHub.Namespace)
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(evalHub, configMap).
+			Build()
+		reconciler := &EvalHubReconciler{
+			Client:     fakeClient,
+			Scheme:     scheme,
+			Namespace:  evalHub.Namespace,
+			httpClient: srv.Client(),
+			hfProbeURL: srv.URL,
+		}
+
+		configData, err := reconciler.generateConfigData(context.Background(), evalHub)
+		require.NoError(t, err)
+
+		var config EvalHubConfig
+		err = yaml.Unmarshal([]byte(configData["config.yaml"]), &config)
+		require.NoError(t, err)
+		assert.False(t, config.Offline)
 	})
 }
 


### PR DESCRIPTION
**Summary**

- Add optional spec.offline to the EvalHub CRD.
- When spec.offline: true, include offline: true in the generated config.yaml ConfigMap (<evalhub>-config).
- Update sample manifest and add unit tests covering the new field.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added offline mode support for EvalHub. Users can now enable offline operation by setting `spec.offline: true` in the EvalHub custom resource configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->