### PR TITLE
fix(lmeval): auto-inject cluster CA bundle for HTTPS endpoints; allow re-run after spec change

### DIFF
--- a/config/components/lmes/rbac/manager-rbac.yaml
+++ b/config/components/lmes/rbac/manager-rbac.yaml
@@ -58,6 +58,8 @@ rules:
   - get
   - watch
   - list
+  - create
+  - update
 - apiGroups:
   - ""
   resources:

--- a/controllers/job_mgr/job_mgr_controller.go
+++ b/controllers/job_mgr/job_mgr_controller.go
@@ -120,7 +120,7 @@ func (job *LMEvalJob) PodSets() []kueue.PodSet {
 		AllowOnline:        lmes.Options.AllowOnline,
 		AllowCodeExecution: lmes.Options.AllowCodeExecution,
 	}
-	pod := lmes.CreatePod(lmes.Options, &job.LMEvalJob, permConfig, log)
+	pod := lmes.CreatePod(lmes.Options, &job.LMEvalJob, permConfig, nil, "", log)
 	podSet := kueue.PodSet{
 		Name:     job.GetPodName(),
 		Count:    1,

--- a/controllers/lmes/constants.go
+++ b/controllers/lmes/constants.go
@@ -45,4 +45,19 @@ const (
 	DefaultBatchSize           = "1"
 	DefaultDetectDevice        = true
 	ServiceName                = "LMES"
+
+	// DefaultCABundleConfigMapName is the standard RHOAI ConfigMap that holds the cluster CA bundle.
+	// It is injected into managed namespaces by the RHOAI operator and trusted by cluster-internal
+	// HTTPS services (e.g., KServe external routes using self-signed certs).
+	DefaultCABundleConfigMapName = "odh-trusted-ca-bundle"
+	// CABundleVolumeName is the volume name used when auto-mounting the cluster CA bundle.
+	CABundleVolumeName = "odh-ca-bundle"
+	// CABundleMountPath is the file path at which the CA bundle is mounted inside the lm-eval pod.
+	// REQUESTS_CA_BUNDLE is set to this path so Python's requests library picks it up automatically.
+	CABundleMountPath = "/etc/ssl/certs/odh-ca-bundle.crt"
+
+	// LastScheduledGenerationAnnotation records the spec generation that was active when the pod
+	// was last created. When a completed job's current generation exceeds this value the operator
+	// knows the spec changed and resets the job so it can be re-run with the updated configuration.
+	LastScheduledGenerationAnnotation = "trustyai.opendatahub.io/last-scheduled-generation"
 )

--- a/controllers/lmes/constants.go
+++ b/controllers/lmes/constants.go
@@ -47,12 +47,20 @@ const (
 	ServiceName                = "LMES"
 
 	// DefaultCABundleConfigMapName is the standard RHOAI ConfigMap that holds the cluster CA bundle.
-	// It is injected into managed namespaces by the RHOAI operator and trusted by cluster-internal
-	// HTTPS services (e.g., KServe external routes using self-signed certs).
+	// It is injected into managed namespaces by the RHOAI operator.
 	DefaultCABundleConfigMapName = "odh-trusted-ca-bundle"
-	// CABundleVolumeName is the volume name used when auto-mounting the cluster CA bundle.
+	// ServiceCAConfigMapName is the well-known ConfigMap that contains the OpenShift
+	// service-serving CA, used by cluster-internal HTTPS services (*.svc.cluster.local).
+	ServiceCAConfigMapName = "openshift-service-ca.crt"
+	// ServiceCAKey is the standard key within the service-serving CA ConfigMap.
+	ServiceCAKey = "service-ca.crt"
+	// MergedCABundleKey is the key used in the per-job merged CA ConfigMap.
+	MergedCABundleKey = "merged-ca-bundle.crt"
+	// MergedCAConfigMapSuffix is appended to the job name to form the merged CA ConfigMap name.
+	MergedCAConfigMapSuffix = "-ca-bundle"
+	// CABundleVolumeName is the volume name used when auto-mounting the merged CA bundle.
 	CABundleVolumeName = "odh-ca-bundle"
-	// CABundleMountPath is the file path at which the CA bundle is mounted inside the lm-eval pod.
+	// CABundleMountPath is the file path at which the merged CA bundle is mounted inside the lm-eval pod.
 	// REQUESTS_CA_BUNDLE is set to this path so Python's requests library picks it up automatically.
 	CABundleMountPath = "/etc/ssl/certs/odh-ca-bundle.crt"
 

--- a/controllers/lmes/lmevaljob_controller.go
+++ b/controllers/lmes/lmevaljob_controller.go
@@ -19,6 +19,7 @@ package lmes
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -31,6 +32,7 @@ import (
 	"github.com/trustyai-explainability/trustyai-service-operator/controllers/utils"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -96,6 +98,8 @@ var (
 			},
 		},
 	}
+
+	errNoCAData = errors.New("no CA bundle data found")
 )
 
 // maintain a list of key-time pair data.
@@ -170,7 +174,7 @@ func (q *syncedMap4Reconciler) remove(key string) {
 // +kubebuilder:rbac:groups=trustyai.opendatahub.io,resources=lmevaljobs/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;create;delete
 // +kubebuilder:rbac:groups="",resources=pods/exec,verbs=get;list;watch;create;delete
-// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;watch;list
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;watch;list;create;update
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;watch;list
 // +kubebuilder:rbac:groups=core,resources=persistentvolumes,verbs=list;get;watch
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=list;get;watch;create;update;patch;delete
@@ -189,9 +193,9 @@ func (r *LMEvalJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return r.handleDeletion(ctx, job, log)
 	}
 
-	// Bug 3: When a completed job's spec is edited its metadata.Generation is
-	// incremented by the API server. Detect that and reset the status so the job
-	// re-runs with the updated configuration.
+	// When a completed job's spec is edited, metadata.Generation is incremented
+	// by the API server. Detect that and reset the status so the job re-runs
+	// with the updated configuration.
 	if job.Status.State == lmesv1alpha1.CompleteJobState {
 		if lastGen := getLastScheduledGeneration(job); lastGen > 0 && job.Generation > lastGen {
 			// Delete the completed pod first. The replacement pod reuses the same
@@ -563,38 +567,12 @@ func (r *LMEvalJobReconciler) handleNewCR(ctx context.Context, log logr.Logger, 
 		return ctrl.Result{}, err
 	}
 
-	// Bug 1: Auto-inject the cluster CA bundle when the model endpoint uses HTTPS
-	// and verify_certificate is not already set. This handles the common RHOAI case
-	// where KServe external routes use self-signed certs trusted by the cluster but
-	// not by Python's default trust store inside the pod.
-	var caBundle *corev1.ConfigMap
-	var caBundleKey string
-	if hasHTTPSBaseURL(job) && !hasExplicitVerifyCertificate(job) {
-		if cm, key, err := r.findCABundle(ctx, job.Namespace); err == nil {
-			caBundle = cm
-			caBundleKey = key
-			log.Info("auto-injecting cluster CA bundle for HTTPS endpoint",
-				"configmap", DefaultCABundleConfigMapName, "key", key)
-		} else {
-			log.Info("HTTPS base_url detected but cluster CA bundle not found, proceeding without auto-injection",
-				"error", err.Error())
-		}
+	caBundle, caBundleKey, err := r.resolveCABundle(ctx, log, job)
+	if err != nil {
+		return ctrl.Result{}, err
 	}
-
-	// Bug 3: Record the spec generation being scheduled. Reconcile reads this back
-	// after completion to detect a spec change and reset the job for re-run.
-	currentGenStr := strconv.FormatInt(job.Generation, 10)
-	annotations := job.GetAnnotations()
-	if annotations == nil {
-		annotations = make(map[string]string)
-	}
-	if annotations[LastScheduledGenerationAnnotation] != currentGenStr {
-		annotations[LastScheduledGenerationAnnotation] = currentGenStr
-		job.SetAnnotations(annotations)
-		if err := r.Update(ctx, job); err != nil {
-			log.Error(err, "failed to update generation annotation")
-			return ctrl.Result{}, err
-		}
+	if err := r.recordScheduledGeneration(ctx, job); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	// construct a new pod and create a pod for the job
@@ -825,28 +803,12 @@ func (r *LMEvalJobReconciler) handleResume(ctx context.Context, log logr.Logger,
 		return r.pullingJobs.addOrUpdate(string(job.GetUID()), Options.PodCheckingInterval), err
 	}
 
-	// Bug 1: Apply the same CA bundle auto-injection on resume as on initial scheduling.
-	var caBundle *corev1.ConfigMap
-	var caBundleKey string
-	if hasHTTPSBaseURL(job) && !hasExplicitVerifyCertificate(job) {
-		if cm, key, err := r.findCABundle(ctx, job.Namespace); err == nil {
-			caBundle = cm
-			caBundleKey = key
-		}
+	caBundle, caBundleKey, err := r.resolveCABundle(ctx, log, job)
+	if err != nil {
+		return ctrl.Result{}, err
 	}
-
-	currentGenStr := strconv.FormatInt(job.Generation, 10)
-	annotations := job.GetAnnotations()
-	if annotations == nil {
-		annotations = make(map[string]string)
-	}
-	if annotations[LastScheduledGenerationAnnotation] != currentGenStr {
-		annotations[LastScheduledGenerationAnnotation] = currentGenStr
-		job.SetAnnotations(annotations)
-		if err := r.Update(ctx, job); err != nil {
-			log.Error(err, "failed to update generation annotation on resume")
-			return ctrl.Result{}, err
-		}
+	if err := r.recordScheduledGeneration(ctx, job); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	pod := CreatePod(Options, job, permConfig, caBundle, caBundleKey, log)
@@ -1349,9 +1311,8 @@ func CreatePod(svcOpts *serviceOptions, job *lmesv1alpha1.LMEvalJob, permConfig 
 	volumes = append(volumes, job.Spec.Pod.GetVolumes()...)
 	volumeMounts = append(volumeMounts, job.Spec.Pod.GetContainer().GetVolumMounts()...)
 
-	// Bug 1: Mount the cluster CA bundle so Python's requests library can verify
-	// the self-signed certificate used by OpenShift external routes. REQUESTS_CA_BUNDLE
-	// is the standard env var that the requests library picks up automatically.
+	// Mount the merged CA bundle so REQUESTS_CA_BUNDLE lets Python's requests
+	// library verify certificates signed by cluster or service-serving CAs.
 	if caBundle != nil && caBundleKey != "" {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      CABundleVolumeName,
@@ -1792,6 +1753,43 @@ func removeProtectedEnvVars(envVars []corev1.EnvVar) []corev1.EnvVar {
 	return allowedEnvVars
 }
 
+// resolveCABundle looks up cluster CA sources and returns a merged ConfigMap
+// when the job targets an HTTPS endpoint without an explicit verify_certificate.
+func (r *LMEvalJobReconciler) resolveCABundle(ctx context.Context, log logr.Logger, job *lmesv1alpha1.LMEvalJob) (*corev1.ConfigMap, string, error) {
+	if !hasHTTPSBaseURL(job) || hasExplicitVerifyCertificate(job) {
+		return nil, "", nil
+	}
+	cm, key, err := r.findAndMergeCABundle(ctx, job)
+	if errors.Is(err, errNoCAData) {
+		log.Info("HTTPS base_url detected but no CA bundle data found, proceeding without auto-injection")
+		return nil, "", nil
+	}
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to prepare CA bundle: %w", err)
+	}
+	log.Info("auto-injecting merged CA bundle for HTTPS endpoint",
+		"configmap", cm.Name, "key", key)
+	return cm, key, nil
+}
+
+// recordScheduledGeneration persists the current spec generation so Reconcile
+// can detect a spec change on a completed job and reset it for re-run.
+func (r *LMEvalJobReconciler) recordScheduledGeneration(ctx context.Context, job *lmesv1alpha1.LMEvalJob) error {
+	currentGenStr := strconv.FormatInt(job.Generation, 10)
+	annotations := job.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	if annotations[LastScheduledGenerationAnnotation] != currentGenStr {
+		annotations[LastScheduledGenerationAnnotation] = currentGenStr
+		job.SetAnnotations(annotations)
+		if err := r.Update(ctx, job); err != nil {
+			return fmt.Errorf("failed to update generation annotation: %w", err)
+		}
+	}
+	return nil
+}
+
 // hasHTTPSBaseURL returns true when any modelArg named "base_url" uses HTTPS.
 func hasHTTPSBaseURL(job *lmesv1alpha1.LMEvalJob) bool {
 	for _, arg := range job.Spec.ModelArgs {
@@ -1830,18 +1828,84 @@ func getLastScheduledGeneration(job *lmesv1alpha1.LMEvalJob) int64 {
 	return gen
 }
 
-// findCABundle looks for the standard RHOAI cluster CA bundle ConfigMap in the
-// given namespace. It tries well-known key names and returns the ConfigMap and
-// the matching key on success.
-func (r *LMEvalJobReconciler) findCABundle(ctx context.Context, namespace string) (*corev1.ConfigMap, string, error) {
-	cm := &corev1.ConfigMap{}
-	if err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: DefaultCABundleConfigMapName}, cm); err != nil {
-		return nil, "", err
+// findAndMergeCABundle collects CA certificates from well-known cluster sources
+// and creates a per-job ConfigMap containing the merged bundle. This ensures
+// that REQUESTS_CA_BUNDLE (which replaces the default trust store) contains
+// both public CAs and the OpenShift service-serving CA.
+//
+// Sources checked (best-effort, each is skipped if not found):
+//   - odh-trusted-ca-bundle: ca-bundle.crt, odh-ca-bundle.crt (public/system CAs)
+//   - openshift-service-ca.crt: service-ca.crt (service-serving CA)
+func (r *LMEvalJobReconciler) findAndMergeCABundle(ctx context.Context, job *lmesv1alpha1.LMEvalJob) (*corev1.ConfigMap, string, error) {
+	log := log.FromContext(ctx)
+	var pemBlocks []string
+
+	// Source 1: odh-trusted-ca-bundle (public/system CAs)
+	odhCM := &corev1.ConfigMap{}
+	if err := r.Get(ctx, types.NamespacedName{Namespace: job.Namespace, Name: DefaultCABundleConfigMapName}, odhCM); err == nil {
+		for _, key := range []string{"ca-bundle.crt", "odh-ca-bundle.crt"} {
+			if data, ok := odhCM.Data[key]; ok && strings.TrimSpace(data) != "" {
+				pemBlocks = append(pemBlocks, data)
+				log.V(1).Info("collected CA data", "configmap", DefaultCABundleConfigMapName, "key", key)
+			}
+		}
+	} else if !apierrors.IsNotFound(err) {
+		log.Error(err, "error reading CA bundle ConfigMap", "name", DefaultCABundleConfigMapName)
 	}
-	for _, key := range []string{"ca-bundle.crt", "odh-ca-bundle.crt", "service-ca.crt"} {
-		if _, ok := cm.Data[key]; ok {
-			return cm, key, nil
+
+	// Source 2: openshift-service-ca.crt (service-serving CA)
+	svcCM := &corev1.ConfigMap{}
+	if err := r.Get(ctx, types.NamespacedName{Namespace: job.Namespace, Name: ServiceCAConfigMapName}, svcCM); err == nil {
+		if data, ok := svcCM.Data[ServiceCAKey]; ok && strings.TrimSpace(data) != "" {
+			pemBlocks = append(pemBlocks, data)
+			log.V(1).Info("collected CA data", "configmap", ServiceCAConfigMapName, "key", ServiceCAKey)
+		}
+	} else if !apierrors.IsNotFound(err) {
+		log.Error(err, "error reading service CA ConfigMap", "name", ServiceCAConfigMapName)
+	}
+
+	if len(pemBlocks) == 0 {
+		return nil, "", errNoCAData
+	}
+
+	merged := strings.Join(pemBlocks, "\n")
+	mergedCMName := job.Name + MergedCAConfigMapSuffix
+
+	mergedCM := &corev1.ConfigMap{}
+	err := r.Get(ctx, types.NamespacedName{Namespace: job.Namespace, Name: mergedCMName}, mergedCM)
+	if apierrors.IsNotFound(err) {
+		ownerRefController := true
+		mergedCM = &corev1.ConfigMap{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      mergedCMName,
+				Namespace: job.Namespace,
+				OwnerReferences: []v1.OwnerReference{
+					{
+						APIVersion: job.APIVersion,
+						Kind:       job.Kind,
+						Name:       job.Name,
+						Controller: &ownerRefController,
+						UID:        job.UID,
+					},
+				},
+			},
+			Data: map[string]string{
+				MergedCABundleKey: merged,
+			},
+		}
+		if err := r.Create(ctx, mergedCM); err != nil {
+			return nil, "", fmt.Errorf("failed to create merged CA ConfigMap: %w", err)
+		}
+	} else if err != nil {
+		return nil, "", fmt.Errorf("failed to read merged CA ConfigMap: %w", err)
+	} else {
+		mergedCM.Data = map[string]string{
+			MergedCABundleKey: merged,
+		}
+		if err := r.Update(ctx, mergedCM); err != nil {
+			return nil, "", fmt.Errorf("failed to update merged CA ConfigMap: %w", err)
 		}
 	}
-	return nil, "", fmt.Errorf("ConfigMap %s has no recognised CA bundle key", DefaultCABundleConfigMapName)
+
+	return mergedCM, MergedCABundleKey, nil
 }

--- a/controllers/lmes/lmevaljob_controller.go
+++ b/controllers/lmes/lmevaljob_controller.go
@@ -480,20 +480,16 @@ func createJobCreationMetrics(log logr.Logger, job *lmesv1alpha1.LMEvalJob) {
 		labels["model_type"] = job.Spec.Model
 		labels["task"] = task
 
-		// grab model name
-		hasUrl := false
-		hasName := false
+		// grab model name and base_url; always set both labels so the
+		// CounterVec has a consistent label cardinality across jobs.
+		labels["model_name"] = ""
+		labels["base_url"] = ""
 		for _, arg := range job.Spec.ModelArgs {
 			if arg.Name == "model" {
 				labels["model_name"] = arg.Value
-				hasUrl = true
 			}
 			if arg.Name == "base_url" {
 				labels["base_url"] = arg.Value
-				hasName = true
-			}
-			if hasUrl && hasName {
-				break
 			}
 		}
 

--- a/controllers/lmes/lmevaljob_controller.go
+++ b/controllers/lmes/lmevaljob_controller.go
@@ -194,6 +194,13 @@ func (r *LMEvalJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// re-runs with the updated configuration.
 	if job.Status.State == lmesv1alpha1.CompleteJobState {
 		if lastGen := getLastScheduledGeneration(job); lastGen > 0 && job.Generation > lastGen {
+			// Delete the completed pod first. The replacement pod reuses the same
+			// name (job.Name), so leaving the old one would cause handleNewCR to
+			// fail with AlreadyExists when it tries to create it.
+			if err := r.deleteJobPod(ctx, job); err != nil && client.IgnoreNotFound(err) != nil {
+				log.Error(err, "failed to delete completed pod before re-run")
+				return ctrl.Result{}, err
+			}
 			log.Info("spec changed for completed job, resetting for re-run",
 				"name", job.Name,
 				"previousGeneration", lastGen,
@@ -829,6 +836,20 @@ func (r *LMEvalJobReconciler) handleResume(ctx context.Context, log logr.Logger,
 		if cm, key, err := r.findCABundle(ctx, job.Namespace); err == nil {
 			caBundle = cm
 			caBundleKey = key
+		}
+	}
+
+	currentGenStr := strconv.FormatInt(job.Generation, 10)
+	annotations := job.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	if annotations[LastScheduledGenerationAnnotation] != currentGenStr {
+		annotations[LastScheduledGenerationAnnotation] = currentGenStr
+		job.SetAnnotations(annotations)
+		if err := r.Update(ctx, job); err != nil {
+			log.Error(err, "failed to update generation annotation on resume")
+			return ctrl.Result{}, err
 		}
 	}
 

--- a/controllers/lmes/lmevaljob_controller.go
+++ b/controllers/lmes/lmevaljob_controller.go
@@ -189,6 +189,31 @@ func (r *LMEvalJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return r.handleDeletion(ctx, job, log)
 	}
 
+	// Bug 3: When a completed job's spec is edited its metadata.Generation is
+	// incremented by the API server. Detect that and reset the status so the job
+	// re-runs with the updated configuration.
+	if job.Status.State == lmesv1alpha1.CompleteJobState {
+		if lastGen := getLastScheduledGeneration(job); lastGen > 0 && job.Generation > lastGen {
+			log.Info("spec changed for completed job, resetting for re-run",
+				"name", job.Name,
+				"previousGeneration", lastGen,
+				"currentGeneration", job.Generation)
+			job.Status.State = lmesv1alpha1.NewJobState
+			job.Status.LastScheduleTime = nil
+			job.Status.CompleteTime = nil
+			job.Status.PodName = ""
+			job.Status.Reason = lmesv1alpha1.NoReason
+			job.Status.Message = ""
+			job.Status.ProgressBars = nil
+			job.Status.Results = ""
+			if err := r.Status().Update(ctx, job); err != nil {
+				log.Error(err, "failed to reset job status for re-run")
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{}, nil
+		}
+	}
+
 	// Treat this as NewJobState
 	if job.Status.LastScheduleTime == nil && job.Status.CompleteTime == nil {
 		job.Status.State = lmesv1alpha1.NewJobState
@@ -535,9 +560,43 @@ func (r *LMEvalJobReconciler) handleNewCR(ctx context.Context, log logr.Logger, 
 		return ctrl.Result{}, err
 	}
 
+	// Bug 1: Auto-inject the cluster CA bundle when the model endpoint uses HTTPS
+	// and verify_certificate is not already set. This handles the common RHOAI case
+	// where KServe external routes use self-signed certs trusted by the cluster but
+	// not by Python's default trust store inside the pod.
+	var caBundle *corev1.ConfigMap
+	var caBundleKey string
+	if hasHTTPSBaseURL(job) && !hasExplicitVerifyCertificate(job) {
+		if cm, key, err := r.findCABundle(ctx, job.Namespace); err == nil {
+			caBundle = cm
+			caBundleKey = key
+			log.Info("auto-injecting cluster CA bundle for HTTPS endpoint",
+				"configmap", DefaultCABundleConfigMapName, "key", key)
+		} else {
+			log.Info("HTTPS base_url detected but cluster CA bundle not found, proceeding without auto-injection",
+				"error", err.Error())
+		}
+	}
+
+	// Bug 3: Record the spec generation being scheduled. Reconcile reads this back
+	// after completion to detect a spec change and reset the job for re-run.
+	currentGenStr := strconv.FormatInt(job.Generation, 10)
+	annotations := job.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	if annotations[LastScheduledGenerationAnnotation] != currentGenStr {
+		annotations[LastScheduledGenerationAnnotation] = currentGenStr
+		job.SetAnnotations(annotations)
+		if err := r.Update(ctx, job); err != nil {
+			log.Error(err, "failed to update generation annotation")
+			return ctrl.Result{}, err
+		}
+	}
+
 	// construct a new pod and create a pod for the job
 	currentTime := v1.Now()
-	pod := CreatePod(Options, job, permConfig, log)
+	pod := CreatePod(Options, job, permConfig, caBundle, caBundleKey, log)
 	if err := r.Create(ctx, pod, &client.CreateOptions{}); err != nil {
 		// Failed to create the pod. Mark the status as complete with failed
 		job.Status.State = lmesv1alpha1.CompleteJobState
@@ -763,7 +822,17 @@ func (r *LMEvalJobReconciler) handleResume(ctx context.Context, log logr.Logger,
 		return r.pullingJobs.addOrUpdate(string(job.GetUID()), Options.PodCheckingInterval), err
 	}
 
-	pod := CreatePod(Options, job, permConfig, log)
+	// Bug 1: Apply the same CA bundle auto-injection on resume as on initial scheduling.
+	var caBundle *corev1.ConfigMap
+	var caBundleKey string
+	if hasHTTPSBaseURL(job) && !hasExplicitVerifyCertificate(job) {
+		if cm, key, err := r.findCABundle(ctx, job.Namespace); err == nil {
+			caBundle = cm
+			caBundleKey = key
+		}
+	}
+
+	pod := CreatePod(Options, job, permConfig, caBundle, caBundleKey, log)
 	if createErr := r.Create(ctx, pod); createErr != nil {
 		log.Error(createErr, "failed to create pod to resume job")
 		return r.pullingJobs.addOrUpdate(string(job.GetUID()), Options.PodCheckingInterval), nil
@@ -888,7 +957,7 @@ func unmarshal(custom string, props []string) (map[string]interface{}, error) {
 	return obj, nil
 }
 
-func CreatePod(svcOpts *serviceOptions, job *lmesv1alpha1.LMEvalJob, permConfig *PermissionConfig, log logr.Logger) *corev1.Pod {
+func CreatePod(svcOpts *serviceOptions, job *lmesv1alpha1.LMEvalJob, permConfig *PermissionConfig, caBundle *corev1.ConfigMap, caBundleKey string, log logr.Logger) *corev1.Pod {
 
 	var envVars = removeProtectedEnvVars(job.Spec.Pod.GetContainer().GetEnv())
 
@@ -1262,6 +1331,33 @@ func CreatePod(svcOpts *serviceOptions, job *lmesv1alpha1.LMEvalJob, permConfig 
 
 	volumes = append(volumes, job.Spec.Pod.GetVolumes()...)
 	volumeMounts = append(volumeMounts, job.Spec.Pod.GetContainer().GetVolumMounts()...)
+
+	// Bug 1: Mount the cluster CA bundle so Python's requests library can verify
+	// the self-signed certificate used by OpenShift external routes. REQUESTS_CA_BUNDLE
+	// is the standard env var that the requests library picks up automatically.
+	if caBundle != nil && caBundleKey != "" {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      CABundleVolumeName,
+			MountPath: CABundleMountPath,
+			SubPath:   caBundleKey,
+			ReadOnly:  true,
+		})
+		volumes = append(volumes, corev1.Volume{
+			Name: CABundleVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: caBundle.Name,
+					},
+				},
+			},
+		})
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  "REQUESTS_CA_BUNDLE",
+			Value: CABundleMountPath,
+		})
+	}
+
 	labels := getPodLabels(job.Labels, log)
 	annotations := getAnnotations(job.Annotations, log)
 	resources := getResources(job.Spec.Pod.GetContainer().GetResources())
@@ -1677,4 +1773,58 @@ func removeProtectedEnvVars(envVars []corev1.EnvVar) []corev1.EnvVar {
 	}
 
 	return allowedEnvVars
+}
+
+// hasHTTPSBaseURL returns true when any modelArg named "base_url" uses HTTPS.
+func hasHTTPSBaseURL(job *lmesv1alpha1.LMEvalJob) bool {
+	for _, arg := range job.Spec.ModelArgs {
+		if arg.Name == "base_url" && strings.HasPrefix(strings.ToLower(arg.Value), "https://") {
+			return true
+		}
+	}
+	return false
+}
+
+// hasExplicitVerifyCertificate returns true when verify_certificate is already
+// present in modelArgs, meaning auto-injection should be skipped.
+func hasExplicitVerifyCertificate(job *lmesv1alpha1.LMEvalJob) bool {
+	for _, arg := range job.Spec.ModelArgs {
+		if arg.Name == "verify_certificate" {
+			return true
+		}
+	}
+	return false
+}
+
+// getLastScheduledGeneration reads the spec generation stored by the previous
+// scheduling cycle. Returns 0 if the annotation is absent or unparseable.
+func getLastScheduledGeneration(job *lmesv1alpha1.LMEvalJob) int64 {
+	if job.Annotations == nil {
+		return 0
+	}
+	genStr, ok := job.Annotations[LastScheduledGenerationAnnotation]
+	if !ok {
+		return 0
+	}
+	gen, err := strconv.ParseInt(genStr, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return gen
+}
+
+// findCABundle looks for the standard RHOAI cluster CA bundle ConfigMap in the
+// given namespace. It tries well-known key names and returns the ConfigMap and
+// the matching key on success.
+func (r *LMEvalJobReconciler) findCABundle(ctx context.Context, namespace string) (*corev1.ConfigMap, string, error) {
+	cm := &corev1.ConfigMap{}
+	if err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: DefaultCABundleConfigMapName}, cm); err != nil {
+		return nil, "", err
+	}
+	for _, key := range []string{"ca-bundle.crt", "odh-ca-bundle.crt", "service-ca.crt"} {
+		if _, ok := cm.Data[key]; ok {
+			return cm, key, nil
+		}
+	}
+	return nil, "", fmt.Errorf("ConfigMap %s has no recognised CA bundle key", DefaultCABundleConfigMapName)
 }

--- a/controllers/lmes/lmevaljob_controller_suite_test.go
+++ b/controllers/lmes/lmevaljob_controller_suite_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -216,17 +217,20 @@ var _ = Describe("LMEvalJob CA bundle injection", func() {
 	ctx := context.Background()
 	trueB := true
 
-	It("injects CA bundle volume, mount, and env var when base_url uses HTTPS", func() {
+	It("injects merged CA bundle when base_url uses HTTPS", func() {
 		caConfigMap := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      lmes.DefaultCABundleConfigMapName,
 				Namespace: testNamespace,
 			},
 			Data: map[string]string{
-				"ca-bundle.crt": "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----",
+				"ca-bundle.crt": "-----BEGIN CERTIFICATE-----\npublic-ca\n-----END CERTIFICATE-----",
 			},
 		}
-		Expect(k8sClient.Create(ctx, caConfigMap)).Should(Succeed())
+		if err := k8sClient.Create(ctx, caConfigMap); err != nil {
+			Expect(apierrors.IsAlreadyExists(err)).To(BeTrue(),
+				"unexpected error creating CA ConfigMap: %v", err)
+		}
 
 		job := &lmesv1alpha1.LMEvalJob{
 			ObjectMeta: metav1.ObjectMeta{
@@ -252,6 +256,18 @@ var _ = Describe("LMEvalJob CA bundle injection", func() {
 		}
 		Expect(k8sClient.Create(ctx, job)).Should(Succeed())
 
+		mergedCMName := "test-ca-bundle" + lmes.MergedCAConfigMapSuffix
+
+		// Verify the merged ConfigMap was created
+		mergedCM := &corev1.ConfigMap{}
+		WaitFor(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{
+				Name: mergedCMName, Namespace: testNamespace,
+			}, mergedCM)
+		}, "merged CA ConfigMap was not created")
+		Expect(mergedCM.Data).To(HaveKey(lmes.MergedCABundleKey))
+		Expect(mergedCM.Data[lmes.MergedCABundleKey]).To(ContainSubstring("public-ca"))
+
 		pod := &corev1.Pod{}
 		WaitFor(func() error {
 			return k8sClient.Get(ctx, types.NamespacedName{
@@ -259,25 +275,25 @@ var _ = Describe("LMEvalJob CA bundle injection", func() {
 			}, pod)
 		}, "pod was not created for HTTPS job")
 
-		// Verify CA bundle volume
+		// Verify CA bundle volume points to merged ConfigMap
 		foundVolume := false
 		for _, v := range pod.Spec.Volumes {
 			if v.Name == lmes.CABundleVolumeName {
 				foundVolume = true
 				Expect(v.VolumeSource.ConfigMap).NotTo(BeNil())
-				Expect(v.VolumeSource.ConfigMap.Name).To(Equal(lmes.DefaultCABundleConfigMapName))
+				Expect(v.VolumeSource.ConfigMap.Name).To(Equal(mergedCMName))
 			}
 		}
 		Expect(foundVolume).To(BeTrue(), "CA bundle volume not found on pod")
 
-		// Verify CA bundle volume mount on main container
+		// Verify volume mount uses merged key
 		mainContainer := pod.Spec.Containers[0]
 		foundMount := false
 		for _, m := range mainContainer.VolumeMounts {
 			if m.Name == lmes.CABundleVolumeName {
 				foundMount = true
 				Expect(m.MountPath).To(Equal(lmes.CABundleMountPath))
-				Expect(m.SubPath).To(Equal("ca-bundle.crt"))
+				Expect(m.SubPath).To(Equal(lmes.MergedCABundleKey))
 				Expect(m.ReadOnly).To(BeTrue())
 			}
 		}
@@ -292,6 +308,74 @@ var _ = Describe("LMEvalJob CA bundle injection", func() {
 			}
 		}
 		Expect(foundEnv).To(BeTrue(), "REQUESTS_CA_BUNDLE env var not found")
+	})
+
+	It("merges both odh-trusted-ca-bundle and openshift-service-ca.crt when both exist", func() {
+		odhCAConfigMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      lmes.DefaultCABundleConfigMapName,
+				Namespace: testNamespace,
+			},
+			Data: map[string]string{
+				"ca-bundle.crt": "-----BEGIN CERTIFICATE-----\npublic-ca\n-----END CERTIFICATE-----",
+			},
+		}
+		if err := k8sClient.Create(ctx, odhCAConfigMap); err != nil {
+			Expect(apierrors.IsAlreadyExists(err)).To(BeTrue(),
+				"unexpected error creating ODH CA ConfigMap: %v", err)
+		}
+
+		svcCAConfigMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      lmes.ServiceCAConfigMapName,
+				Namespace: testNamespace,
+			},
+			Data: map[string]string{
+				lmes.ServiceCAKey: "-----BEGIN CERTIFICATE-----\nservice-ca\n-----END CERTIFICATE-----",
+			},
+		}
+		if err := k8sClient.Create(ctx, svcCAConfigMap); err != nil {
+			Expect(apierrors.IsAlreadyExists(err)).To(BeTrue(),
+				"unexpected error creating service CA ConfigMap: %v", err)
+		}
+
+		job := &lmesv1alpha1.LMEvalJob{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-ca-merged",
+				Namespace: testNamespace,
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind:       lmesv1alpha1.KindName,
+				APIVersion: lmesv1alpha1.Version,
+			},
+			Spec: lmesv1alpha1.LMEvalJobSpec{
+				AllowOnline:        &trueB,
+				AllowCodeExecution: &trueB,
+				Model:              "hf",
+				ModelArgs: []lmesv1alpha1.Arg{
+					{Name: "pretrained", Value: "google/flan-t5-base"},
+					{Name: "base_url", Value: "https://model.svc.cluster.local:8443"},
+				},
+				TaskList: lmesv1alpha1.TaskList{
+					TaskNames: []string{"task1"},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, job)).Should(Succeed())
+
+		mergedCMName := "test-ca-merged" + lmes.MergedCAConfigMapSuffix
+
+		mergedCM := &corev1.ConfigMap{}
+		WaitFor(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{
+				Name: mergedCMName, Namespace: testNamespace,
+			}, mergedCM)
+		}, "merged CA ConfigMap was not created")
+
+		Expect(mergedCM.Data[lmes.MergedCABundleKey]).To(ContainSubstring("public-ca"),
+			"merged bundle should contain public CAs from odh-trusted-ca-bundle")
+		Expect(mergedCM.Data[lmes.MergedCABundleKey]).To(ContainSubstring("service-ca"),
+			"merged bundle should contain service-serving CA from openshift-service-ca.crt")
 	})
 
 	It("does not inject CA bundle when base_url uses HTTP", func() {
@@ -515,5 +599,127 @@ var _ = Describe("LMEvalJob re-run after spec change", func() {
 			return nil
 		}, time.Second*3, defaultPolling).Should(Succeed(),
 			"completed job should not be reset when spec is unchanged")
+	})
+
+	It("updates the merged CA ConfigMap when an HTTPS job is re-run after spec change", func() {
+		// Ensure CA source ConfigMap exists (may already exist from CA injection tests)
+		caConfigMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      lmes.DefaultCABundleConfigMapName,
+				Namespace: testNamespace,
+			},
+			Data: map[string]string{
+				"ca-bundle.crt": "-----BEGIN CERTIFICATE-----\npublic-ca\n-----END CERTIFICATE-----",
+			},
+		}
+		err := k8sClient.Create(ctx, caConfigMap)
+		if err != nil {
+			Expect(apierrors.IsAlreadyExists(err)).To(BeTrue(),
+				"unexpected error creating CA ConfigMap: %v", err)
+		}
+
+		job := &lmesv1alpha1.LMEvalJob{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-rerun-ca",
+				Namespace: testNamespace,
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind:       lmesv1alpha1.KindName,
+				APIVersion: lmesv1alpha1.Version,
+			},
+			Spec: lmesv1alpha1.LMEvalJobSpec{
+				AllowOnline:        &trueB,
+				AllowCodeExecution: &trueB,
+				Model:              "hf",
+				ModelArgs: []lmesv1alpha1.Arg{
+					{Name: "pretrained", Value: "google/flan-t5-base"},
+					{Name: "base_url", Value: "https://model.svc.cluster.local:8443"},
+				},
+				TaskList: lmesv1alpha1.TaskList{
+					TaskNames: []string{"task1"},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, job)).Should(Succeed())
+
+		mergedCMName := "test-rerun-ca" + lmes.MergedCAConfigMapSuffix
+
+		// Wait for initial merged ConfigMap and pod
+		mergedCM := &corev1.ConfigMap{}
+		WaitFor(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{
+				Name: mergedCMName, Namespace: testNamespace,
+			}, mergedCM)
+		}, "initial merged CA ConfigMap was not created")
+
+		WaitFor(func() error {
+			if err := k8sClient.Get(ctx, types.NamespacedName{
+				Name: "test-rerun-ca", Namespace: testNamespace,
+			}, job); err != nil {
+				return err
+			}
+			if job.Status.State != lmesv1alpha1.ScheduledJobState {
+				return fmt.Errorf("expected Scheduled, got %s", job.Status.State)
+			}
+			return nil
+		}, "job did not reach Scheduled state")
+
+		pod := &corev1.Pod{}
+		WaitFor(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{
+				Name: "test-rerun-ca", Namespace: testNamespace,
+			}, pod)
+		}, "initial pod was not created")
+
+		// Verify initial pod has CA volume
+		foundVolume := false
+		for _, v := range pod.Spec.Volumes {
+			if v.Name == lmes.CABundleVolumeName {
+				foundVolume = true
+				Expect(v.VolumeSource.ConfigMap.Name).To(Equal(mergedCMName))
+			}
+		}
+		Expect(foundVolume).To(BeTrue(), "initial pod missing CA bundle volume")
+
+		// Mark as Complete, then update the spec to trigger re-run
+		job.Status.State = lmesv1alpha1.CompleteJobState
+		job.Status.Reason = lmesv1alpha1.SucceedReason
+		now := metav1.Now()
+		job.Status.CompleteTime = &now
+		Expect(k8sClient.Status().Update(ctx, job)).Should(Succeed())
+
+		Eventually(func() error {
+			if err := k8sClient.Get(ctx, types.NamespacedName{
+				Name: "test-rerun-ca", Namespace: testNamespace,
+			}, job); err != nil {
+				return err
+			}
+			job.Spec.ModelArgs = []lmesv1alpha1.Arg{
+				{Name: "pretrained", Value: "google/flan-t5-small"},
+				{Name: "base_url", Value: "https://model.svc.cluster.local:8443"},
+			}
+			return k8sClient.Update(ctx, job)
+		}, defaultTimeout, defaultPolling).Should(Succeed(), "failed to update HTTPS job spec")
+
+		// Wait for the job to be reset and re-scheduled
+		WaitFor(func() error {
+			if err := k8sClient.Get(ctx, types.NamespacedName{
+				Name: "test-rerun-ca", Namespace: testNamespace,
+			}, job); err != nil {
+				return err
+			}
+			if job.Status.State != lmesv1alpha1.ScheduledJobState {
+				return fmt.Errorf("expected Scheduled after re-run, got %s", job.Status.State)
+			}
+			return nil
+		}, "job was not re-scheduled after spec change")
+
+		// Verify the merged ConfigMap still exists with correct data after re-run
+		Expect(k8sClient.Get(ctx, types.NamespacedName{
+			Name: mergedCMName, Namespace: testNamespace,
+		}, mergedCM)).Should(Succeed())
+		Expect(mergedCM.Data).To(HaveKey(lmes.MergedCABundleKey))
+		Expect(mergedCM.Data[lmes.MergedCABundleKey]).To(ContainSubstring("public-ca"),
+			"re-run merged bundle should still contain public CAs")
 	})
 })

--- a/controllers/lmes/lmevaljob_controller_suite_test.go
+++ b/controllers/lmes/lmevaljob_controller_suite_test.go
@@ -2,6 +2,7 @@ package lmes_test
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -208,5 +209,306 @@ var _ = Describe("Simple LMEvalJob", func() {
 				)
 			}, "can't find the job pod")
 		})
+	})
+})
+
+var _ = Describe("LMEvalJob CA bundle injection", func() {
+	ctx := context.Background()
+	trueB := true
+
+	It("injects CA bundle volume, mount, and env var when base_url uses HTTPS", func() {
+		caConfigMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      lmes.DefaultCABundleConfigMapName,
+				Namespace: testNamespace,
+			},
+			Data: map[string]string{
+				"ca-bundle.crt": "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----",
+			},
+		}
+		Expect(k8sClient.Create(ctx, caConfigMap)).Should(Succeed())
+
+		job := &lmesv1alpha1.LMEvalJob{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-ca-bundle",
+				Namespace: testNamespace,
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind:       lmesv1alpha1.KindName,
+				APIVersion: lmesv1alpha1.Version,
+			},
+			Spec: lmesv1alpha1.LMEvalJobSpec{
+				AllowOnline:        &trueB,
+				AllowCodeExecution: &trueB,
+				Model:              "hf",
+				ModelArgs: []lmesv1alpha1.Arg{
+					{Name: "pretrained", Value: "google/flan-t5-base"},
+					{Name: "base_url", Value: "https://model.example.com"},
+				},
+				TaskList: lmesv1alpha1.TaskList{
+					TaskNames: []string{"task1"},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, job)).Should(Succeed())
+
+		pod := &corev1.Pod{}
+		WaitFor(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{
+				Name: "test-ca-bundle", Namespace: testNamespace,
+			}, pod)
+		}, "pod was not created for HTTPS job")
+
+		// Verify CA bundle volume
+		foundVolume := false
+		for _, v := range pod.Spec.Volumes {
+			if v.Name == lmes.CABundleVolumeName {
+				foundVolume = true
+				Expect(v.VolumeSource.ConfigMap).NotTo(BeNil())
+				Expect(v.VolumeSource.ConfigMap.Name).To(Equal(lmes.DefaultCABundleConfigMapName))
+			}
+		}
+		Expect(foundVolume).To(BeTrue(), "CA bundle volume not found on pod")
+
+		// Verify CA bundle volume mount on main container
+		mainContainer := pod.Spec.Containers[0]
+		foundMount := false
+		for _, m := range mainContainer.VolumeMounts {
+			if m.Name == lmes.CABundleVolumeName {
+				foundMount = true
+				Expect(m.MountPath).To(Equal(lmes.CABundleMountPath))
+				Expect(m.SubPath).To(Equal("ca-bundle.crt"))
+				Expect(m.ReadOnly).To(BeTrue())
+			}
+		}
+		Expect(foundMount).To(BeTrue(), "CA bundle volume mount not found on main container")
+
+		// Verify REQUESTS_CA_BUNDLE env var
+		foundEnv := false
+		for _, env := range mainContainer.Env {
+			if env.Name == "REQUESTS_CA_BUNDLE" {
+				foundEnv = true
+				Expect(env.Value).To(Equal(lmes.CABundleMountPath))
+			}
+		}
+		Expect(foundEnv).To(BeTrue(), "REQUESTS_CA_BUNDLE env var not found")
+	})
+
+	It("does not inject CA bundle when base_url uses HTTP", func() {
+		job := &lmesv1alpha1.LMEvalJob{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-no-ca-http",
+				Namespace: testNamespace,
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind:       lmesv1alpha1.KindName,
+				APIVersion: lmesv1alpha1.Version,
+			},
+			Spec: lmesv1alpha1.LMEvalJobSpec{
+				AllowOnline:        &trueB,
+				AllowCodeExecution: &trueB,
+				Model:              "hf",
+				ModelArgs: []lmesv1alpha1.Arg{
+					{Name: "pretrained", Value: "google/flan-t5-base"},
+					{Name: "base_url", Value: "http://model.example.com"},
+				},
+				TaskList: lmesv1alpha1.TaskList{
+					TaskNames: []string{"task1"},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, job)).Should(Succeed())
+
+		pod := &corev1.Pod{}
+		WaitFor(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{
+				Name: "test-no-ca-http", Namespace: testNamespace,
+			}, pod)
+		}, "pod was not created for HTTP job")
+
+		for _, v := range pod.Spec.Volumes {
+			Expect(v.Name).NotTo(Equal(lmes.CABundleVolumeName), "unexpected CA bundle volume on HTTP job")
+		}
+		for _, env := range pod.Spec.Containers[0].Env {
+			Expect(env.Name).NotTo(Equal("REQUESTS_CA_BUNDLE"), "unexpected REQUESTS_CA_BUNDLE on HTTP job")
+		}
+	})
+
+	It("does not inject CA bundle when verify_certificate is explicitly set", func() {
+		job := &lmesv1alpha1.LMEvalJob{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-no-ca-explicit",
+				Namespace: testNamespace,
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind:       lmesv1alpha1.KindName,
+				APIVersion: lmesv1alpha1.Version,
+			},
+			Spec: lmesv1alpha1.LMEvalJobSpec{
+				AllowOnline:        &trueB,
+				AllowCodeExecution: &trueB,
+				Model:              "hf",
+				ModelArgs: []lmesv1alpha1.Arg{
+					{Name: "pretrained", Value: "google/flan-t5-base"},
+					{Name: "base_url", Value: "https://model.example.com"},
+					{Name: "verify_certificate", Value: "false"},
+				},
+				TaskList: lmesv1alpha1.TaskList{
+					TaskNames: []string{"task1"},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, job)).Should(Succeed())
+
+		pod := &corev1.Pod{}
+		WaitFor(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{
+				Name: "test-no-ca-explicit", Namespace: testNamespace,
+			}, pod)
+		}, "pod was not created for job with explicit verify_certificate")
+
+		for _, v := range pod.Spec.Volumes {
+			Expect(v.Name).NotTo(Equal(lmes.CABundleVolumeName), "unexpected CA bundle volume when verify_certificate is set")
+		}
+		for _, env := range pod.Spec.Containers[0].Env {
+			Expect(env.Name).NotTo(Equal("REQUESTS_CA_BUNDLE"), "unexpected REQUESTS_CA_BUNDLE when verify_certificate is set")
+		}
+	})
+})
+
+var _ = Describe("LMEvalJob re-run after spec change", func() {
+	ctx := context.Background()
+	trueB := true
+
+	It("resets a completed job when the spec is updated", func() {
+		job := &lmesv1alpha1.LMEvalJob{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-rerun",
+				Namespace: testNamespace,
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind:       lmesv1alpha1.KindName,
+				APIVersion: lmesv1alpha1.Version,
+			},
+			Spec: lmesv1alpha1.LMEvalJobSpec{
+				AllowOnline:        &trueB,
+				AllowCodeExecution: &trueB,
+				Model:              "hf",
+				ModelArgs: []lmesv1alpha1.Arg{
+					{Name: "pretrained", Value: "google/flan-t5-base"},
+				},
+				TaskList: lmesv1alpha1.TaskList{
+					TaskNames: []string{"task1"},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, job)).Should(Succeed())
+
+		// Wait for the pod to be created and the job to reach Scheduled state
+		WaitFor(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{
+				Name: "test-rerun", Namespace: testNamespace,
+			}, &corev1.Pod{})
+		}, "initial pod was not created")
+
+		WaitFor(func() error {
+			if err := k8sClient.Get(ctx, types.NamespacedName{
+				Name: "test-rerun", Namespace: testNamespace,
+			}, job); err != nil {
+				return err
+			}
+			if job.Status.State != lmesv1alpha1.ScheduledJobState {
+				return fmt.Errorf("expected Scheduled, got %s", job.Status.State)
+			}
+			return nil
+		}, "job did not reach Scheduled state")
+
+		Expect(job.Annotations).To(HaveKey(lmes.LastScheduledGenerationAnnotation))
+
+		// Manually mark the job as Complete (no kubelet in envtest to do this)
+		job.Status.State = lmesv1alpha1.CompleteJobState
+		job.Status.Reason = lmesv1alpha1.SucceedReason
+		now := metav1.Now()
+		job.Status.CompleteTime = &now
+		Expect(k8sClient.Status().Update(ctx, job)).Should(Succeed())
+
+		// Update the spec to bump metadata.generation
+		Eventually(func() error {
+			if err := k8sClient.Get(ctx, types.NamespacedName{
+				Name: "test-rerun", Namespace: testNamespace,
+			}, job); err != nil {
+				return err
+			}
+			job.Spec.ModelArgs = []lmesv1alpha1.Arg{
+				{Name: "pretrained", Value: "google/flan-t5-small"},
+			}
+			return k8sClient.Update(ctx, job)
+		}, defaultTimeout, defaultPolling).Should(Succeed(), "failed to update job spec")
+
+		// The controller should detect the generation change and reset the job
+		WaitFor(func() error {
+			if err := k8sClient.Get(ctx, types.NamespacedName{
+				Name: "test-rerun", Namespace: testNamespace,
+			}, job); err != nil {
+				return err
+			}
+			if job.Status.State == lmesv1alpha1.CompleteJobState {
+				return fmt.Errorf("job is still Complete, waiting for re-run reset")
+			}
+			return nil
+		}, "job was not reset after spec change")
+	})
+
+	It("does not reset a completed job when the spec is unchanged", func() {
+		job := &lmesv1alpha1.LMEvalJob{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-no-rerun",
+				Namespace: testNamespace,
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind:       lmesv1alpha1.KindName,
+				APIVersion: lmesv1alpha1.Version,
+			},
+			Spec: lmesv1alpha1.LMEvalJobSpec{
+				AllowOnline:        &trueB,
+				AllowCodeExecution: &trueB,
+				Model:              "hf",
+				ModelArgs: []lmesv1alpha1.Arg{
+					{Name: "pretrained", Value: "google/flan-t5-base"},
+				},
+				TaskList: lmesv1alpha1.TaskList{
+					TaskNames: []string{"task1"},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, job)).Should(Succeed())
+
+		WaitFor(func() error {
+			if err := k8sClient.Get(ctx, types.NamespacedName{
+				Name: "test-no-rerun", Namespace: testNamespace,
+			}, job); err != nil {
+				return err
+			}
+			if job.Status.State != lmesv1alpha1.ScheduledJobState {
+				return fmt.Errorf("expected Scheduled, got %s", job.Status.State)
+			}
+			return nil
+		}, "job did not reach Scheduled state")
+
+		// Mark as Complete without changing the spec
+		job.Status.State = lmesv1alpha1.CompleteJobState
+		job.Status.Reason = lmesv1alpha1.SucceedReason
+		now := metav1.Now()
+		job.Status.CompleteTime = &now
+		Expect(k8sClient.Status().Update(ctx, job)).Should(Succeed())
+
+		// Verify the job stays Complete (no re-run triggered)
+		Consistently(func() lmesv1alpha1.JobState {
+			_ = k8sClient.Get(ctx, types.NamespacedName{
+				Name: "test-no-rerun", Namespace: testNamespace,
+			}, job)
+			return job.Status.State
+		}, time.Second*3, defaultPolling).Should(Equal(lmesv1alpha1.CompleteJobState),
+			"completed job should not be reset when spec is unchanged")
 	})
 })

--- a/controllers/lmes/lmevaljob_controller_suite_test.go
+++ b/controllers/lmes/lmevaljob_controller_suite_test.go
@@ -503,12 +503,17 @@ var _ = Describe("LMEvalJob re-run after spec change", func() {
 		Expect(k8sClient.Status().Update(ctx, job)).Should(Succeed())
 
 		// Verify the job stays Complete (no re-run triggered)
-		Consistently(func() lmesv1alpha1.JobState {
-			_ = k8sClient.Get(ctx, types.NamespacedName{
+		Consistently(func() error {
+			if err := k8sClient.Get(ctx, types.NamespacedName{
 				Name: "test-no-rerun", Namespace: testNamespace,
-			}, job)
-			return job.Status.State
-		}, time.Second*3, defaultPolling).Should(Equal(lmesv1alpha1.CompleteJobState),
+			}, job); err != nil {
+				return err
+			}
+			if job.Status.State != lmesv1alpha1.CompleteJobState {
+				return fmt.Errorf("expected Complete, got %s", job.Status.State)
+			}
+			return nil
+		}, time.Second*3, defaultPolling).Should(Succeed(),
 			"completed job should not be reset when spec is unchanged")
 	})
 })

--- a/controllers/lmes/lmevaljob_controller_test.go
+++ b/controllers/lmes/lmevaljob_controller_test.go
@@ -4546,17 +4546,18 @@ func Test_CreatePodWithCABundle(t *testing.T) {
 		},
 	}
 
+	mergedCMName := "test-ca" + MergedCAConfigMapSuffix
 	caBundle := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      DefaultCABundleConfigMapName,
+			Name:      mergedCMName,
 			Namespace: "default",
 		},
 		Data: map[string]string{
-			"ca-bundle.crt": "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----",
+			MergedCABundleKey: "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----",
 		},
 	}
 
-	pod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), caBundle, "ca-bundle.crt", log)
+	pod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), caBundle, MergedCABundleKey, log)
 	require.NotNil(t, pod)
 
 	// Verify CA bundle volume exists
@@ -4565,7 +4566,7 @@ func Test_CreatePodWithCABundle(t *testing.T) {
 		if v.Name == CABundleVolumeName {
 			foundVolume = true
 			require.NotNil(t, v.VolumeSource.ConfigMap)
-			assert.Equal(t, DefaultCABundleConfigMapName, v.VolumeSource.ConfigMap.Name)
+			assert.Equal(t, mergedCMName, v.VolumeSource.ConfigMap.Name)
 			break
 		}
 	}
@@ -4578,7 +4579,7 @@ func Test_CreatePodWithCABundle(t *testing.T) {
 		if m.Name == CABundleVolumeName {
 			foundMount = true
 			assert.Equal(t, CABundleMountPath, m.MountPath)
-			assert.Equal(t, "ca-bundle.crt", m.SubPath)
+			assert.Equal(t, MergedCABundleKey, m.SubPath)
 			assert.True(t, m.ReadOnly)
 			break
 		}

--- a/controllers/lmes/lmevaljob_controller_test.go
+++ b/controllers/lmes/lmevaljob_controller_test.go
@@ -4371,3 +4371,268 @@ func Test_OCIPodConfiguration(t *testing.T) {
 		assert.Equal(t, "sha256:a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef12345678", envMap["OCI_SUBJECT"].Value)
 	})
 }
+
+func Test_hasHTTPSBaseURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []lmesv1alpha1.Arg
+		expected bool
+	}{
+		{
+			name:     "https base_url",
+			args:     []lmesv1alpha1.Arg{{Name: "base_url", Value: "https://model.example.com"}},
+			expected: true,
+		},
+		{
+			name:     "http base_url",
+			args:     []lmesv1alpha1.Arg{{Name: "base_url", Value: "http://model.example.com"}},
+			expected: false,
+		},
+		{
+			name:     "uppercase HTTPS base_url",
+			args:     []lmesv1alpha1.Arg{{Name: "base_url", Value: "HTTPS://model.example.com"}},
+			expected: true,
+		},
+		{
+			name:     "no base_url arg",
+			args:     []lmesv1alpha1.Arg{{Name: "pretrained", Value: "google/flan-t5-base"}},
+			expected: false,
+		},
+		{
+			name:     "empty args",
+			args:     nil,
+			expected: false,
+		},
+		{
+			name: "other arg with https value",
+			args: []lmesv1alpha1.Arg{{Name: "endpoint", Value: "https://other.example.com"}},
+			expected: false,
+		},
+		{
+			name: "base_url among multiple args",
+			args: []lmesv1alpha1.Arg{
+				{Name: "pretrained", Value: "google/flan-t5-base"},
+				{Name: "base_url", Value: "https://model.example.com"},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job := &lmesv1alpha1.LMEvalJob{
+				Spec: lmesv1alpha1.LMEvalJobSpec{ModelArgs: tt.args},
+			}
+			assert.Equal(t, tt.expected, hasHTTPSBaseURL(job))
+		})
+	}
+}
+
+func Test_hasExplicitVerifyCertificate(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []lmesv1alpha1.Arg
+		expected bool
+	}{
+		{
+			name:     "verify_certificate present",
+			args:     []lmesv1alpha1.Arg{{Name: "verify_certificate", Value: "false"}},
+			expected: true,
+		},
+		{
+			name:     "verify_certificate absent",
+			args:     []lmesv1alpha1.Arg{{Name: "pretrained", Value: "google/flan-t5-base"}},
+			expected: false,
+		},
+		{
+			name:     "empty args",
+			args:     nil,
+			expected: false,
+		},
+		{
+			name: "verify_certificate among multiple args",
+			args: []lmesv1alpha1.Arg{
+				{Name: "base_url", Value: "https://model.example.com"},
+				{Name: "verify_certificate", Value: "true"},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job := &lmesv1alpha1.LMEvalJob{
+				Spec: lmesv1alpha1.LMEvalJobSpec{ModelArgs: tt.args},
+			}
+			assert.Equal(t, tt.expected, hasExplicitVerifyCertificate(job))
+		})
+	}
+}
+
+func Test_getLastScheduledGeneration(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    int64
+	}{
+		{
+			name:        "nil annotations",
+			annotations: nil,
+			expected:    0,
+		},
+		{
+			name:        "annotation missing",
+			annotations: map[string]string{"other": "value"},
+			expected:    0,
+		},
+		{
+			name:        "valid generation",
+			annotations: map[string]string{LastScheduledGenerationAnnotation: "5"},
+			expected:    5,
+		},
+		{
+			name:        "invalid generation",
+			annotations: map[string]string{LastScheduledGenerationAnnotation: "notanumber"},
+			expected:    0,
+		},
+		{
+			name:        "empty string",
+			annotations: map[string]string{LastScheduledGenerationAnnotation: ""},
+			expected:    0,
+		},
+		{
+			name:        "zero generation",
+			annotations: map[string]string{LastScheduledGenerationAnnotation: "0"},
+			expected:    0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job := &lmesv1alpha1.LMEvalJob{
+				ObjectMeta: metav1.ObjectMeta{Annotations: tt.annotations},
+			}
+			assert.Equal(t, tt.expected, getLastScheduledGeneration(job))
+		})
+	}
+}
+
+func Test_CreatePodWithCABundle(t *testing.T) {
+	log := log.FromContext(context.Background())
+	svcOpts := &serviceOptions{
+		PodImage:        "podimage:latest",
+		DriverImage:     "driver:latest",
+		ImagePullPolicy: corev1.PullAlways,
+	}
+
+	job := &lmesv1alpha1.LMEvalJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ca",
+			Namespace: "default",
+			UID:       "for-testing",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       lmesv1alpha1.KindName,
+			APIVersion: lmesv1alpha1.Version,
+		},
+		Spec: lmesv1alpha1.LMEvalJobSpec{
+			Model: "hf",
+			ModelArgs: []lmesv1alpha1.Arg{
+				{Name: "base_url", Value: "https://model.example.com"},
+			},
+			TaskList: lmesv1alpha1.TaskList{
+				TaskNames: []string{"task1"},
+			},
+		},
+	}
+
+	caBundle := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DefaultCABundleConfigMapName,
+			Namespace: "default",
+		},
+		Data: map[string]string{
+			"ca-bundle.crt": "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----",
+		},
+	}
+
+	pod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), caBundle, "ca-bundle.crt", log)
+	require.NotNil(t, pod)
+
+	// Verify CA bundle volume exists
+	var foundVolume bool
+	for _, v := range pod.Spec.Volumes {
+		if v.Name == CABundleVolumeName {
+			foundVolume = true
+			require.NotNil(t, v.VolumeSource.ConfigMap)
+			assert.Equal(t, DefaultCABundleConfigMapName, v.VolumeSource.ConfigMap.Name)
+			break
+		}
+	}
+	assert.True(t, foundVolume, "expected volume %q not found", CABundleVolumeName)
+
+	// Verify CA bundle volume mount on main container
+	mainContainer := pod.Spec.Containers[0]
+	var foundMount bool
+	for _, m := range mainContainer.VolumeMounts {
+		if m.Name == CABundleVolumeName {
+			foundMount = true
+			assert.Equal(t, CABundleMountPath, m.MountPath)
+			assert.Equal(t, "ca-bundle.crt", m.SubPath)
+			assert.True(t, m.ReadOnly)
+			break
+		}
+	}
+	assert.True(t, foundMount, "expected volume mount %q not found", CABundleVolumeName)
+
+	// Verify REQUESTS_CA_BUNDLE env var
+	envMap := make(map[string]string)
+	for _, env := range mainContainer.Env {
+		envMap[env.Name] = env.Value
+	}
+	assert.Equal(t, CABundleMountPath, envMap["REQUESTS_CA_BUNDLE"])
+}
+
+func Test_CreatePodWithoutCABundle(t *testing.T) {
+	log := log.FromContext(context.Background())
+	svcOpts := &serviceOptions{
+		PodImage:        "podimage:latest",
+		DriverImage:     "driver:latest",
+		ImagePullPolicy: corev1.PullAlways,
+	}
+
+	job := &lmesv1alpha1.LMEvalJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-no-ca",
+			Namespace: "default",
+			UID:       "for-testing",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       lmesv1alpha1.KindName,
+			APIVersion: lmesv1alpha1.Version,
+		},
+		Spec: lmesv1alpha1.LMEvalJobSpec{
+			Model: "hf",
+			ModelArgs: []lmesv1alpha1.Arg{
+				{Name: "base_url", Value: "http://model.example.com"},
+			},
+			TaskList: lmesv1alpha1.TaskList{
+				TaskNames: []string{"task1"},
+			},
+		},
+	}
+
+	pod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), nil, "", log)
+	require.NotNil(t, pod)
+
+	// Verify no CA bundle volume
+	for _, v := range pod.Spec.Volumes {
+		assert.NotEqual(t, CABundleVolumeName, v.Name, "unexpected CA bundle volume")
+	}
+
+	// Verify no REQUESTS_CA_BUNDLE env var
+	mainContainer := pod.Spec.Containers[0]
+	for _, env := range mainContainer.Env {
+		assert.NotEqual(t, "REQUESTS_CA_BUNDLE", env.Name, "unexpected REQUESTS_CA_BUNDLE env var")
+	}
+}

--- a/controllers/lmes/lmevaljob_controller_test.go
+++ b/controllers/lmes/lmevaljob_controller_test.go
@@ -188,7 +188,7 @@ func Test_SimplePod(t *testing.T) {
 		},
 	}
 
-	newPod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), log)
+	newPod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), nil, "", log)
 
 	assert.Equal(t, expect, newPod)
 }
@@ -453,7 +453,7 @@ func Test_WithCustomPod(t *testing.T) {
 		},
 	}
 
-	newPod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), log)
+	newPod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), nil, "", log)
 
 	assert.Equal(t, expect, newPod)
 
@@ -468,7 +468,7 @@ func Test_WithCustomPod(t *testing.T) {
 		"custom/annotation1": "annotation1",
 	}
 
-	newPod = CreatePod(svcOpts, job, NewDefaultPermissionConfig(), log)
+	newPod = CreatePod(svcOpts, job, NewDefaultPermissionConfig(), nil, "", log)
 	assert.Equal(t, expect, newPod)
 }
 
@@ -644,7 +644,7 @@ func Test_EnvSecretsPod(t *testing.T) {
 		},
 	}
 
-	newPod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), log)
+	newPod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), nil, "", log)
 	// maybe only verify the envs: Containers[0].Env
 	assert.Equal(t, expect, newPod)
 }
@@ -839,7 +839,7 @@ func Test_FileSecretsPod(t *testing.T) {
 		},
 	}
 
-	newPod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), log)
+	newPod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), nil, "", log)
 	// maybe only verify the envs: Containers[0].Env
 	assert.Equal(t, expect, newPod)
 }
@@ -1789,7 +1789,7 @@ func Test_ManagedPVC(t *testing.T) {
 		},
 	}
 
-	newPod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), log)
+	newPod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), nil, "", log)
 
 	assert.Equal(t, expect, newPod)
 }
@@ -1956,7 +1956,7 @@ func Test_ExistingPVC(t *testing.T) {
 		},
 	}
 
-	newPod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), log)
+	newPod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), nil, "", log)
 
 	assert.Equal(t, expect, newPod)
 }
@@ -2146,7 +2146,7 @@ func Test_PVCPreference(t *testing.T) {
 		},
 	}
 
-	newPod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), log)
+	newPod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), nil, "", log)
 
 	assert.Equal(t, expect, newPod)
 }
@@ -2335,7 +2335,7 @@ func Test_OfflineMode(t *testing.T) {
 		},
 	}
 
-	newPod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), log)
+	newPod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), nil, "", log)
 
 	assert.Equal(t, expect, newPod)
 }
@@ -2556,7 +2556,7 @@ func Test_ProtectedVars(t *testing.T) {
 		},
 	}
 
-	newPod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), log)
+	newPod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), nil, "", log)
 
 	assert.Equal(t, expect, newPod)
 }
@@ -2752,7 +2752,7 @@ func Test_OnlineModeDisabled(t *testing.T) {
 		},
 	}
 
-	newPod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), log)
+	newPod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), nil, "", log)
 
 	assert.Equal(t, expect, newPod)
 }
@@ -2929,7 +2929,7 @@ func Test_OnlineMode(t *testing.T) {
 		},
 	}
 
-	newPod := CreatePod(svcOpts, job, permConfig, log)
+	newPod := CreatePod(svcOpts, job, permConfig, nil, "", log)
 
 	assert.Equal(t, expect, newPod)
 }
@@ -3109,7 +3109,7 @@ func Test_AllowCodeOnlineMode(t *testing.T) {
 		},
 	}
 
-	newPod := CreatePod(svcOpts, job, permConfig, log)
+	newPod := CreatePod(svcOpts, job, permConfig, nil, "", log)
 
 	assert.Equal(t, expect, newPod)
 }
@@ -3307,7 +3307,7 @@ func Test_AllowCodeOfflineMode(t *testing.T) {
 		},
 	}
 
-	newPod := CreatePod(svcOpts, job, permConfig, log)
+	newPod := CreatePod(svcOpts, job, permConfig, nil, "", log)
 
 	assert.Equal(t, expect, newPod)
 }
@@ -3512,7 +3512,7 @@ func Test_OfflineModeWithOutput(t *testing.T) {
 		},
 	}
 
-	newPod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), log)
+	newPod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), nil, "", log)
 
 	assert.Equal(t, expect, newPod)
 }
@@ -3622,7 +3622,7 @@ func Test_CustomTasksGitSource(t *testing.T) {
 				},
 			}
 
-			pod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), log)
+			pod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), nil, "", log)
 
 			require.NotNil(t, pod)
 
@@ -3713,7 +3713,7 @@ func Test_CustomTasksGitSourceOfflineMode(t *testing.T) {
 
 	logger := logr.Discard()
 
-	pod := CreatePod(Options, job, NewDefaultPermissionConfig(), logger)
+	pod := CreatePod(Options, job, NewDefaultPermissionConfig(), nil, "", logger)
 
 	if pod == nil {
 		t.Fatal("pod should not be nil")
@@ -4016,7 +4016,7 @@ func Test_OCIPodConfiguration(t *testing.T) {
 		hasOCI := job.Spec.HasOCIOutput()
 		assert.True(t, hasOCI, "Job should have OCI output configured")
 
-		pod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), logger)
+		pod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), nil, "", logger)
 		assert.NotNil(t, pod, "Should generate pod successfully")
 
 		// Check environment variables
@@ -4072,7 +4072,7 @@ func Test_OCIPodConfiguration(t *testing.T) {
 			},
 		}
 
-		pod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), logger)
+		pod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), nil, "", logger)
 		assert.NotNil(t, pod, "Should generate pod successfully")
 
 		// Check environment variables
@@ -4144,7 +4144,7 @@ func Test_OCIPodConfiguration(t *testing.T) {
 			},
 		}
 
-		pod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), logger)
+		pod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), nil, "", logger)
 		assert.NotNil(t, pod, "Should generate pod successfully")
 
 		// Check environment variables
@@ -4187,7 +4187,7 @@ func Test_OCIPodConfiguration(t *testing.T) {
 			},
 		}
 
-		pod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), logger)
+		pod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), nil, "", logger)
 		assert.NotNil(t, pod, "Should generate pod successfully")
 
 		// Check environment variables
@@ -4229,7 +4229,7 @@ func Test_OCIPodConfiguration(t *testing.T) {
 			},
 		}
 
-		pod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), logger)
+		pod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), nil, "", logger)
 		assert.NotNil(t, pod, "Should generate pod successfully")
 
 		// Check environment variables
@@ -4271,7 +4271,7 @@ func Test_OCIPodConfiguration(t *testing.T) {
 			},
 		}
 
-		pod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), logger)
+		pod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), nil, "", logger)
 		assert.NotNil(t, pod, "Should generate pod successfully")
 
 		// Check environment variables
@@ -4313,7 +4313,7 @@ func Test_OCIPodConfiguration(t *testing.T) {
 			},
 		}
 
-		pod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), logger)
+		pod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), nil, "", logger)
 		assert.NotNil(t, pod, "Should generate pod successfully")
 
 		// Check environment variables
@@ -4356,7 +4356,7 @@ func Test_OCIPodConfiguration(t *testing.T) {
 			},
 		}
 
-		pod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), logger)
+		pod := CreatePod(svcOpts, job, NewDefaultPermissionConfig(), nil, "", logger)
 		assert.NotNil(t, pod, "Should generate pod successfully")
 
 		// Check environment variables


### PR DESCRIPTION
Jira: [RHOAIENG-60487](https://issues.redhat.com/browse/RHOAIENG-60487)

## Summary

Fixes two issues in the LMEval operator.

### SSL failure on HTTPS endpoints (external routes and cluster-internal services)

When a model is deployed with *Make model deployment available through an external route* enabled, OpenShift creates an HTTPS ingress signed by the cluster's self-signed CA. Similarly, cluster-internal services (`*.svc.cluster.local`) use certificates signed by the OpenShift service-serving CA. The lm-eval pod has no knowledge of either CA, so Python's `requests` library rejects the connection:

```
ssl.SSLCertVerificationError: certificate verify failed: self-signed certificate in certificate chain
```

`REQUESTS_CA_BUNDLE` replaces Python's default trust store entirely, so mounting a single CA source loses all others.

Fix: in `handleNewCR` and `handleResume`, if any `modelArg` named `base_url` uses an `https://` scheme and `verify_certificate` is not already set, the operator collects CA certificates from multiple well-known cluster sources:
- `odh-trusted-ca-bundle`: `ca-bundle.crt` and `odh-ca-bundle.crt` keys (public/system CAs, injected by the RHOAI operator)
- `openshift-service-ca.crt`: `service-ca.crt` key (service-serving CA for `*.svc.cluster.local`)

All found PEM data is concatenated into a per-job merged ConfigMap (`<jobName>-ca-bundle`) with an owner reference to the LMEvalJob for automatic GC. The merged ConfigMap is mounted at `/etc/ssl/certs/odh-ca-bundle.crt` and `REQUESTS_CA_BUNDLE` is set to that path. Each source is best-effort — missing ConfigMaps are skipped, but real API errors (Create/Update failures on the merged ConfigMap) are propagated so the reconciler retries.

### Completed job cannot be re-run after spec edit

Once a job reaches `CompleteJobState` (including `Failed` reason), editing the spec has no effect. The operator does not watch for spec changes on completed jobs, and there is no supported way to reset the status through the status subresource via `oc patch`.

Fix: `handleNewCR` and `handleResume` both write the current `metadata.Generation` into an annotation (`trustyai.opendatahub.io/last-scheduled-generation`) each time a pod is created. In `Reconcile`, a new guard checks completed jobs: if the current generation exceeds the stored value, the completed pod is deleted and the status is fully reset to `New` (clearing `lastScheduleTime`, `completeTime`, `podName`, `reason`, `message`, `progressBars`, `results`); the next reconcile cycle re-runs the job. The `lastGen > 0` guard means jobs created before this change are never accidentally reset. Recording the annotation in `handleResume` also prevents a spurious extra re-run when the spec is edited while a job is suspended and then resumed.

### Pre-existing bug fix: metrics label cardinality panic

The `createJobCreationMetrics` function in the controller builds a Prometheus `CounterVec` with label names derived from the first `LMEvalJob` it processes. If a subsequent job has different `modelArgs` (e.g. one has `base_url` and another doesn't), the label count mismatches and Prometheus panics with `inconsistent label cardinality`. This bug exists on `main` but is not surfaced because there is only one LMES test case. Our new CA bundle tests create jobs with varying `modelArgs`, exposing the panic.

Fix: always initialize both `model_name` and `base_url` labels to empty strings before populating from `modelArgs`, ensuring every job produces the same 6-label set. This is committed separately from the main fixes.

## Steps to reproduce

### Setup

1. Provision an OpenShift cluster with GPUs
2. Install RHOAI 3.4ea2 (or later)
3. Deploy an LLM (e.g. TinyLlama) with **"Make model deployment available through an external route"** enabled — this creates an HTTPS ingress signed by the cluster's self-signed CA
4. Enable evaluations in the UI by setting `disableLMEval` to `false` in the `OdhDashboardConfig` CR

### Bug 1: SSL failure on HTTPS endpoints

5. Create an evaluation run from the RHOAI Dashboard UI targeting the deployed model. The UI generates an `LMEvalJob` CR with `base_url: https://<model>.<namespace>.apps.<cluster-domain>/v1/completions`.

6. The pod starts, downloads the dataset, but fails at the first API request:

   ```
   ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed:
     self-signed certificate in certificate chain (_ssl.c:1004)
   ```

7. The job enters `Complete` state with `reason: Failed`.

The RHOAI Dashboard UI provides no mechanism to set `verify_certificate` or mount custom CA bundles, so there is no workaround from the UI.

**Minimal reproducer (CLI):**

```yaml
apiVersion: trustyai.opendatahub.io/v1alpha1
kind: LMEvalJob
metadata:
  name: test-ssl
spec:
  allowOnline: true
  model: local-completions
  modelArgs:
  - name: model
    value: tinyllama
  - name: base_url
    value: https://<model>.<namespace>.apps.<cluster-domain>/v1/completions
  taskList:
    taskNames:
    - arc_easy
```

Any `LMEvalJob` with an `https://` value in `base_url` triggers the issue. The operator does not inject cluster CA certificates, so the pod has no way to verify the server's certificate.

Note: Our envtest integration tests use `model: hf` with a synthetic `base_url` because they only verify the operator's pod-spec injection (volumes, mounts, env vars) — lm-eval never actually runs in envtest.

### Bug 2: Completed job cannot be re-run after spec edit

Continuing from Bug 1, the user tries to fix the failed job by editing the spec:

1. The job is in `Complete` state with `reason: Failed` after the SSL error.

2. Edit the LMEvalJob spec (e.g. change a modelArg):

   ```bash
   oc edit lmevaljob test-ssl
   # Change the pretrained model value, or add verify_certificate
   ```

3. Nothing happens — the job stays `Complete` and no new pod is created:

   ```bash
   $ oc get lmevaljob test-ssl
   NAME       STATE
   test-ssl   Complete
   ```

4. Attempting to reset the status via `oc patch` has no effect (the status subresource is separate):

   ```bash
   $ oc patch lmevaljob test-ssl --type=merge -p '{"status": {"state": "New"}}'
   lmevaljob.trustyai.opendatahub.io/test-ssl patched (no change)
   ```

5. Deleting the failed pod does not trigger a new pod creation either.

The only workaround is to delete the entire `LMEvalJob` and create a new one.

### Note: RHOAI Dashboard UI does not expose TLS options (not addressed here)

The RHOAI Dashboard UI creates `LMEvalJob` CRs with no mechanism for users to set `verify_certificate`, mount custom CA bundles, or reference cert secrets. This means jobs created from the UI will always fail against external HTTPS endpoints unless the operator handles CA injection automatically.

This PR addresses the common case: when `odh-trusted-ca-bundle` exists in the namespace (injected by the RHOAI operator), the cluster CA is mounted transparently and UI-created jobs with HTTPS endpoints work without any user intervention.

However, edge cases remain where automatic injection is not sufficient:
- Clusters where the RHOAI operator does not inject `odh-trusted-ca-bundle` into the namespace
- Models behind custom (non-cluster) CAs that require a user-supplied certificate path
- Users who need to explicitly disable verification (`verify_certificate: "False"`) for testing

These cases still require CLI intervention (`oc edit` / `oc patch` on the `LMEvalJob` spec). Exposing TLS options in the Dashboard UI is a separate concern tracked outside this PR.

## Changed files

| File | Change |
|---|---|
| `controllers/lmes/constants.go` | New constants for CA bundle ConfigMap names, volume name, mount path, merged key, and annotation key |
| `controllers/lmes/lmevaljob_controller.go` | `CreatePod` signature extended with CA params; `findAndMergeCABundle` merges multiple CA sources into per-job ConfigMap; `resolveCABundle` helper with proper error handling (sentinel for no-data vs. API errors); `recordScheduledGeneration` helper; re-run detection with pod cleanup in `Reconcile`; metrics label cardinality fix; RBAC marker updated to `create;update` for ConfigMaps |
| `controllers/lmes/lmevaljob_controller_test.go` | All direct `CreatePod` calls updated to pass `nil, ""` for the new CA bundle params; unit tests for `hasHTTPSBaseURL`, `hasExplicitVerifyCertificate`, `getLastScheduledGeneration`, `CreatePodWithCABundle`, `CreatePodWithoutCABundle` |
| `controllers/lmes/lmevaljob_controller_suite_test.go` | Integration tests for CA bundle injection (HTTPS, HTTP negative, verify_certificate negative, merged multi-source), re-run logic (spec change resets, unchanged stays Complete), and re-run + CA integration |
| `controllers/job_mgr/job_mgr_controller.go` | `CreatePod` call updated for new CA bundle parameters (passes `nil, ""` — tracked in #730) |
| `config/components/lmes/rbac/manager-rbac.yaml` | Generated RBAC adds `create;update` verbs for ConfigMaps |

## Testing

### Unit / integration tests (envtest)

Tests in `controllers/lmes/lmevaljob_controller_suite_test.go` run against a controller-runtime envtest environment with real CRDs:

| Test | What it verifies |
|---|---|
| **CA injection — HTTPS** | Pod created for a job with `base_url: https://...` gets a merged ConfigMap containing the CA data, with the volume, mount at `/etc/ssl/certs/odh-ca-bundle.crt`, and `REQUESTS_CA_BUNDLE` env var |
| **CA injection — merged multi-source** | When both `odh-trusted-ca-bundle` and `openshift-service-ca.crt` exist, the merged ConfigMap contains data from both sources |
| **CA injection — HTTP (negative)** | Pod created for a job with `base_url: http://...` has no CA volume or env var |
| **CA injection — verify_certificate set (negative)** | Pod created for a job with `base_url: https://...` AND `verify_certificate: false` has no CA volume or env var |
| **CA injection — missing ConfigMap (negative)** | The "Simple LMEvalJob" test creates a job without any CA ConfigMaps in the namespace — the job proceeds normally without CA injection |
| **Re-run — spec change resets job** | A completed job whose spec is edited (bumping `metadata.Generation`) is reset to `New` and a new pod is created; the `last-scheduled-generation` annotation is set |
| **Re-run — unchanged spec stays Complete** | A completed job whose spec is not edited remains `Complete` (no spurious re-run) |
| **Re-run + CA integration** | An HTTPS job that completes and is re-run after spec change retains its merged CA ConfigMap with correct data |

### Manual integration tests (live OpenShift cluster)

Operator run locally (`go run ./cmd/main.go --enable-services LMES`) against a live OpenShift cluster. Both bugs were first reproduced on `main`, then verified fixed on the PR branch. Each test created an `LMEvalJob` CR and inspected the resulting pod spec and job status.

An `odh-trusted-ca-bundle` ConfigMap was pre-created in the test namespace to simulate the RHOAI-managed CA bundle.

| Test | From `main` | From PR branch | Pass |
|---|---|---|---|
| HTTPS job pod has CA volume, mount, and `REQUESTS_CA_BUNDLE` | Not present | Present | ✅ |
| HTTP job pod has no CA injection | N/A | Not present | ✅ |
| HTTPS + explicit `verify_certificate` has no CA injection | N/A | Not present | ✅ |
| Completed job resets to `New` after spec edit | Stays `Complete` | Resets → new pod | ✅ |
| Completed job stays `Complete` when spec is unchanged | Stays `Complete` | Stays `Complete` | ✅ |
| `last-scheduled-generation` annotation set on schedule | N/A | Set to `1` | ✅ |

All tests passed on both envtest and live cluster.

## CI status

| Check | Status | Notes |
|---|---|---|
| `build` (unit + integration tests) | ✅ Pass | |
| `deploy` | ✅ Pass | |
| `ci/prow/images` | ✅ Pass | |
| `lintAllTheThings` | ✅ Pass | |
| `Gosec Security Scanner` | ✅ Pass | |
| `ci/prow/trustyai-service-operator-e2e` | ❌ Fail | **Pre-existing infrastructure failure.** Failing on all recent PRs including merged #731 and #726. Not related to this PR's changes. |
| `Trivy Security Scan` | ❌ Fail | **Pre-existing dependency vulnerabilities.** `go.opentelemetry.io/otel` (CVE-2026-29181) and `urllib3` in `tests/Pipfile.lock` (CVE-2026-44431, CVE-2026-44432). Failing on all PRs including `main`. Not related to this PR's changes. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
