### PR TITLE
fix(evalhub): remove hardcoded namespace fallback in ConfigMap lookup

### DIFF
--- a/controllers/evalhub/build_test.go
+++ b/controllers/evalhub/build_test.go
@@ -384,7 +384,7 @@ var _ = Describe("buildServiceSpec", func() {
 	})
 })
 
-var _ = Describe("getEvalHubImage", func() {
+var _ = Describe("getImageFromConfigMap", func() {
 	It("returns the image from the operator ConfigMap", func() {
 		nsName := fmt.Sprintf("evalhub-getimage-%d", time.Now().UnixNano())
 		ns := createNamespace(nsName)
@@ -406,12 +406,12 @@ var _ = Describe("getEvalHubImage", func() {
 			Client:    k8sClient,
 			Namespace: nsName,
 		}
-		image, err := r.getEvalHubImage(ctx)
+		image, err := r.getImageFromConfigMap(ctx, configMapEvalHubImageKey)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(image).To(Equal("quay.io/test/eval-hub:custom"))
 	})
 
-	It("returns the fallback image and an error when the ConfigMap is not found", func() {
+	It("returns an error when the ConfigMap is not found", func() {
 		emptyNS := fmt.Sprintf("evalhub-getimage-empty-%d", time.Now().UnixNano())
 		empty := createNamespace(emptyNS)
 		Expect(k8sClient.Create(ctx, empty)).To(Succeed())
@@ -421,34 +421,18 @@ var _ = Describe("getEvalHubImage", func() {
 			Client:    k8sClient,
 			Namespace: emptyNS,
 		}
-		image, err := r.getEvalHubImage(ctx)
+		_, err := r.getImageFromConfigMap(ctx, configMapEvalHubImageKey)
 		Expect(err).To(HaveOccurred())
-		Expect(image).To(Equal(defaultEvalHubImage))
+		Expect(err.Error()).To(ContainSubstring("not found"))
 	})
 
-	It("resolves the operator namespace when reconciler.Namespace is empty", func() {
-		const systemNS = "trustyai-service-operator-system"
-		sys := createNamespace(systemNS)
-		Expect(k8sClient.Create(ctx, sys)).To(Succeed())
-		defer deleteNamespace(sys)
-
-		cm := &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      configMapName,
-				Namespace: systemNS,
-			},
-			Data: map[string]string{
-				configMapEvalHubImageKey: "quay.io/test/eval-hub:default-ns",
-			},
-		}
-		Expect(k8sClient.Create(ctx, cm)).To(Succeed())
-
+	It("returns an error when reconciler.Namespace is empty", func() {
 		r := &EvalHubReconciler{
 			Client:    k8sClient,
 			Namespace: "",
 		}
-		image, err := r.getEvalHubImage(ctx)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(image).To(Equal("quay.io/test/eval-hub:default-ns"))
+		_, err := r.getImageFromConfigMap(ctx, configMapEvalHubImageKey)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("operator namespace not set"))
 	})
 })

--- a/controllers/evalhub/configmap.go
+++ b/controllers/evalhub/configmap.go
@@ -351,7 +351,7 @@ func (r *EvalHubReconciler) getImageFromConfigMap(ctx context.Context, key strin
 	// Define the key for the ConfigMap
 	configMapKey := types.NamespacedName{
 		Namespace: r.Namespace,
-		Name:      configMapName,
+		Name:      r.effectiveOperatorConfigMapName(),
 	}
 
 	// Create an empty ConfigMap object
@@ -363,11 +363,10 @@ func (r *EvalHubReconciler) getImageFromConfigMap(ctx context.Context, key strin
 		if errors.IsNotFound(err) {
 			// ConfigMap not found - FAIL deployment with clear error
 			return "", fmt.Errorf("required configmap '%s' not found in namespace '%s' - operator configuration missing",
-				configMapName, r.Namespace)
+				configMapKey.Name, r.Namespace)
 		}
-		// Other error occurred when trying to fetch the ConfigMap
 		return "", fmt.Errorf("error reading configmap '%s' in namespace '%s': %w",
-			configMapName, r.Namespace, err)
+			configMapKey.Name, r.Namespace, err)
 	}
 
 	log.V(1).Info("Found ConfigMap", "configmap", configMapKey)

--- a/controllers/evalhub/deployment.go
+++ b/controllers/evalhub/deployment.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	evalhubv1alpha1 "github.com/trustyai-explainability/trustyai-service-operator/api/evalhub/v1alpha1"
-	"github.com/trustyai-explainability/trustyai-service-operator/controllers/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -74,7 +73,7 @@ func (r *EvalHubReconciler) buildDeploymentSpec(ctx context.Context, instance *e
 		evalHubImage = defaultEvalHubImage
 	}
 
-	kubeRBACProxyImage, err := r.getKubeRBACProxyImage(ctx)
+	kubeRBACProxyImage, err := r.getImageFromConfigMap(ctx, configMapKubeRBACProxyImageKey)
 	if err != nil {
 		return appsv1.DeploymentSpec{}, fmt.Errorf("getting kube-rbac-proxy image: %w", err)
 	}
@@ -403,15 +402,6 @@ func (r *EvalHubReconciler) buildDeploymentSpec(ctx context.Context, instance *e
 			},
 		},
 	}, nil
-}
-
-// getKubeRBACProxyImage retrieves the kube-rbac-proxy image from the operator ConfigMap.
-func (r *EvalHubReconciler) getKubeRBACProxyImage(ctx context.Context) (string, error) {
-	namespace := r.Namespace
-	if namespace == "" {
-		return "", fmt.Errorf("operator namespace not set")
-	}
-	return utils.GetImageFromConfigMap(ctx, r.Client, configMapKubeRBACProxyImageKey, r.effectiveOperatorConfigMapName(), namespace)
 }
 
 // mergeEnvVars merges default environment variables with CR-specified ones,

--- a/controllers/evalhub/deployment.go
+++ b/controllers/evalhub/deployment.go
@@ -68,7 +68,7 @@ func (r *EvalHubReconciler) buildDeploymentSpec(ctx context.Context, instance *e
 	}
 
 	// Get image from ConfigMap with fallback
-	evalHubImage, err := r.getEvalHubImage(ctx)
+	evalHubImage, err := r.getImageFromConfigMap(ctx, configMapEvalHubImageKey)
 	if err != nil {
 		log.FromContext(ctx).Error(err, "Error getting EvalHub image from ConfigMap. Using the default image value of "+defaultEvalHubImage)
 		evalHubImage = defaultEvalHubImage
@@ -412,18 +412,6 @@ func (r *EvalHubReconciler) getKubeRBACProxyImage(ctx context.Context) (string, 
 		return "", fmt.Errorf("operator namespace not set")
 	}
 	return utils.GetImageFromConfigMap(ctx, r.Client, configMapKubeRBACProxyImageKey, r.effectiveOperatorConfigMapName(), namespace)
-}
-
-// getEvalHubImage retrieves the EvalHub image from ConfigMap with fallback to default
-func (r *EvalHubReconciler) getEvalHubImage(ctx context.Context) (string, error) {
-	// Get the namespace where the operator is deployed (where the ConfigMap should be)
-	namespace := r.Namespace
-	if namespace == "" {
-		// Fallback to default namespace if not set
-		namespace = "trustyai-service-operator-system"
-	}
-
-	return utils.GetImageFromConfigMapWithFallback(ctx, r.Client, configMapEvalHubImageKey, r.effectiveOperatorConfigMapName(), namespace, defaultEvalHubImage)
 }
 
 // mergeEnvVars merges default environment variables with CR-specified ones,

--- a/controllers/evalhub/deployment_operator_settings.go
+++ b/controllers/evalhub/deployment_operator_settings.go
@@ -40,13 +40,6 @@ func cloneResourceRequirements(r corev1.ResourceRequirements) corev1.ResourceReq
 	return out
 }
 
-func (r *EvalHubReconciler) operatorNamespace() string {
-	if r.Namespace != "" {
-		return r.Namespace
-	}
-	return "trustyai-service-operator-system"
-}
-
 func (r *EvalHubReconciler) effectiveOperatorConfigMapName() string {
 	if r.OperatorConfigMapName != "" {
 		return r.OperatorConfigMapName
@@ -57,7 +50,7 @@ func (r *EvalHubReconciler) effectiveOperatorConfigMapName() string {
 // readOperatorConfigMapData returns ConfigMap .Data for the operator settings CM, or nil if absent / on read error.
 func (r *EvalHubReconciler) readOperatorConfigMapData(ctx context.Context) map[string]string {
 	cm := &corev1.ConfigMap{}
-	key := types.NamespacedName{Namespace: r.operatorNamespace(), Name: r.effectiveOperatorConfigMapName()}
+	key := types.NamespacedName{Namespace: r.Namespace, Name: r.effectiveOperatorConfigMapName()}
 	err := r.Get(ctx, key, cm)
 	if errors.IsNotFound(err) {
 		return nil

--- a/controllers/evalhub/suite_test.go
+++ b/controllers/evalhub/suite_test.go
@@ -196,7 +196,7 @@ func setupReconciler(namespace string) (*EvalHubReconciler, context.Context) {
 		EventRecorder:         eventRecorder,
 	}
 
-	// Create the operator image ConfigMap so getEvalHubImage succeeds.
+	// Create the operator image ConfigMap so getImageFromConfigMap succeeds.
 	operatorCM := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      configMapName,


### PR DESCRIPTION
## Summary

The `getEvalHubImage()` function in the EvalHub controller silently fell back to a hardcoded namespace (`trustyai-service-operator-system`) when `r.Namespace` was empty, then read the operator ConfigMap from that namespace. In non-default deployments (e.g. `opendatahub`, `redhat-ods-operator`), this could silently read the wrong ConfigMap or miss a misconfiguration entirely.

The controller already had a properly validated `getImageFromConfigMap()` that returns an error when the namespace is unset. This PR removes the duplicate `getEvalHubImage()` and replaces its call site with `getImageFromConfigMap()`, making the behaviour consistent.

## Changes

- Replaced `getEvalHubImage()` call in `buildDeploymentSpec` with `getImageFromConfigMap(ctx, configMapEvalHubImageKey)`
- Deleted the `getEvalHubImage()` function
- Updated tests to match: empty namespace now returns an error, missing ConfigMap no longer returns a fallback image

Fixes [RHOAIENG-63756](https://redhat.atlassian.net/browse/RHOAIENG-63756)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test coverage for image retrieval to validate ConfigMap-based scenarios with enhanced error path validation for missing ConfigMap and namespace configurations.

* **Refactor**
  * Simplified container image lookup logic with consolidated error handling for missing configuration settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trustyai-explainability/trustyai-service-operator/pull/738?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->