### PR TITLE
fix(rbac-proxy): replace origin-kube-rbac-proxy with odh-kube-rbac-proxy

### DIFF
--- a/config/base/params.env
+++ b/config/base/params.env
@@ -1,7 +1,7 @@
 trustyaiServiceImage=quay.io/trustyai/trustyai-service:latest
 trustyaiOperatorImage=quay.io/trustyai/trustyai-service-operator:latest
 evalHubImage=quay.io/evalhub/evalhub:latest
-kube-rbac-proxy=quay.io/openshift/origin-kube-rbac-proxy:4.19
+kube-rbac-proxy=quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable
 kServeServerless=enabled
 lmes-driver-image=quay.io/trustyai/ta-lmes-driver:latest
 lmes-pod-image=quay.io/opendatahub/ta-lmes-job:odh-3.4-final

--- a/config/overlays/mcp-guardrails/params.env
+++ b/config/overlays/mcp-guardrails/params.env
@@ -1,4 +1,4 @@
 trustyaiServiceImage=quay.io/opendatahub/trustyai-service:latest
 trustyaiOperatorImage=quay.io/opendatahub/trustyai-service-operator:latest
-kube-rbac-proxy=quay.io/openshift/origin-kube-rbac-proxy:4.19
+kube-rbac-proxy=quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable
 nemo-guardrails-image=quay.io/trustyai/nemo-guardrails-server:latest

--- a/config/overlays/odh-kueue/params.env
+++ b/config/overlays/odh-kueue/params.env
@@ -1,6 +1,6 @@
 trustyaiServiceImage=quay.io/trustyai/trustyai-service:latest
 trustyaiOperatorImage=quay.io/trustyai/trustyai-service-operator:latest
-kube-rbac-proxy=quay.io/openshift/origin-kube-rbac-proxy:4.19
+kube-rbac-proxy=quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable
 kServeServerless=enabled
 lmes-driver-image=quay.io/trustyai/ta-lmes-driver:latest
 lmes-pod-image=quay.io/trustyai/ta-lmes-job:latest

--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -1,7 +1,7 @@
 trustyaiServiceImage=quay.io/opendatahub/trustyai-service:latest
 trustyaiOperatorImage=quay.io/opendatahub/trustyai-service-operator:latest
 evalHubImage=quay.io/evalhub/evalhub:latest
-kube-rbac-proxy=quay.io/openshift/origin-kube-rbac-proxy:4.19
+kube-rbac-proxy=quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable
 kServeServerless=enabled
 lmes-driver-image=quay.io/opendatahub/ta-lmes-driver:latest
 lmes-pod-image=quay.io/opendatahub/ta-lmes-job:odh-3.4-final

--- a/config/overlays/rhoai/params.env
+++ b/config/overlays/rhoai/params.env
@@ -1,7 +1,7 @@
 trustyaiServiceImage=quay.io/trustyai/trustyai-service:latest
 trustyaiOperatorImage=quay.io/trustyai/trustyai-service-operator:latest
 evalHubImage=quay.io/evalhub/evalhub:latest
-kube-rbac-proxy=quay.io/openshift/origin-kube-rbac-proxy:4.19
+kube-rbac-proxy=quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable
 kServeServerless=enabled
 lmes-driver-image=quay.io/trustyai/ta-lmes-driver:latest
 lmes-pod-image=quay.io/trustyai/ta-lmes-job:latest

--- a/controllers/evalhub/deployment_test.go
+++ b/controllers/evalhub/deployment_test.go
@@ -48,7 +48,7 @@ var _ = Describe("EvalHub Deployment", func() {
 			},
 			Data: map[string]string{
 				"evalHubImage":    "quay.io/ruimvieira/eval-hub:test",
-				"kube-rbac-proxy": "quay.io/openshift/origin-kube-rbac-proxy:4.19",
+				"kube-rbac-proxy": "quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable",
 			},
 		}
 		Expect(k8sClient.Create(ctx, configMap)).Should(Succeed())
@@ -143,7 +143,7 @@ var _ = Describe("EvalHub Deployment", func() {
 				}
 			}
 			Expect(krp).NotTo(BeNil())
-			Expect(krp.Image).To(Equal("quay.io/openshift/origin-kube-rbac-proxy:4.19"))
+			Expect(krp.Image).To(Equal("quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable"))
 			Expect(krp.Args).To(ContainElement("--config-file=" + kubeRBACProxyConfigMountPath))
 			Expect(strings.Join(krp.Args, " ")).To(ContainSubstring(fmt.Sprintf("--upstream=http://127.0.0.1:%d/", evalHubAppPort)))
 			var hasAuthMount bool

--- a/controllers/evalhub/suite_test.go
+++ b/controllers/evalhub/suite_test.go
@@ -131,7 +131,7 @@ func createConfigMap(name, namespace string) *corev1.ConfigMap {
 		},
 		Data: map[string]string{
 			"evalHubImage":    "quay.io/ruimvieira/eval-hub:test",
-			"kube-rbac-proxy": "quay.io/openshift/origin-kube-rbac-proxy:4.19",
+			"kube-rbac-proxy": "quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable",
 		},
 	}
 }

--- a/controllers/evalhub/unit_test.go
+++ b/controllers/evalhub/unit_test.go
@@ -107,7 +107,7 @@ func TestEvalHubReconciler_reconcileConfigMap(t *testing.T) {
 		},
 		Data: map[string]string{
 			configMapEvalHubImageKey:       "quay.io/evalhub/evalhub:test",
-			configMapKubeRBACProxyImageKey: "quay.io/openshift/origin-kube-rbac-proxy:4.19",
+			configMapKubeRBACProxyImageKey: "quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable",
 		},
 	}
 
@@ -1310,7 +1310,7 @@ func TestEvalHubReconciler_reconcileDeployment_WithDB(t *testing.T) {
 		},
 		Data: map[string]string{
 			configMapEvalHubImageKey:       "quay.io/test/eval-hub:latest",
-			configMapKubeRBACProxyImageKey: "quay.io/openshift/origin-kube-rbac-proxy:4.19",
+			configMapKubeRBACProxyImageKey: "quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable",
 		},
 	}
 
@@ -1555,7 +1555,7 @@ func TestEvalHubReconciler_reconcileProviderConfigMaps(t *testing.T) {
 			},
 			Data: map[string]string{
 				configMapEvalHubImageKey:       "quay.io/test/eval-hub:latest",
-				configMapKubeRBACProxyImageKey: "quay.io/openshift/origin-kube-rbac-proxy:4.19",
+				configMapKubeRBACProxyImageKey: "quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable",
 			},
 		}
 

--- a/controllers/gorch/deployment_test.go
+++ b/controllers/gorch/deployment_test.go
@@ -51,7 +51,7 @@ func TestDeploymentTemplateRendering(t *testing.T) {
 			"guardrails-orchestrator-image":      "quay.io/trustyai/ta-guardrails-orchestrator:latest",
 			"guardrails-sidecar-gateway-image":   "quay.io/trustyai/ta-guardrails-gateway:latest",
 			"guardrails-built-in-detector-image": "quay.io/trustyai/ta-guardrails-regex:latest",
-			"kube-rbac-proxy":                    "quay.io/openshift/origin-kube-rbac-proxy:4.19",
+			"kube-rbac-proxy":                    "quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable",
 		},
 	}
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(operatorConfigMap).Build()

--- a/controllers/lmes/lmevaljob_controller_test.go
+++ b/controllers/lmes/lmevaljob_controller_test.go
@@ -4404,8 +4404,8 @@ func Test_hasHTTPSBaseURL(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "other arg with https value",
-			args: []lmesv1alpha1.Arg{{Name: "endpoint", Value: "https://other.example.com"}},
+			name:     "other arg with https value",
+			args:     []lmesv1alpha1.Arg{{Name: "endpoint", Value: "https://other.example.com"}},
 			expected: false,
 		},
 		{

--- a/controllers/nemo_guardrails/nemoguardrail_controller_test.go
+++ b/controllers/nemo_guardrails/nemoguardrail_controller_test.go
@@ -66,7 +66,7 @@ var _ = Describe("NemoGuardrails Controller", func() {
 			},
 			Data: map[string]string{
 				nemoGuardrailsImageKey: "quay.io/trustyai/nemo-guardrails-server:latest",
-				tas.KubeRBACProxyName:  "quay.io/openshift/origin-kube-rbac-proxy:4.19",
+				tas.KubeRBACProxyName:  "quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable",
 			},
 		}
 		err = k8sClient.Create(ctx, operatorConfigMap)

--- a/controllers/tas/constants.go
+++ b/controllers/tas/constants.go
@@ -38,7 +38,7 @@ const (
 	KubeRBACProxyServicePort     = 8443
 	KubeRBACProxyName            = "kube-rbac-proxy"
 	KubeRBACProxyServicePortName = "https"
-	defaultKubeRBACProxyImage    = "quay.io/openshift/origin-kube-rbac-proxy:4.19"
+	defaultKubeRBACProxyImage    = "quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable"
 )
 
 // Status types

--- a/controllers/tas/deployment_test.go
+++ b/controllers/tas/deployment_test.go
@@ -54,7 +54,7 @@ func setupAndTestDeploymentDefault(instance *trustyaiopendatahubiov1alpha1.Trust
 
 	Expect(len(deployment.Spec.Template.Spec.Containers)).Should(Equal(2))
 	Expect(deployment.Spec.Template.Spec.Containers[0].Image).Should(Equal("quay.io/trustyai/trustyai-service:latest"))
-	Expect(deployment.Spec.Template.Spec.Containers[1].Image).Should(Equal("quay.io/openshift/origin-kube-rbac-proxy:4.19"))
+	Expect(deployment.Spec.Template.Spec.Containers[1].Image).Should(Equal("quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable"))
 
 	WaitFor(func() error {
 		internalServiceConfig := getServiceConfig(instance.Name, instance)
@@ -889,7 +889,7 @@ var _ = Describe("TrustyAI operator", func() {
 
 				Expect(len(deployment.Spec.Template.Spec.Containers)).Should(Equal(2))
 				Expect(deployment.Spec.Template.Spec.Containers[0].Image).Should(Equal("quay.io/trustyai/trustyai-service:latest"))
-				Expect(deployment.Spec.Template.Spec.Containers[1].Image).Should(Equal("quay.io/openshift/origin-kube-rbac-proxy:4.19"))
+				Expect(deployment.Spec.Template.Spec.Containers[1].Image).Should(Equal("quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable"))
 
 				WaitFor(func() error {
 					err := reconciler.createServiceAccount(ctx, instance)


### PR DESCRIPTION
## What and why

Replaces `quay.io/openshift/origin-kube-rbac-proxy:4.19` with `quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable` in all configuration overlays and controller defaults.

The ODH image is actively maintained and includes new SAR features required by the EvalHub controller.

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Changes

- `config/base/params.env`
- `config/overlays/{odh,odh-kueue,rhoai,dev,mcp-guardrails}/params.env`
- `controllers/tas/constants.go`
- `controllers/tas/deployment_test.go`
- `controllers/gorch/deployment_test.go`
- `controllers/nemo_guardrails/nemoguardrail_controller_test.go`
- `controllers/evalhub/{deployment_test,suite_test,unit_test}.go`

## Testing

- [x] Tests updated to reflect the new image reference
- [ ] Tested manually