### PR TITLE
refactor(evalhub): reuse evalHubImage for MCP deployment instead of separate key

### DIFF
--- a/controllers/evalhub/constants.go
+++ b/controllers/evalhub/constants.go
@@ -86,10 +86,8 @@ const (
 	sidecarBaseURL = "http://localhost:8080"
 
 	// MCP server configuration
-	defaultMCPImage      = "quay.io/evalhub/evalhub:latest"
-	configMapMCPImageKey = "evalHubMCPImage"
-	mcpBinaryPath        = "/app/evalhub-mcp"
-	mcpContainerName     = "evalhub-mcp"
+	mcpBinaryPath    = "/app/evalhub-mcp"
+	mcpContainerName = "evalhub-mcp"
 	// mcpAppPort is the evalhub-mcp listen port on loopback; kube-rbac-proxy terminates TLS on mcpServicePort.
 	mcpAppPort             = 8445
 	mcpServicePort         = 8443

--- a/controllers/evalhub/mcp_deployment.go
+++ b/controllers/evalhub/mcp_deployment.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	evalhubv1alpha1 "github.com/trustyai-explainability/trustyai-service-operator/api/evalhub/v1alpha1"
-	"github.com/trustyai-explainability/trustyai-service-operator/controllers/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -82,10 +81,10 @@ func (r *EvalHubReconciler) buildMCPDeploymentSpec(ctx context.Context, instance
 	image := mcpSpec.Image
 	if image == "" {
 		var err error
-		image, err = r.getMCPImage(ctx)
+		image, err = r.getImageFromConfigMap(ctx, configMapEvalHubImageKey)
 		if err != nil {
-			log.FromContext(ctx).Error(err, "Error getting MCP image from ConfigMap, using default "+defaultMCPImage)
-			image = defaultMCPImage
+			log.FromContext(ctx).Error(err, "Error getting EvalHub image for MCP from ConfigMap, using default "+defaultEvalHubImage)
+			image = defaultEvalHubImage
 		}
 	}
 
@@ -315,14 +314,6 @@ func (r *EvalHubReconciler) buildMCPDeploymentSpec(ctx context.Context, instance
 			},
 		},
 	}, nil
-}
-
-func (r *EvalHubReconciler) getMCPImage(ctx context.Context) (string, error) {
-	namespace := r.Namespace
-	if namespace == "" {
-		namespace = "trustyai-service-operator-system"
-	}
-	return utils.GetImageFromConfigMapWithFallback(ctx, r.Client, configMapMCPImageKey, configMapName, namespace, defaultMCPImage)
 }
 
 // deleteMCPResource deletes a namespaced resource if it exists.

--- a/controllers/evalhub/suite_test.go
+++ b/controllers/evalhub/suite_test.go
@@ -131,7 +131,6 @@ func createConfigMap(name, namespace string) *corev1.ConfigMap {
 		},
 		Data: map[string]string{
 			"evalHubImage":    "quay.io/ruimvieira/eval-hub:test",
-			"evalHubMCPImage": "quay.io/evalhub/evalhub-mcp:test",
 			"kube-rbac-proxy": "quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable",
 		},
 	}
@@ -205,7 +204,6 @@ func setupReconciler(namespace string) (*EvalHubReconciler, context.Context) {
 		},
 		Data: map[string]string{
 			configMapEvalHubImageKey:       "quay.io/evalhub/evalhub:test",
-			configMapMCPImageKey:           "quay.io/evalhub/evalhub:test",
 			configMapKubeRBACProxyImageKey: "quay.io/openshift/origin-kube-rbac-proxy:4.19",
 		},
 	}


### PR DESCRIPTION
## What and why

The MCP deployment was using a separate `evalHubMCPImage` ConfigMap key to resolve its container image, falling back to `quay.io/evalhub/evalhub:latest`.
Since the MCP server binary (`evalhub-mcp`) is shipped in the same image as the EvalHub service, this required operators to set two identical image entries in `params.env` or accept the public fallback image instead of a locally-built one.

Simplify by reusing the existing `evalHubImage` ConfigMap key for the MCP deployment. The CR-level `spec.mcp.image` field still provides a per-instance override when a genuinely different image is needed.

Closes [RHOAIENG-66841](https://redhat.atlassian.net/browse/RHOAIENG-66841)

## Type

- [ ] feat
- [ ] fix
- [x] refactor / chore
- [ ] docs
- [ ] test / ci

## Testing

- [x] Tested manually

After operator redeploy with only `evalHubImage` set in `params.env`, the MCP pod uses the correct internal registry image:

```  
oc get pod -n opendatahub -l  -o jsonpath='{..image}'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal code organization for MCP component configuration and image handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->