### PR TITLE
fix(evalhub): update MCP deployment test to expect --auth-type arg

### DIFF
--- a/controllers/evalhub/mcp_deployment_test.go
+++ b/controllers/evalhub/mcp_deployment_test.go
@@ -62,6 +62,7 @@ func TestBuildMCPDeploymentSpec_envAndArgs(t *testing.T) {
 		"--transport", "http",
 		"--host", "127.0.0.1",
 		"--port", "8445",
+		"--auth-type", "rbac-proxy",
 	}, mcpC.Args)
 	assert.Nil(t, mcpC.LivenessProbe)
 	assert.Nil(t, mcpC.ReadinessProbe)


### PR DESCRIPTION
## What and why

The TestBuildMCPDeploymentSpec_envAndArgs test was failing because buildMCPDeploymentSpec now appends --auth-type rbac-proxy to the MCP container args, but the test still expected the old 8-element arg list.

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] go test -run TestBuildMCPDeploymentSpec_envAndArgs ./controllers/evalhub/ passes

## Breaking changes

None.