### PR TITLE
fix(evalhub): fix kube-rbac-proxy auth mappings and switch upstream to HTTP loopback

### DIFF
--- a/controllers/evalhub/configmap.go
+++ b/controllers/evalhub/configmap.go
@@ -304,7 +304,8 @@ func generateAuthConfigData() string {
                 apiGroup: mlflow.kubeflow.org
                 resource: experiments
                 verb: get
-        - resources:
+        - methods: [get, delete, put, patch]
+          resources:
             - rewrites:
                 byHttpHeader:
                   name: X-Tenant
@@ -315,7 +316,8 @@ func generateAuthConfigData() string {
                 verb: "{{.FromMethod}}"
     - path: /api/v1/evaluations/collections
       mappings:
-        - resources:
+        - methods: [get, post, delete, put, patch]
+          resources:
             - rewrites:
                 byHttpHeader:
                   name: X-Tenant
@@ -326,7 +328,8 @@ func generateAuthConfigData() string {
                 verb: "{{.FromMethod}}"
     - path: /api/v1/evaluations/providers
       mappings:
-        - resources:
+        - methods: [get, post, delete, put, patch]
+          resources:
             - rewrites:
                 byHttpHeader:
                   name: X-Tenant

--- a/controllers/evalhub/deployment.go
+++ b/controllers/evalhub/deployment.go
@@ -92,14 +92,6 @@ func (r *EvalHubReconciler) buildDeploymentSpec(ctx context.Context, instance *e
 			Value: fmt.Sprintf("%d", evalHubAppPort),
 		},
 		{
-			Name:  "TLS_CERT_FILE",
-			Value: tlsSecretMountPath + "/" + tlsCertFile,
-		},
-		{
-			Name:  "TLS_KEY_FILE",
-			Value: tlsSecretMountPath + "/" + tlsKeyFile,
-		},
-		{
 			Name:  "LOG_LEVEL",
 			Value: "INFO",
 		},

--- a/controllers/evalhub/route.go
+++ b/controllers/evalhub/route.go
@@ -43,7 +43,6 @@ func (r *EvalHubReconciler) reconcileRoute(ctx context.Context, instance *evalhu
 		return getErr
 	}
 
-	// Define the desired route spec
 	desiredSpec := r.buildRouteSpec(instance)
 
 	if errors.IsNotFound(getErr) {
@@ -69,9 +68,9 @@ func (r *EvalHubReconciler) reconcileRoute(ctx context.Context, instance *evalhu
 	}
 }
 
-// buildRouteSpec builds the route specification for EvalHub
+// buildRouteSpec builds the route specification for EvalHub.
 func (r *EvalHubReconciler) buildRouteSpec(instance *evalhubv1alpha1.EvalHub) routev1.RouteSpec {
-	routeSpec := routev1.RouteSpec{
+	return routev1.RouteSpec{
 		To: routev1.RouteTargetReference{
 			Kind:   "Service",
 			Name:   instance.Name,
@@ -80,14 +79,11 @@ func (r *EvalHubReconciler) buildRouteSpec(instance *evalhubv1alpha1.EvalHub) ro
 		Port: &routev1.RoutePort{
 			TargetPort: intstr.FromString("https"),
 		},
-		// Default TLS configuration for EvalHub
 		TLS: &routev1.TLSConfig{
 			Termination:                   routev1.TLSTerminationReencrypt,
 			InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
 		},
 	}
-
-	return routeSpec
 }
 
 // isRouteSupported checks if Route resources are supported in the cluster


### PR DESCRIPTION
## What and why

Two fixes for the EvalHub deployment that prevented the kube-rbac-proxy from starting and routing traffic correctly.

1. Missing methods in `kube-rbac-proxy` auth config (`configmap.go`)

The generated `auth.yaml` had three endpoint mappings without a methods field. The ODH `kube-rbac-proxy` rejects any auth config where a mapping does not declare a non-empty methods list, crashing at startup with:

```
  command failed: invalid authorization config: mappings[N] must specify a non-empty methods list
```

Added explicit methods to the catch-all mapping on `/api/v1/evaluations/jobs` (`[get, delete, put, patch]`) and to the single mappings on `/api/v1/evaluations/collections` and `/api/v1/evaluations/providers` (`[get, post, delete, put, patch]`).

2. EvalHub serving HTTPS while proxy upstream was HTTP (`deployment.go`, `route.go`)

The `kube-rbac-proxy` was configured with `--upstream=http://127.0.0.1:8444/` but EvalHub was starting in TLS mode (it enables TLS whenever `TLS_CERT_FILE`/`TLS_KEY_FILE` are set). This caused a continuous stream of TLS handshake errors on the loopback and the pod never became healthy from the router's perspective.

Removed `TLS_CERT_FILE` and `TLS_KEY_FILE` from EvalHub's container env so it serves plain HTTP on the loopback, matching the proxy's upstream scheme. The `kube-rbac-proxy` continues to handle all external TLS on port 8443 via its own service cert. This follows the same pattern as TAS. Port 8444 is not exposed in the Service, so all traffic (internal and external) must pass through the proxy and its SAR checks.

## Type

- [x] fix

## Testing

- [x] Tested manually
- Authenticated GET /api/v1/evaluations/providers returns 200 with provider list
- Unauthenticated request returns non-2xx (SAR enforced by proxy)
- Route health check (/api/v1/health) responds correctly via the public route

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Authorization configurations now explicitly define HTTP methods for API endpoint mappings.
  * Updated deployment environment variables: added PORT setting, removed TLS certificate and key variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->