### PR TITLE
chore: add cmd arg to EH service for rbac-proxy mode

### DIFF
--- a/controllers/evalhub/build_test.go
+++ b/controllers/evalhub/build_test.go
@@ -113,6 +113,7 @@ var _ = Describe("buildDeploymentSpec", func() {
 		Expect(container.Name).To(Equal(containerName))
 		Expect(container.Image).To(Equal("quay.io/test/eval-hub:v1.2.3"))
 		Expect(container.ImagePullPolicy).To(Equal(corev1.PullAlways))
+		Expect(container.Args).To(Equal([]string{"--auth-type", evalHubAuthTypeRBACProxy}))
 
 		Expect(container.Ports).To(HaveLen(1))
 		Expect(container.Ports[0].Name).To(Equal("evalhub"))

--- a/controllers/evalhub/constants.go
+++ b/controllers/evalhub/constants.go
@@ -13,7 +13,8 @@ const (
 	defaultEvalHubImage = "quay.io/evalhub/evalhub:latest"
 
 	// Container configuration
-	containerName = "evalhub"
+	containerName            = "evalhub"
+	evalHubAuthTypeRBACProxy = "rbac-proxy"
 	// evalHubAppPort is the eval-hub container listen port on loopback (API_HOST=127.0.0.1, PORT in deployment env).
 	// kube-rbac-proxy upstream is http://127.0.0.1:<evalHubAppPort>/ on the pod network (TLS is terminated on servicePort).
 	evalHubAppPort = 8444

--- a/controllers/evalhub/deployment.go
+++ b/controllers/evalhub/deployment.go
@@ -181,6 +181,9 @@ func (r *EvalHubReconciler) buildDeploymentSpec(ctx context.Context, instance *e
 		Name:            containerName,
 		Image:           evalHubImage,
 		ImagePullPolicy: corev1.PullAlways,
+		Args: []string{
+			"--auth-type", evalHubAuthTypeRBACProxy,
+		},
 		Ports: []corev1.ContainerPort{
 			{
 				Name:          "evalhub",

--- a/controllers/evalhub/deployment_test.go
+++ b/controllers/evalhub/deployment_test.go
@@ -128,6 +128,7 @@ var _ = Describe("EvalHub Deployment", func() {
 			By("Checking evalhub container configuration")
 			Expect(evalHubContainer.Image).To(Equal("quay.io/ruimvieira/eval-hub:test")) // From test configmap
 			Expect(evalHubContainer.ImagePullPolicy).To(Equal(corev1.PullAlways))
+			Expect(evalHubContainer.Args).To(Equal([]string{"--auth-type", evalHubAuthTypeRBACProxy}))
 
 			// Check ports (loopback app port; Service targets kube-rbac-proxy on 8443)
 			Expect(evalHubContainer.Ports).To(HaveLen(1))
@@ -619,6 +620,7 @@ var _ = Describe("EvalHubReconciler reconcileDeployment", func() {
 
 		Expect(evalHubC.Image).To(Equal("quay.io/test/eval-hub:latest"))
 		Expect(evalHubC.ImagePullPolicy).To(Equal(corev1.PullAlways))
+		Expect(evalHubC.Args).To(Equal([]string{"--auth-type", evalHubAuthTypeRBACProxy}))
 		Expect(evalHubC.Ports).To(HaveLen(1))
 		Expect(evalHubC.Ports[0].Name).To(Equal("evalhub"))
 		Expect(evalHubC.Ports[0].ContainerPort).To(Equal(int32(evalHubAppPort)))


### PR DESCRIPTION
Related to https://redhat.atlassian.net/browse/RHOAIENG-66295 and https://github.com/eval-hub/eval-hub/pull/623#discussion_r3375231593

Adds a command line argument to EH service to indicate that it is running behind an rbac-proxy. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * EvalHub deployment now includes explicit RBAC-proxy authentication configuration, with arguments passed to the container at runtime.

* **Tests**
  * Enhanced test coverage to validate RBAC-proxy authentication configuration is correctly applied during deployment creation and reconciliation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->