### PR TITLE
chore(tests): migrate test Dockerfile from UBI8 to UBI9

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8:8.10-1020
+FROM registry.access.redhat.com/ubi9/ubi:latest
 ARG OC_CLI_URL=https://mirror.openshift.com/pub/openshift-v4/amd64/clients/ocp/4.14.33/openshift-client-linux.tar.gz
 ARG TRUSTYAI_TESTS_ORG=trustyai-explainability
 ARG TRUSTYAI_TESTS_REPO=trustyai-tests
@@ -33,7 +33,7 @@ RUN wget -O installandtest.sh "https://raw.githubusercontent.com/trustyai-explai
     cp installandtest.sh $HOME/peak
 
 # Install poetry to support the exeuction of trustyai-tests
-RUN curl -sSL https://install.python-poetry.org | python3 -
+RUN curl -sSL https://install.python-poetry.org | python3.11 -
 ENV PATH="${PATH}:$HOME/.local/bin"
 
 # break cache if the repo has changed
@@ -41,6 +41,7 @@ ADD https://api.github.com/repos/${TRUSTYAI_TESTS_ORG}/${TRUSTYAI_TESTS_REPO}/gi
 RUN cd $HOME/peak && \
     git clone -b ${TRUSTYAI_TESTS_BRANCH} https://github.com/${TRUSTYAI_TESTS_ORG}/${TRUSTYAI_TESTS_REPO}.git && \
     cd trustyai-tests && \
+    poetry env use python3.11 && \
     poetry install
 
 


### PR DESCRIPTION
## What and why

Migrates `tests/Dockerfile` from `ubi8:8.10-1020` to `ubi9/ubi:latest`, aligning the test image with the UBI9 base already used by the operator and driver images.

Three changes were required:

1. **Base image**: `ubi8:8.10-1020` → `ubi9/ubi:latest`.
2. **Poetry installer**: changed `python3` to `python3.11`. On UBI9 the system default `python3` is 3.9; `python3.11` is an additional package. Running the installer against 3.9 caused it to fail silently.
3. **Poetry virtualenv**: added `poetry env use python3.11` before `poetry install`. Without this, Poetry resolves dependencies against the 3.9 interpreter and fails because transitive dependencies (`ipython`, `openshift-python-wrapper`) require Python >= 3.10.

Closes [RHOAIENG-61101](https://redhat.atlassian.net/browse/RHOAIENG-61101)

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [x] refactor / chore
- [ ] test / ci

## Testing

- [x] Tested manually

## Breaking changes

None. Build arguments and runtime behaviour are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the testing environment base image to the latest version.
  * Configured build tools to explicitly use Python 3.11 for consistency in the testing pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->