### PR TITLE
Refactor: Update SAR config to fix errors with /{id} endpoints

### DIFF
--- a/controllers/evalhub/configmap.go
+++ b/controllers/evalhub/configmap.go
@@ -276,8 +276,30 @@ func generateAuthConfigData() string {
                 apiGroup: trustyai.opendatahub.io
                 resource: status-events
                 verb: create
+    - path: /api/v1/evaluations/jobs/*
+      mappings:
+        - methods: [get, delete, put, patch]
+          resources:
+            - rewrites:
+                byHttpHeader:
+                  name: X-Tenant
+              resourceAttributes:
+                namespace: "{{.FromHeader}}"
+                apiGroup: trustyai.opendatahub.io
+                resource: evaluations
+                verb: "{{.FromMethod}}"
     - path: /api/v1/evaluations/jobs
       mappings:
+        - methods: [get]
+          resources:
+            - rewrites:
+                byHttpHeader:
+                  name: X-Tenant
+              resourceAttributes:
+                namespace: "{{.FromHeader}}"
+                apiGroup: trustyai.opendatahub.io
+                resource: evaluations
+                verb: list
         - methods: [post]
           resources:
             - rewrites:
@@ -304,19 +326,9 @@ func generateAuthConfigData() string {
                 apiGroup: mlflow.kubeflow.org
                 resource: experiments
                 verb: get
-        - methods: [get, delete, put, patch]
-          resources:
-            - rewrites:
-                byHttpHeader:
-                  name: X-Tenant
-              resourceAttributes:
-                namespace: "{{.FromHeader}}"
-                apiGroup: trustyai.opendatahub.io
-                resource: evaluations
-                verb: "{{.FromMethod}}"
-    - path: /api/v1/evaluations/collections
+    - path: /api/v1/evaluations/collections/*
       mappings:
-        - methods: [get, post, delete, put, patch]
+        - methods: [get, delete, put, patch]
           resources:
             - rewrites:
                 byHttpHeader:
@@ -326,9 +338,31 @@ func generateAuthConfigData() string {
                 apiGroup: trustyai.opendatahub.io
                 resource: collections
                 verb: "{{.FromMethod}}"
-    - path: /api/v1/evaluations/providers
+    - path: /api/v1/evaluations/collections
       mappings:
-        - methods: [get, post, delete, put, patch]
+        - methods: [get]
+          resources:
+            - rewrites:
+                byHttpHeader:
+                  name: X-Tenant
+              resourceAttributes:
+                namespace: "{{.FromHeader}}"
+                apiGroup: trustyai.opendatahub.io
+                resource: collections
+                verb: list
+        - methods: [post]
+          resources:
+            - rewrites:
+                byHttpHeader:
+                  name: X-Tenant
+              resourceAttributes:
+                namespace: "{{.FromHeader}}"
+                apiGroup: trustyai.opendatahub.io
+                resource: collections
+                verb: create
+    - path: /api/v1/evaluations/providers/*
+      mappings:
+        - methods: [get, delete, put, patch]
           resources:
             - rewrites:
                 byHttpHeader:
@@ -338,6 +372,28 @@ func generateAuthConfigData() string {
                 apiGroup: trustyai.opendatahub.io
                 resource: providers
                 verb: "{{.FromMethod}}"
+    - path: /api/v1/evaluations/providers
+      mappings:
+        - methods: [get]
+          resources:
+            - rewrites:
+                byHttpHeader:
+                  name: X-Tenant
+              resourceAttributes:
+                namespace: "{{.FromHeader}}"
+                apiGroup: trustyai.opendatahub.io
+                resource: providers
+                verb: list
+        - methods: [post]
+          resources:
+            - rewrites:
+                byHttpHeader:
+                  name: X-Tenant
+              resourceAttributes:
+                namespace: "{{.FromHeader}}"
+                apiGroup: trustyai.opendatahub.io
+                resource: providers
+                verb: create
 `
 }
 


### PR DESCRIPTION
Fix for 403 errors on PUT/PATCH/DELETE jobs/id, collections/id and providers/id endpoints found during tests.

This is a continuation of https://github.com/trustyai-explainability/trustyai-service-operator/pull/716. The tests in the linked PR focused only on /jobs, /collections, /providers APIs (due to an assumption that the SAR config which was in eval-hub was already tested and just needed to be moved to rbac proxy) and hence the error with /id endpoints was missed.

### Complete Test Results with this fix

  Base paths (list/create endpoints) - all working correctly:
  - GET: returns list
  - POST: passes authorization, reaches app (creates resource or returns validation error)

  Individual resource paths (/{id}) - all working correctly:
  - GET: 404 (not 403) ✅
  - PUT: 404 or 400 validation (not 403) ✅
  - PATCH: 404 or 400 validation (not 403) ✅
  - DELETE: 404 (not 403) ✅
  - POST: 403 (intentionally blocked - POST not valid on individual resources) ✅

Note that the last scenario (403 instead of 405 on invalid operations) need to be thought through and might need a another fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured multi-tenant authorization policies for improved endpoint rule granularity and HTTP method mapping. Refined handling of collection and provider resource operations through separate path configurations, ensuring more precise access control enforcement and better distinction between different operation types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->