### PR TITLE
fix(evalhub): add explicit methods to MCP kube-rbac-proxy auth mappings

### DIFF
--- a/controllers/evalhub/mcp_configmap.go
+++ b/controllers/evalhub/mcp_configmap.go
@@ -120,19 +120,22 @@ func (r *EvalHubReconciler) generateMCPConfigData(instance *evalhubv1alpha1.Eval
 	}
 
 	return map[string]string{
-		mcpConfigFileName:     string(configYAML),
+		mcpConfigFileName:       string(configYAML),
 		evalHubAuthConfigMapKey: generateMCPAuthConfigData(instance),
 	}, nil
 }
 
 // generateMCPAuthConfigData returns kube-rbac-proxy authorization for the MCP server.
 // Clients must hold get/create on evalhubs/proxy for this EvalHub instance (see createAPIAccessRole).
+// Each mapping must declare an explicit methods list — kube-rbac-proxy rejects mappings without one.
+// GET maps to verb:get (SSE stream establishment); POST maps to verb:create (MCP message send).
 func generateMCPAuthConfigData(instance *evalhubv1alpha1.EvalHub) string {
 	return fmt.Sprintf(`authorization:
   endpoints:
     - path: /*
       mappings:
-        - resources:
+        - methods: [get]
+          resources:
             - resourceAttributes:
                 namespace: %q
                 apiGroup: trustyai.opendatahub.io
@@ -140,6 +143,8 @@ func generateMCPAuthConfigData(instance *evalhubv1alpha1.EvalHub) string {
                 subresource: proxy
                 name: %q
                 verb: get
+        - methods: [post]
+          resources:
             - resourceAttributes:
                 namespace: %q
                 apiGroup: trustyai.opendatahub.io

--- a/controllers/evalhub/mcp_configmap_test.go
+++ b/controllers/evalhub/mcp_configmap_test.go
@@ -41,7 +41,10 @@ var _ = Describe("generateMCPConfigData", func() {
 			Expect(cfg.Port).To(Equal(mcpAppPort))
 
 			Expect(data).To(HaveKey(evalHubAuthConfigMapKey))
-			Expect(data[evalHubAuthConfigMapKey]).To(ContainSubstring("evalhubs"))
+			auth := data[evalHubAuthConfigMapKey]
+			Expect(auth).To(ContainSubstring("evalhubs"))
+			Expect(auth).To(ContainSubstring("methods: [get]"))
+			Expect(auth).To(ContainSubstring("methods: [post]"))
 		})
 	})
 

--- a/controllers/evalhub/unit_test.go
+++ b/controllers/evalhub/unit_test.go
@@ -2099,3 +2099,21 @@ func TestEvalHubReconciler_reconcileServiceMonitor_NoOpUpdate(t *testing.T) {
 	assert.Equal(t, 0, smUpdateCount,
 		"reconcileServiceMonitor should not update when spec is unchanged")
 }
+
+func TestGenerateMCPAuthConfigData_MethodsPresent(t *testing.T) {
+	instance := &evalhubv1alpha1.EvalHub{
+		ObjectMeta: metav1.ObjectMeta{Name: "eh", Namespace: "team-a"},
+	}
+	out := generateMCPAuthConfigData(instance)
+
+	// kube-rbac-proxy rejects mappings without an explicit methods list.
+	assert.Contains(t, out, "methods: [get]", "GET mapping must declare methods")
+	assert.Contains(t, out, "methods: [post]", "POST mapping must declare methods")
+	assert.Contains(t, out, "evalhubs")
+	assert.Contains(t, out, "team-a")
+	assert.Contains(t, out, "eh")
+
+	// Validate the generated YAML is parseable.
+	var parsed map[string]interface{}
+	require.NoError(t, yaml.Unmarshal([]byte(out), &parsed), "auth.yaml must be valid YAML")
+}


### PR DESCRIPTION
## What and why

kube-rbac-proxy rejects auth configs where a mapping omits the `methods` field (`mappings[0] must specify a non-empty methods list`). The MCP ConfigMap was generating a single mapping with no `methods`, causing the kube-rbac-proxy sidecar to crash on startup.

Split into two explicit method-keyed mappings that match the MCP HTTP transport semantics:
- `methods: [get]` -> `verb: get` (SSE stream establishment)
- `methods: [post]` -> `verb: create` (MCP message sends)

Closes [RHOAIENG-66839](https://redhat.atlassian.net/browse/RHOAIENG-66839)

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

`TestGenerateMCPAuthConfigData_MethodsPresent` (new, standard Go test, no envtest required) asserts both `methods: [get]` and `methods: [post]` are present and the output is valid YAML. The existing Ginkgo assertion in `mcp_configmap_test.go` is also extended to check both method entries.

Verified against a running cluster: MCP pod starts cleanly after the operator reconciles the updated ConfigMap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Enhanced MCP authorization configuration to include explicit HTTP methods declarations for API endpoints, with GET and POST operations now clearly specified in separate mappings for improved clarity and consistency.

* **Tests**
  * Improved test coverage to verify explicit methods declarations are present in generated authorization configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->