### PR TITLE
chore(evalhub): add standard LLM evaluation suite collections and benchmarks

### DIFF
--- a/config/configmaps/evalhub/collection-coding-v1.yaml
+++ b/config/configmaps/evalhub/collection-coding-v1.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: evalhub-collection-coding-v1
+  labels:
+    trustyai.opendatahub.io/evalhub-collection-type: system
+    trustyai.opendatahub.io/evalhub-collection-name: coding-v1
+data:
+  coding-v1.yaml: |
+    id: coding-v1
+    name: Coding v1
+    category: code
+    description: >
+      Evaluates code generation capability of instruction-tuned chat LLMs on real-world
+      competitive programming problems. LiveCodeBench v6 samples problems from Codeforces,
+      LeetCode, and AtCoder after the model knowledge cutoff, eliminating data contamination
+      risk. Execution-based scoring: generated code is run against hidden test cases.
+      Primary metric is codegen_pass@1 averaged over 3 random seeds (k=1, n=3).
+      SWE-Bench (agentic software engineering) will be added in v2 when the harness
+      integration is available.
+      Part of the Standard LLM Evaluation Suite (standard-llm-evals-v1).
+    tags:
+      - code
+      - competitive-programming
+      - execution
+      - contamination-free
+      - chat
+      - lighteval
+      - vllm
+      - standard
+    pass_criteria:
+      threshold: 0.25
+    benchmarks:
+      - id: lcb:codegeneration_v6
+        provider_id: lighteval
+        weight: 1
+        primary_score:
+          metric: codegen_pass@1
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.25
+        parameters:
+          num_fewshot: 0
+          apply_chat_template: true
+          pass_at_k: 1
+          num_samples: 3

--- a/config/configmaps/evalhub/collection-instruction-following-v1.yaml
+++ b/config/configmaps/evalhub/collection-instruction-following-v1.yaml
@@ -1,0 +1,95 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: evalhub-collection-instruction-following-v1
+  labels:
+    trustyai.opendatahub.io/evalhub-collection-type: system
+    trustyai.opendatahub.io/evalhub-collection-name: instruction-following-v1
+data:
+  instruction-following-v1.yaml: |
+    id: instruction-following-v1
+    name: Instruction Following v1
+    category: instruction_following
+    description: >
+      Evaluates how well instruction-tuned chat LLMs follow explicit instructions across
+      math word problems, broad knowledge, multi-choice reasoning, formatting constraints,
+      and competition mathematics. Uses 5-shot with chain-of-thought and fewshot_as_multiturn
+      for knowledge-intensive tasks; IFEval and Math 500 are always 0-shot. All benchmarks
+      require --apply_chat_template and a vLLM OpenAI-compatible endpoint.
+      Part of the Standard LLM Evaluation Suite (standard-llm-evals-v1).
+    tags:
+      - instruction_following
+      - chat
+      - lm_eval
+      - lighteval
+      - vllm
+      - standard
+    pass_criteria:
+      # Weighted average across 5 benchmarks (equal weight).
+      # Threshold reflects a capable instruction-following model.
+      threshold: 0.50
+    benchmarks:
+      - id: gsm8k_platinum_cot_llama
+        provider_id: lm_evaluation_harness
+        weight: 1
+        primary_score:
+          metric: exact_match
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.65
+        parameters:
+          num_fewshot: 5
+          apply_chat_template: true
+          fewshot_as_multiturn: true
+
+      - id: mmlu_cot_llama
+        provider_id: lm_evaluation_harness
+        weight: 1
+        primary_score:
+          metric: exact_match
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.60
+        parameters:
+          num_fewshot: 5
+          apply_chat_template: true
+          fewshot_as_multiturn: true
+
+      - id: leaderboard_mmlu_pro
+        provider_id: lm_evaluation_harness
+        weight: 1
+        primary_score:
+          metric: acc_norm
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.45
+        parameters:
+          num_fewshot: 5
+          apply_chat_template: true
+          fewshot_as_multiturn: true
+
+      - id: ifeval
+        provider_id: lm_evaluation_harness
+        weight: 1
+        primary_score:
+          metric: inst_level_strict_acc
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.60
+        parameters:
+          num_fewshot: 0
+          apply_chat_template: true
+
+      - id: math_500
+        provider_id: lighteval
+        weight: 1
+        primary_score:
+          metric: pass@1
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.30
+        parameters:
+          num_fewshot: 0
+          apply_chat_template: true
+          pass_at_k: 1
+          num_samples: 3

--- a/config/configmaps/evalhub/collection-long-context-v1.yaml
+++ b/config/configmaps/evalhub/collection-long-context-v1.yaml
@@ -1,0 +1,87 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: evalhub-collection-long-context-v1
+  labels:
+    trustyai.opendatahub.io/evalhub-collection-type: system
+    trustyai.opendatahub.io/evalhub-collection-name: long-context-v1
+data:
+  long-context-v1.yaml: |
+    id: long-context-v1
+    name: Long Context v1
+    category: long_context
+    description: >
+      Evaluates long-context retrieval and comprehension for instruction-tuned chat LLMs
+      using Multi-step Retrieval and Comprehension Reasoning (MRCR). MRCR scores the model
+      across sequence-length buckets from 0 to max model length; the primary metric is AUC
+      (area under the score-vs-length curve) with per-bucket subscores also available
+      (e.g. score_gt_16k_le_32k). Four needle-count variants are included: 1, 2, 4, and 8
+      needles — each harder than the previous because the model must simultaneously track
+      and return more pieces of information. Each variant is run 3 times with different seeds.
+      See: https://github.com/EleutherAI/lm-evaluation-harness/pull/3754
+      Part of the Standard LLM Evaluation Suite (standard-llm-evals-v1).
+    tags:
+      - long_context
+      - retrieval
+      - comprehension
+      - multi_needle
+      - chat
+      - lm_eval
+      - vllm
+      - standard
+    pass_criteria:
+      # Weighted average with declining weights as needle count increases.
+      # The 1-needle baseline carries the most weight; 8-needle is auxiliary.
+      threshold: 0.45
+    benchmarks:
+      - id: mrcr
+        provider_id: lm_evaluation_harness
+        weight: 4   # Baseline variant — most representative single score
+        primary_score:
+          metric: auc
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.55
+        parameters:
+          num_fewshot: 0
+          apply_chat_template: true
+          repetitions: 3
+
+      - id: mrcr_2needle
+        provider_id: lm_evaluation_harness
+        weight: 3
+        primary_score:
+          metric: auc
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.55
+        parameters:
+          num_fewshot: 0
+          apply_chat_template: true
+          repetitions: 3
+
+      - id: mrcr_4needle
+        provider_id: lm_evaluation_harness
+        weight: 2
+        primary_score:
+          metric: auc
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.45
+        parameters:
+          num_fewshot: 0
+          apply_chat_template: true
+          repetitions: 3
+
+      - id: mrcr_8needle
+        provider_id: lm_evaluation_harness
+        weight: 1   # Hardest variant; lower absolute scores expected
+        primary_score:
+          metric: auc
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.35
+        parameters:
+          num_fewshot: 0
+          apply_chat_template: true
+          repetitions: 3

--- a/config/configmaps/evalhub/collection-reasoning-v1.yaml
+++ b/config/configmaps/evalhub/collection-reasoning-v1.yaml
@@ -1,0 +1,112 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: evalhub-collection-reasoning-v1
+  labels:
+    trustyai.opendatahub.io/evalhub-collection-type: system
+    trustyai.opendatahub.io/evalhub-collection-name: reasoning-v1
+data:
+  reasoning-v1.yaml: |
+    id: reasoning-v1
+    name: Reasoning v1
+    category: reasoning
+    description: >
+      Evaluates multi-step and chain-of-thought reasoning for instruction-tuned chat LLMs
+      across math word problems, advanced multidomain Q&A, instruction following, competition
+      mathematics, expert-level science, and competition coding math. All benchmarks are 0-shot
+      to probe raw reasoning without in-context demonstrations. Math 500 and AIME 25 use pass@k
+      averaged over multiple seeds (3 and 8 respectively); GPQA Diamond uses 3 seeds.
+      All benchmarks require --apply_chat_template and a vLLM OpenAI-compatible endpoint.
+      Part of the Standard LLM Evaluation Suite (standard-llm-evals-v1).
+    tags:
+      - reasoning
+      - math
+      - science
+      - chain_of_thought
+      - chat
+      - lm_eval
+      - lighteval
+      - vllm
+      - standard
+    pass_criteria:
+      # Weighted average (equal weight). AIME 25 has lower weight — very hard competition math.
+      # Threshold reflects solid reasoning capability across diverse task types.
+      threshold: 0.38
+    benchmarks:
+      - id: gsm8k_platinum_cot_llama
+        provider_id: lm_evaluation_harness
+        weight: 1
+        primary_score:
+          metric: exact_match
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.60   # Slightly lower than IF variant — 0-shot is harder
+        parameters:
+          num_fewshot: 0
+          apply_chat_template: true
+
+      - id: leaderboard_mmlu_pro
+        provider_id: lm_evaluation_harness
+        weight: 1
+        primary_score:
+          metric: acc_norm
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.40   # 0-shot is harder than 5-shot
+        parameters:
+          num_fewshot: 0
+          apply_chat_template: true
+
+      - id: ifeval
+        provider_id: lm_evaluation_harness
+        weight: 1
+        primary_score:
+          metric: inst_level_strict_acc
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.60
+        parameters:
+          num_fewshot: 0
+          apply_chat_template: true
+
+      - id: math_500
+        provider_id: lighteval
+        weight: 1
+        primary_score:
+          metric: pass@1
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.30
+        parameters:
+          num_fewshot: 0
+          apply_chat_template: true
+          pass_at_k: 1
+          num_samples: 3
+
+      - id: aime25
+        provider_id: lighteval
+        weight: 1   # Competition math — lower absolute scores expected even for strong models
+        primary_score:
+          metric: pass@1
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.15
+        parameters:
+          num_fewshot: 0
+          apply_chat_template: true
+          pass_at_k: 1
+          num_samples: 8   # 8-seed average per standard protocol
+
+      - id: gpqa:diamond
+        provider_id: lighteval
+        weight: 1
+        primary_score:
+          metric: gpqa_pass@1
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.35
+        parameters:
+          num_fewshot: 0
+          apply_chat_template: true
+          pass_at_k: 1
+          num_samples: 3

--- a/config/configmaps/evalhub/collection-standard-llm-evals-v1.yaml
+++ b/config/configmaps/evalhub/collection-standard-llm-evals-v1.yaml
@@ -1,0 +1,206 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: evalhub-collection-standard-llm-evals-v1
+  labels:
+    trustyai.opendatahub.io/evalhub-collection-type: system
+    trustyai.opendatahub.io/evalhub-collection-name: standard-llm-evals-v1
+data:
+  standard-llm-evals-v1.yaml: |
+    id: standard-llm-evals-v1
+    name: Standard LLM Evaluation Suite v1
+    category: general
+    description: >
+      Standard evaluation protocol for instruction-tuned chat LLMs covering instruction following,
+      reasoning, math, coding, and long-context tasks. Uses lm-eval (LM Evaluation Harness) for
+      generative and multiple-choice tasks, and lighteval for pass@k math and coding evaluations.
+      Follows the vLLM evaluation protocol: always apply chat template, use fewshot_as_multiturn
+      for 1+ fewshot examples, and match sampling parameters to the model provider recommendation.
+      Each benchmark is run with 3 repetitions (8 for AIME 25) using different seeds; the
+      repetition count is encoded in the pass@k n parameter (e.g. k=1,n=3 or k=1,n=8).
+    tags:
+      - instruction_following
+      - reasoning
+      - math
+      - coding
+      - long_context
+      - lm_eval
+      - lighteval
+      - standard
+      - chat
+      - vllm
+    pass_criteria:
+      # Weighted average across all benchmarks. Weights reflect benchmark importance;
+      # AIME 25 and MRCR variants carry lower weight (hard / auxiliary).
+      threshold: 0.45
+    benchmarks:
+      # ── Instruction Following ──────────────────────────────────────────────────
+      - id: gsm8k_platinum_cot_llama
+        provider_id: lm_evaluation_harness
+        weight: 2
+        primary_score:
+          metric: exact_match
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.65
+        parameters:
+          num_fewshot: 5
+          apply_chat_template: true
+          fewshot_as_multiturn: true
+          # Category: Instruction Following (5-shot)
+          # For Reasoning use 0-shot instead — submit as a separate job with num_fewshot: 0
+
+      - id: mmlu_cot_llama
+        provider_id: lm_evaluation_harness
+        weight: 2
+        primary_score:
+          metric: exact_match
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.60
+        parameters:
+          num_fewshot: 5
+          apply_chat_template: true
+          fewshot_as_multiturn: true
+
+      - id: leaderboard_mmlu_pro
+        provider_id: lm_evaluation_harness
+        weight: 2
+        primary_score:
+          metric: acc_norm
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.45
+        parameters:
+          num_fewshot: 5
+          apply_chat_template: true
+          fewshot_as_multiturn: true
+
+      - id: ifeval
+        provider_id: lm_evaluation_harness
+        weight: 2
+        primary_score:
+          metric: inst_level_strict_acc
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.60
+        parameters:
+          num_fewshot: 0
+          apply_chat_template: true
+
+      # ── Math & Reasoning ───────────────────────────────────────────────────────
+      - id: math_500
+        provider_id: lighteval
+        weight: 2
+        primary_score:
+          metric: pass@1
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.30
+        parameters:
+          num_fewshot: 0
+          apply_chat_template: true
+          # k=1, n=3: average over 3 seeds. Equivalent to 3 separate runs with different seeds.
+          pass_at_k: 1
+          num_samples: 3
+
+      - id: aime25
+        provider_id: lighteval
+        weight: 1   # Competition math — very hard, lower absolute scores expected
+        primary_score:
+          metric: pass@1
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.15
+        parameters:
+          num_fewshot: 0
+          apply_chat_template: true
+          # k=1, n=8: average over 8 seeds per protocol (equivalent to 8 separate runs)
+          pass_at_k: 1
+          num_samples: 8
+
+      - id: gpqa:diamond
+        provider_id: lighteval
+        weight: 2
+        primary_score:
+          metric: gpqa_pass@1
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.35
+        parameters:
+          num_fewshot: 0
+          apply_chat_template: true
+          pass_at_k: 1
+          num_samples: 3
+
+      # ── Coding ─────────────────────────────────────────────────────────────────
+      - id: lcb:codegeneration_v6
+        provider_id: lighteval
+        weight: 2
+        primary_score:
+          metric: codegen_pass@1
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.25
+        parameters:
+          num_fewshot: 0
+          apply_chat_template: true
+          pass_at_k: 1
+          num_samples: 3
+
+      # ── Long Context ───────────────────────────────────────────────────────────
+      # MRCR evaluates long-context recall at multiple sequence-length buckets.
+      # Primary metric is AUC (area under the score-vs-length curve).
+      # Per-bucket scores: score_gt_16k_le_32k, score_gt_32k_le_64k, score_gt_64k_le_128k, etc.
+      # See: https://github.com/EleutherAI/lm-evaluation-harness/pull/3754
+      - id: mrcr
+        provider_id: lm_evaluation_harness
+        weight: 1
+        primary_score:
+          metric: auc
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.55
+        parameters:
+          num_fewshot: 0
+          apply_chat_template: true
+          repetitions: 3     # 3 runs with different seeds
+
+      - id: mrcr_2needle
+        provider_id: lm_evaluation_harness
+        weight: 1
+        primary_score:
+          metric: auc
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.55
+        parameters:
+          num_fewshot: 0
+          apply_chat_template: true
+          repetitions: 3
+
+      - id: mrcr_4needle
+        provider_id: lm_evaluation_harness
+        weight: 1
+        primary_score:
+          metric: auc
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.45
+        parameters:
+          num_fewshot: 0
+          apply_chat_template: true
+          repetitions: 3
+
+      - id: mrcr_8needle
+        provider_id: lm_evaluation_harness
+        weight: 1
+        primary_score:
+          metric: auc
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.35
+        parameters:
+          num_fewshot: 0
+          apply_chat_template: true
+          repetitions: 3

--- a/config/configmaps/evalhub/kustomization.yaml
+++ b/config/configmaps/evalhub/kustomization.yaml
@@ -5,8 +5,13 @@ resources:
   - provider-ibm-clear.yaml
   - provider-lighteval.yaml
   - provider-lm-evaluation-harness.yaml
+  - collection-coding-v1.yaml
+  - collection-instruction-following-v1.yaml
   - collection-leaderboard-v2.yaml
+  - collection-long-context-v1.yaml
+  - collection-reasoning-v1.yaml
   - collection-safety-and-fairness-v1.yaml
+  - collection-standard-llm-evals-v1.yaml
   - collection-toxicity-and-ethical-principles.yaml
 
 namespace: system

--- a/config/configmaps/evalhub/provider-lighteval.yaml
+++ b/config/configmaps/evalhub/provider-lighteval.yaml
@@ -465,3 +465,72 @@ data:
           lower_is_better: false
         pass_criteria:
           threshold: 0.25
+      - id: math_500
+        name: MATH-500 competition problems
+        description: |-
+          500 hand-picked problems from the MATH dataset spanning 7 subject areas (algebra,
+          counting, geometry, number theory, probability, pre-calculus, intermediate algebra).
+          Tests competition-level mathematical reasoning with multi-step solutions. Primary
+          metric is pass@1 averaged over 3 random seeds (k=1, n=3 in lighteval syntax).
+        category: math
+        metrics:
+          - pass@1
+          - exact_match
+        num_few_shot: 0
+        dataset_size: 500
+        tags:
+          - math
+          - reasoning
+          - competition
+          - lighteval
+        primary_score:
+          metric: pass@1
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.30
+      - id: gpqa:diamond
+        name: Graduate-level science (GPQA Diamond)
+        description: |-
+          Expert-crafted PhD-level multiple-choice questions in biology, chemistry, and physics
+          requiring deep domain synthesis across topics rarely co-occurring in training data.
+          Diamond subset is the hardest tier — domain experts answer correctly ~65% of the time.
+          Primary metric is gpqa_pass@1 averaged over 3 random seeds.
+        category: reasoning
+        metrics:
+          - gpqa_pass@1
+          - acc
+        num_few_shot: 0
+        dataset_size: 198
+        tags:
+          - reasoning
+          - science
+          - expert
+          - competition
+          - lighteval
+        primary_score:
+          metric: gpqa_pass@1
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.35
+      - id: lcb:codegeneration_v6
+        name: LiveCodeBench v6 — code generation
+        description: |-
+          Real-world competitive programming problems collected from Codeforces, LeetCode, and
+          AtCoder after the model knowledge cutoff — eliminates data contamination risk.
+          Execution-based evaluation: generated code is run against hidden test cases.
+          Primary metric is codegen_pass@1 averaged over 3 random seeds.
+        category: code
+        metrics:
+          - codegen_pass@1
+        num_few_shot: 0
+        tags:
+          - code
+          - competitive-programming
+          - execution
+          - contamination-free
+          - lighteval
+        primary_score:
+          metric: codegen_pass@1
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.25

--- a/config/configmaps/evalhub/provider-lm-evaluation-harness.yaml
+++ b/config/configmaps/evalhub/provider-lm-evaluation-harness.yaml
@@ -3099,3 +3099,169 @@ data:
           lower_is_better: true
         pass_criteria:
           threshold: 0.6
+      # ── Standard LLM Evaluation Suite benchmarks ────────────────────────────────
+      # These benchmarks are used in the standard-llm-evals-v1 collection.
+      # They require lm-eval >= 0.4.x with --apply_chat_template and
+      # --fewshot_as_multiturn flags, served via vLLM OpenAI-compatible API.
+      - id: gsm8k_platinum_cot_llama
+        name: GSM8k-Platinum (CoT, Llama chat format)
+        description: |-
+          Filtered, higher-quality subset of GSM8k with corrected labels, evaluated with
+          chain-of-thought prompting in Llama chat template format. 5-shot for instruction-
+          following evaluation; 0-shot for reasoning evaluation. Metric: exact_match,strict-match.
+        category: math
+        metrics:
+          - exact_match
+        num_few_shot: 5   # 5-shot for instruction-following; use 0 for reasoning
+        tags:
+          - math
+          - reasoning
+          - instruction_following
+          - chain_of_thought
+          - chat
+          - lm_eval
+        primary_score:
+          metric: exact_match
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.65
+      - id: mmlu_cot_llama
+        name: MMLU with chain-of-thought (Llama chat format)
+        description: |-
+          57-subject MMLU evaluated with chain-of-thought reasoning using Llama chat template.
+          5-shot with fewshot_as_multiturn. Metric: exact_match,strict_match.
+        category: knowledge
+        metrics:
+          - exact_match
+        num_few_shot: 5
+        dataset_size: 15908
+        tags:
+          - knowledge
+          - multitask
+          - chain_of_thought
+          - chat
+          - lm_eval
+        primary_score:
+          metric: exact_match
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.60
+      - id: ifeval
+        name: Instruction Following Evaluation (IFEval)
+        description: |-
+          541 prompts with 25 verifiable instruction types covering length, keyword, format,
+          JSON structure, and language constraints — evaluates strict adherence to explicit
+          formatting requirements. Scored at both prompt level and instruction level.
+          Metric: inst_level_strict_acc. Use 0-shot with chat template.
+        category: instruction_following
+        metrics:
+          - prompt_level_strict_acc
+          - inst_level_strict_acc
+          - prompt_level_loose_acc
+          - inst_level_loose_acc
+        num_few_shot: 0
+        dataset_size: 541
+        tags:
+          - instruction_following
+          - chat
+          - lm_eval
+        primary_score:
+          metric: inst_level_strict_acc
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.60
+      - id: mrcr
+        name: Multi-step Retrieval and Comprehension Reasoning (MRCR — 1 needle)
+        description: |-
+          Evaluates long-context recall and reasoning with 1 needle across sequence length
+          buckets from 0 to max model length. Primary metric is AUC (area under the
+          score-vs-length curve); per-bucket scores (e.g. score_gt_16k_le_32k) are also
+          reported. Run 3 times with different seeds. See:
+          https://github.com/EleutherAI/lm-evaluation-harness/pull/3754
+        category: long_context
+        metrics:
+          - auc
+          - score_gt_8k_le_16k
+          - score_gt_16k_le_32k
+          - score_gt_32k_le_64k
+          - score_gt_64k_le_128k
+        num_few_shot: 0
+        tags:
+          - long_context
+          - retrieval
+          - comprehension
+          - lm_eval
+        primary_score:
+          metric: auc
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.55
+      - id: mrcr_2needle
+        name: MRCR — 2-needle retrieval
+        description: |-
+          Multi-step Retrieval and Comprehension Reasoning with 2 needles to locate across
+          long contexts. Harder than the 1-needle variant because the model must track and
+          return multiple pieces of information. Primary metric: AUC across length buckets.
+        category: long_context
+        metrics:
+          - auc
+          - score_gt_8k_le_16k
+          - score_gt_16k_le_32k
+          - score_gt_32k_le_64k
+        num_few_shot: 0
+        tags:
+          - long_context
+          - retrieval
+          - multi_needle
+          - lm_eval
+        primary_score:
+          metric: auc
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.55
+      - id: mrcr_4needle
+        name: MRCR — 4-needle retrieval
+        description: |-
+          Multi-step Retrieval and Comprehension Reasoning with 4 needles to locate across
+          long contexts. Requires the model to maintain and return 4 distinct pieces of
+          information from a long document. Primary metric: AUC across length buckets.
+        category: long_context
+        metrics:
+          - auc
+          - score_gt_8k_le_16k
+          - score_gt_16k_le_32k
+          - score_gt_32k_le_64k
+        num_few_shot: 0
+        tags:
+          - long_context
+          - retrieval
+          - multi_needle
+          - lm_eval
+        primary_score:
+          metric: auc
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.45
+      - id: mrcr_8needle
+        name: MRCR — 8-needle retrieval
+        description: |-
+          Multi-step Retrieval and Comprehension Reasoning with 8 needles — the hardest MRCR
+          variant. Requires simultaneously tracking and returning 8 distinct pieces of information
+          from a long document. Primary metric: AUC across length buckets.
+        category: long_context
+        metrics:
+          - auc
+          - score_gt_8k_le_16k
+          - score_gt_16k_le_32k
+          - score_gt_32k_le_64k
+        num_few_shot: 0
+        tags:
+          - long_context
+          - retrieval
+          - multi_needle
+          - lm_eval
+        primary_score:
+          metric: auc
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.35


### PR DESCRIPTION
New collections were added to evalhub: https://github.com/eval-hub/eval-hub/pull/586 
Provider lighteval and lm-eval-harness also had their benchmarks updated as part of that PR

Add 5 new evaluation collections (coding-v1, instruction-following-v1, long-context-v1, reasoning-v1, standard-llm-evals-v1) and sync upstream benchmark definitions for lighteval (math_500, gpqa:diamond, lcb:codegeneration_v6) and lm-evaluation-harness (gsm8k_platinum_cot_llama, mmlu_cot_llama, ifeval, mrcr variants).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added five new evaluation collections: Coding v1, Instruction Following v1, Long-Context v1, Reasoning v1, and Standard LLM Evals v1 for comprehensive LLM benchmarking
  * Added three new benchmarks to evaluation providers: MATH-500, GPQA Diamond, and LiveCodeBench v6 code generation support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->