### PR TITLE
feat(chaos): integrate operator-chaos L1 shift-left upgrade validation

### DIFF
--- a/.github/workflows/operator-chaos.yml
+++ b/.github/workflows/operator-chaos.yml
@@ -1,0 +1,158 @@
+name: Operator Chaos
+
+on:
+  pull_request:
+    paths:
+      - "api/**"
+      - "cmd/**"
+      - "config/**"
+      - "controllers/**"
+      - "chaos/knowledge/**"
+      - ".github/workflows/operator-chaos.yml"
+
+permissions:
+  contents: read
+
+env:
+  OPERATOR_CHAOS_VERSION: "9e6ac9668b9aaca2f0f2ddf169867862b7925b80"
+
+jobs:
+  operator-chaos:
+    name: Operator Chaos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install operator-chaos
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/bin"
+          GOBIN="${RUNNER_TEMP}/bin" go install "github.com/opendatahub-io/operator-chaos/cmd/operator-chaos@${OPERATOR_CHAOS_VERSION}"
+          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
+
+      - name: Checkout base branch assets
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base-branch
+          persist-credentials: false
+          sparse-checkout: |
+            chaos/knowledge
+            config/components/tas/crd
+            config/components/evalhub/crd
+            config/components/lmes/crd
+            config/components/gorch/crd
+            config/components/nemo-guardrails/crd
+          sparse-checkout-cone-mode: false
+
+      - name: Validate knowledge model
+        shell: bash
+        run: |
+          set -euo pipefail
+          operator-chaos validate --knowledge "chaos/knowledge/trustyai.yaml"
+
+      - name: Run local preflight
+        shell: bash
+        run: |
+          set -euo pipefail
+          operator-chaos preflight --knowledge "chaos/knowledge/trustyai.yaml" --local
+
+      - name: Diff knowledge model
+        shell: bash
+        run: |
+          set -euo pipefail
+          base_knowledge_file="base-branch/chaos/knowledge/trustyai.yaml"
+          if [[ ! -f "${base_knowledge_file}" ]]; then
+            echo "No base knowledge model found; skipping knowledge diff for bootstrap PR."
+            exit 0
+          fi
+
+          output_dir="${RUNNER_TEMP}/operator-chaos"
+          mkdir -p "${output_dir}"
+          knowledge_diff_json="${output_dir}/knowledge-diff.json"
+
+          operator-chaos diff \
+            --source "base-branch/chaos/knowledge" \
+            --target "chaos/knowledge" \
+            --breaking \
+            --format json > "${knowledge_diff_json}"
+          operator-chaos diff \
+            --source "base-branch/chaos/knowledge" \
+            --target "chaos/knowledge" \
+            --breaking
+
+          knowledge_breaking=$(jq -r '.summary.breakingChanges // 0' "${knowledge_diff_json}")
+          if (( knowledge_breaking > 0 )); then
+            echo "operator-chaos detected ${knowledge_breaking} breaking knowledge change(s)."
+            exit 1
+          fi
+
+      - name: Diff CRD schemas
+        shell: bash
+        run: |
+          set -euo pipefail
+          output_dir="${RUNNER_TEMP}/operator-chaos"
+          mkdir -p "${output_dir}"
+          source_dir="${output_dir}/source-crds"
+          target_dir="${output_dir}/target-crds"
+          rm -rf "${source_dir}" "${target_dir}"
+          mkdir -p "${source_dir}" "${target_dir}"
+
+          has_base_crds=false
+          for component_dir in base-branch/config/components/*/crd; do
+            if [[ -d "${component_dir}" ]]; then
+              cp "${component_dir}"/*.yaml "${source_dir}/" 2>/dev/null && has_base_crds=true
+            fi
+          done
+          if [[ "${has_base_crds}" != "true" ]]; then
+            echo "No base CRDs found; skipping CRD diff for bootstrap PR."
+            exit 0
+          fi
+
+          for component_dir in config/components/*/crd; do
+            if [[ -d "${component_dir}" ]]; then
+              cp "${component_dir}"/*.yaml "${target_dir}/" 2>/dev/null || true
+            fi
+          done
+
+          crd_diff_json="${output_dir}/crd-diff.json"
+          operator-chaos diff-crds \
+            --source-crds "${source_dir}" \
+            --target-crds "${target_dir}" \
+            --format json > "${crd_diff_json}"
+          operator-chaos diff-crds \
+            --source-crds "${source_dir}" \
+            --target-crds "${target_dir}"
+
+          crd_breaking=$(jq -r '
+            reduce ((.crds // [])[]?.apiVersions[]?.schemaChanges[]?) as $change
+              (0; if ($change.severity | ascii_downcase) == "breaking" then . + 1 else . end)
+          ' "${crd_diff_json}")
+          if (( crd_breaking > 0 )); then
+            echo "operator-chaos detected ${crd_breaking} breaking CRD schema change(s)."
+            exit 1
+          fi
+
+      - name: Preview upgrade simulation
+        shell: bash
+        run: |
+          set -euo pipefail
+          base_knowledge_file="base-branch/chaos/knowledge/trustyai.yaml"
+          if [[ ! -f "${base_knowledge_file}" ]]; then
+            echo "No base knowledge model found; skipping simulate-upgrade for bootstrap PR."
+            exit 0
+          fi
+
+          operator-chaos simulate-upgrade \
+            --source "base-branch/chaos/knowledge" \
+            --target "chaos/knowledge" \
+            --dry-run

--- a/.github/workflows/operator-chaos.yml
+++ b/.github/workflows/operator-chaos.yml
@@ -1,4 +1,4 @@
-name: Tier 2 - Operator Chaos
+name: Tier 2 - Shift-left Upgrade Validation
 
 on:
   pull_request:
@@ -18,7 +18,7 @@ env:
 
 jobs:
   operator-chaos:
-    name: Tier 2 - Operator Chaos
+    name: Operator Chaos
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/operator-chaos.yml
+++ b/.github/workflows/operator-chaos.yml
@@ -1,4 +1,4 @@
-name: Operator Chaos
+name: Tier 2 - Operator Chaos
 
 on:
   pull_request:
@@ -18,7 +18,7 @@ env:
 
 jobs:
   operator-chaos:
-    name: Operator Chaos
+    name: Tier 2 - Operator Chaos
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,4 +197,18 @@ GitHub Actions in `.github/workflows/`:
 - `lint-yaml.yaml` — yamllint on `config/**/*.yaml`
 - `gosec.yaml` — security scanning (SARIF output)
 - `smoke.yaml` — smoke tests
+- `operator-chaos.yml` — shift-left upgrade validation (L1: knowledge model + CRD diff)
 - `.dependabot.yml` — auto-updates Go deps
+
+## Shift-left Upgrade Validation (operator-chaos)
+
+L1 integration using [operator-chaos](https://github.com/opendatahub-io/operator-chaos). Catches breaking CRD schema changes and knowledge model regressions at PR time without a cluster.
+
+```
+chaos/knowledge/trustyai.yaml   # Knowledge model (operator control plane topology)
+.github/workflows/operator-chaos.yml  # GHA workflow
+```
+
+The knowledge model covers the **operator control plane only** — the Deployment, RBAC, ServiceAccount, leader election, and ServiceMonitor. Per-CR workloads (TrustyAIService instances, EvalHub instances, etc.) are dynamic user-created resources and are not modelled.
+
+When modifying CRDs (`api/` types → `make manifests`) or RBAC/manager resources, the workflow automatically validates that no breaking changes are introduced. Update `chaos/knowledge/trustyai.yaml` whenever the operator's own managed resources change (new RBAC roles, renamed resources, etc.).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,7 +204,7 @@ GitHub Actions in `.github/workflows/`:
 
 L1 integration using [operator-chaos](https://github.com/opendatahub-io/operator-chaos). Catches breaking CRD schema changes and knowledge model regressions at PR time without a cluster.
 
-```
+```text
 chaos/knowledge/trustyai.yaml   # Knowledge model (operator control plane topology)
 .github/workflows/operator-chaos.yml  # GHA workflow
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,32 @@ To ensure the contributed code adheres to the project goals, we have set up some
 1. [linters](https://github.com/trustyai-explainability/trustyai-service-operator/actions/workflows/lint-yaml.yaml): Ensure the check for linters is successful.
 2. [smoke tests](https://github.com/trustyai-explainability/trustyai-service-operator/actions/workflows/smoke.yaml): Ensure the operator passes the smoke tests
 3. [unit-tests](https://github.com/trustyai-explainability/trustyai-service-operator/actions/workflows/controller-tests.yaml): Ensure unit tests pass.
-4. e2e-tests: Ensure OpenShift CI job for e2e tests pass.
+4. [operator-chaos](https://github.com/trustyai-explainability/trustyai-service-operator/actions/workflows/operator-chaos.yml): Ensure no breaking upgrade changes are introduced.
+5. e2e-tests: Ensure OpenShift CI job for e2e tests pass.
+
+### Shift-left Upgrade Validation (operator-chaos)
+
+This operator uses [operator-chaos](https://github.com/opendatahub-io/operator-chaos) for shift-left upgrade validation. A GitHub Actions workflow runs on every PR that touches operator code, CRDs, or the knowledge model to catch breaking changes before merge.
+
+**What it checks:**
+- Knowledge model validity and structural regressions
+- CRD schema breaking changes across all 5 CRDs
+- Simulated upgrade dry-run
+
+**Maintaining the knowledge model:**
+
+The knowledge model at `chaos/knowledge/trustyai.yaml` describes the operator's control plane topology. Update it when:
+- Adding or removing RBAC resources
+- Renaming the operator deployment or service account
+- Changing the leader election lease name
+- Adding new operator-level resources (not per-CR workloads)
+
+```bash
+# Validate locally
+go install github.com/opendatahub-io/operator-chaos/cmd/operator-chaos@9e6ac9668b9aaca2f0f2ddf169867862b7925b80
+operator-chaos validate --knowledge chaos/knowledge/trustyai.yaml
+operator-chaos preflight --knowledge chaos/knowledge/trustyai.yaml --local
+```
 
 ### Code Style Guidelines
 

--- a/chaos/knowledge/trustyai.yaml
+++ b/chaos/knowledge/trustyai.yaml
@@ -1,0 +1,70 @@
+operator:
+  name: trustyai-service-operator
+  namespace: redhat-ods-applications
+  repository: https://github.com/trustyai-explainability/trustyai-service-operator
+
+components:
+  - name: trustyai-service-operator-controller-manager
+    controller: TrustyAIServiceReconciler
+    managedResources:
+      - apiVersion: apps/v1
+        kind: Deployment
+        name: trustyai-service-operator-controller-manager
+        namespace: redhat-ods-applications
+        labels:
+          control-plane: trustyai-service-operator
+          app.kubernetes.io/part-of: trustyai
+        expectedSpec:
+          replicas: 1
+      - apiVersion: v1
+        kind: ServiceAccount
+        name: trustyai-service-operator-controller-manager
+        namespace: redhat-ods-applications
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        name: trustyai-service-operator-manager-role
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        name: trustyai-service-operator-manager-rolebinding
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        name: trustyai-service-operator-metrics-reader
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        name: trustyai-service-operator-proxy-role
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        name: trustyai-service-operator-proxy-rolebinding
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: Role
+        name: trustyai-service-operator-leader-election-role
+        namespace: redhat-ods-applications
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        name: trustyai-service-operator-leader-election-rolebinding
+        namespace: redhat-ods-applications
+      - apiVersion: v1
+        kind: Service
+        name: trustyai-service-operator-controller-manager-metrics-service
+        namespace: redhat-ods-applications
+      - apiVersion: coordination.k8s.io/v1
+        kind: Lease
+        name: b7e9931f.trustyai.opendatahub.io
+        namespace: redhat-ods-applications
+      - apiVersion: monitoring.coreos.com/v1
+        kind: ServiceMonitor
+        name: trustyai-service-operator-controller-manager-metrics-monitor
+        namespace: redhat-ods-applications
+    steadyState:
+      checks:
+        - type: conditionTrue
+          apiVersion: apps/v1
+          kind: Deployment
+          name: trustyai-service-operator-controller-manager
+          namespace: redhat-ods-applications
+          conditionType: Available
+      timeout: "60s"
+
+recovery:
+  reconcileTimeout: "300s"
+  maxReconcileCycles: 10


### PR DESCRIPTION
## What and why

Integrates operator-chaos (https://github.com/opendatahub-io/operator-chaos) at L1 maturity level to catch upgrade-breaking changes (CRD schema regressions, knowledge model drift) at PR time, no cluster required. 

Closes [RHOAIENG-63064](https://redhat.atlassian.net/browse/RHOAIENG-63064)

## What's included

- Knowledge model (`chaos/knowledge/trustyai.yaml`): describes the operator control plane topology: Deployment, ServiceAccount, RBAC (6 roles/bindings), leader election Lease, metrics Service, and ServiceMonitor. Per-CR workloads are intentionally excluded as they are dynamic user-created resources.
- GHA workflow (`.github/workflows/operator-chaos.yml`): runs on PRs touching api/, cmd/, config/, controllers/, or chaos/knowledge/. Steps: validate knowledge model, local preflight, diff knowledge for breaking changes, diff all 5 CRD schemas, and dry-run upgrade simulation. Bootstrap PRs (no base knowledge/CRDs) skip gracefully.
- Docs: CONTRIBUTING.md updated with operator-chaos quality gate and maintenance guide.


## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] operator-chaos validate --knowledge chaos/knowledge/trustyai.yaml, passes (model valid)
- [x] operator-chaos preflight --knowledge chaos/knowledge/trustyai.yaml --local, passes (1 component, 12 resources)
- [ ] GHA workflow runs on first PR merge (bootstrap, all diff steps skip gracefully)

## Breaking changes

None. This is additive, a new CI gate that only runs on PRs touching operator code paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added automated pull request validation to detect breaking changes in operator schemas and knowledge models, with workflow failure reporting for incompatibilities.

* **Documentation**
  * Updated contributor guides with upgrade validation procedures and local validation commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->