### PR TITLE
feat(evalhub): add rbac-proxy auth type to MCP deployment spec

### DIFF
--- a/controllers/evalhub/mcp_deployment.go
+++ b/controllers/evalhub/mcp_deployment.go
@@ -157,6 +157,7 @@ func (r *EvalHubReconciler) buildMCPDeploymentSpec(ctx context.Context, instance
 			"--transport", clientTransport,
 			"--host", "127.0.0.1",
 			"--port", strconv.Itoa(mcpAppPort),
+			"--auth-type", "rbac-proxy", // when running here we are always behind the kube-rbac-proxy
 		},
 		Ports: []corev1.ContainerPort{
 			{


### PR DESCRIPTION
This adds a command line flag to tell the MCP service that it is running behind the rbac-kube-proxy. In this case the MCP service will verify the `X-Tenant` and `X-User` HTTP headers on each API request (except the health API).