### PR TITLE
fix(ci): pin kustomize version in smoke workflow install step

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install kustomize
         run: |
-          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s -- 5.7.0
           sudo mv kustomize /usr/local/bin/
 
       - name: Apply external CRDs


### PR DESCRIPTION
## What and why

Fixes the kustomize install step in the smoke workflow that was failing with:
  
tar (child): ./kustomize_v*_linux_amd64.tar.gz: Cannot open: No such file or directory

The `install_kustomize.sh` script, when called without a version argument, hits the GitHub API to resolve the latest release URL. Under rate-limiting conditions (no `GITHUB_TOKEN` provided) this silently returns an empty URL, the `curl -sLO` download produces nothing, and the subsequent `tar` glob finds no file to extract.

Pinning to `5.7.0` (matching `KUSTOMIZE_VERSION` in the `Makefile`) causes the script to construct a direct release URL, skipping the API call entirely.


## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

## Breaking changes

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated smoke test workflow to use a specific Kustomize version, ensuring consistent test execution across runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trustyai-explainability/trustyai-service-operator/pull/741?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->