### PR TITLE
chore(evalhub): add context-aware vulnerability scan benchmark

### DIFF
--- a/config/configmaps/evalhub/provider-garak.yaml
+++ b/config/configmaps/evalhub/provider-garak.yaml
@@ -28,6 +28,21 @@ data:
       local:
         command: 'true'
     benchmarks:
+    - id: intents
+      name: Context-aware vulnerability scan
+      description: Risk assessment with a context-aware custom intent typology and probes of increasing complexity.
+      category: security
+      metrics:
+      - attack_success_rate
+      tags:
+      - security
+      - intents
+      - red_team
+      primary_score:
+        metric: attack_success_rate
+        lower_is_better: true
+      pass_criteria:
+        threshold: 0.3
     - id: owasp_llm_top10
       name: OWASP LLM top 10 risk scan
       description: Tests against the top 10 security risks specific to LLM applications.


### PR DESCRIPTION
With https://github.com/trustyai-explainability/llama-stack-provider-trustyai-garak/pull/163 we enable `intents` benchmark for non-kfp mode. This PR adds the corresponding `intents` benchmark to the non-kfp `garak` config.

Resolves [RHOAIENG-63138](https://redhat.atlassian.net/browse/RHOAIENG-63138)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new vulnerability scan benchmark with configurable security evaluation metrics and pass criteria thresholds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trustyai-explainability/trustyai-service-operator/pull/736?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->