### PR TITLE
feat(evalhub): inject discovery ConfigMap into tenant namespaces for service URL resolution

### DIFF
--- a/controllers/evalhub/constants.go
+++ b/controllers/evalhub/constants.go
@@ -98,6 +98,12 @@ const (
 	mcpServiceCAVolumeName = "mcp-service-ca"
 	mcpServiceCAMountPath  = "/etc/evalhub-mcp/ca"
 
+	// Discovery ConfigMap injected into every tenant namespace for EvalHub service URL resolution.
+	// A single well-known CM is shared across all EvalHub instances; each instance owns one
+	// key of the form "{instanceName}.url" so multiple EvalHub instances can coexist.
+	discoveryConfigMapName  = "evalhub-discovery"
+	discoveryConfigMapLabel = "evalhub.trustyai.opendatahub.io/discovery"
+
 	// Collection ConfigMap configuration
 	collectionLabel       = "trustyai.opendatahub.io/evalhub-collection-type"
 	collectionNameLabel   = "trustyai.opendatahub.io/evalhub-collection-name"

--- a/controllers/evalhub/tenant_namespaces.go
+++ b/controllers/evalhub/tenant_namespaces.go
@@ -2,6 +2,7 @@ package evalhub
 
 import (
 	"context"
+	"fmt"
 
 	evalhubv1 "github.com/trustyai-explainability/trustyai-service-operator/api/evalhub/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -83,6 +84,13 @@ func (r *EvalHubReconciler) reconcileTenantNamespaces(ctx context.Context, insta
 			log.Error(err, "Failed to create service CA ConfigMap in tenant namespace", "namespace", ns)
 			return err
 		}
+
+		// Inject this instance's service URL into the shared discovery ConfigMap so clients
+		// can resolve it from within the tenant namespace without cross-namespace lookups.
+		if err := r.reconcileDiscoveryConfigMap(ctx, instance, ns); err != nil {
+			log.Error(err, "Failed to reconcile discovery ConfigMap in tenant namespace", "namespace", ns)
+			return err
+		}
 	}
 
 	// Clean up resources from namespaces that lost the tenant label.
@@ -90,6 +98,13 @@ func (r *EvalHubReconciler) reconcileTenantNamespaces(ctx context.Context, insta
 	// and remove those that are no longer active tenants.
 	if err := r.cleanupStaleTenantResources(ctx, instance, activeTenants); err != nil {
 		log.Error(err, "Failed to clean up stale tenant resources")
+		return err
+	}
+
+	// Remove this instance's URL key from discovery ConfigMaps in namespaces that
+	// are no longer active tenants. Deletes the CM if it becomes empty.
+	if err := r.cleanupDiscoveryConfigMaps(ctx, instance, activeTenants); err != nil {
+		log.Error(err, "Failed to clean up discovery ConfigMaps")
 		return err
 	}
 
@@ -210,4 +225,76 @@ func (r *EvalHubReconciler) createTenantServiceCAConfigMap(ctx context.Context, 
 	}
 	log.Info("Creating service CA ConfigMap in tenant namespace", "namespace", namespace, "name", cmName)
 	return r.Create(ctx, cm)
+}
+
+// reconcileDiscoveryConfigMap upserts the well-known "evalhub-discovery" ConfigMap in
+// namespace, setting a key "{instance.Name}.url" to the service URL of this instance.
+// Multiple EvalHub instances share the same ConfigMap; each owns exactly one key.
+func (r *EvalHubReconciler) reconcileDiscoveryConfigMap(ctx context.Context, instance *evalhubv1.EvalHub, namespace string) error {
+	log := log.FromContext(ctx)
+	serviceURL := fmt.Sprintf("https://%s.%s.svc.cluster.local:%d",
+		instance.Name, instance.Namespace, servicePort)
+	urlKey := instance.Name + ".url"
+
+	cm := &corev1.ConfigMap{}
+	err := r.Get(ctx, client.ObjectKey{Name: discoveryConfigMapName, Namespace: namespace}, cm)
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	if errors.IsNotFound(err) {
+		cm = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      discoveryConfigMapName,
+				Namespace: namespace,
+				Labels:    map[string]string{discoveryConfigMapLabel: "true"},
+			},
+			Data: map[string]string{urlKey: serviceURL},
+		}
+		log.Info("Creating discovery ConfigMap in tenant namespace", "namespace", namespace)
+		return r.Create(ctx, cm)
+	}
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
+	if cm.Data[urlKey] != serviceURL {
+		cm.Data[urlKey] = serviceURL
+		return r.Update(ctx, cm)
+	}
+	return nil
+}
+
+// cleanupDiscoveryConfigMaps removes the "{instance.Name}.url" key from the discovery
+// ConfigMap in any namespace that is no longer an active tenant. If the removal empties
+// the ConfigMap it is deleted entirely.
+func (r *EvalHubReconciler) cleanupDiscoveryConfigMaps(ctx context.Context, instance *evalhubv1.EvalHub, activeTenants map[string]bool) error {
+	log := log.FromContext(ctx)
+	urlKey := instance.Name + ".url"
+
+	cmList := &corev1.ConfigMapList{}
+	if err := r.List(ctx, cmList, client.MatchingLabels{discoveryConfigMapLabel: "true"}); err != nil {
+		return err
+	}
+	for i := range cmList.Items {
+		cm := &cmList.Items[i]
+		ns := cm.Namespace
+		if ns == instance.Namespace || activeTenants[ns] {
+			continue
+		}
+		if _, hasKey := cm.Data[urlKey]; !hasKey {
+			continue
+		}
+		delete(cm.Data, urlKey)
+		if len(cm.Data) == 0 {
+			log.Info("Deleting empty discovery ConfigMap", "namespace", ns)
+			if err := r.Delete(ctx, cm); err != nil && !errors.IsNotFound(err) {
+				return err
+			}
+		} else {
+			log.Info("Removing stale URL key from discovery ConfigMap", "namespace", ns, "key", urlKey)
+			if err := r.Update(ctx, cm); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }

--- a/controllers/evalhub/unit_test.go
+++ b/controllers/evalhub/unit_test.go
@@ -2100,6 +2100,194 @@ func TestEvalHubReconciler_reconcileServiceMonitor_NoOpUpdate(t *testing.T) {
 		"reconcileServiceMonitor should not update when spec is unchanged")
 }
 
+func TestEvalHubReconciler_reconcileDiscoveryConfigMap(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, evalhubv1.AddToScheme(scheme))
+
+	ctx := context.Background()
+	instanceNamespace := "opendatahub"
+	tenantNamespace := "team-a"
+	evalHubName := "evalhub"
+
+	evalHub := &evalhubv1.EvalHub{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      evalHubName,
+			Namespace: instanceNamespace,
+			UID:       "test-uid-789",
+		},
+	}
+
+	expectedURL := "https://evalhub.opendatahub.svc.cluster.local:8443"
+	urlKey := evalHubName + ".url"
+
+	t.Run("should create discovery ConfigMap in tenant namespace", func(t *testing.T) {
+		tenantNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: tenantNamespace}}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(evalHub, tenantNS).Build()
+		reconciler := &EvalHubReconciler{Client: fakeClient, Scheme: scheme, EventRecorder: record.NewFakeRecorder(10)}
+
+		err := reconciler.reconcileDiscoveryConfigMap(ctx, evalHub, tenantNamespace)
+		require.NoError(t, err)
+
+		cm := &corev1.ConfigMap{}
+		err = fakeClient.Get(ctx, types.NamespacedName{Name: discoveryConfigMapName, Namespace: tenantNamespace}, cm)
+		require.NoError(t, err)
+
+		assert.Equal(t, discoveryConfigMapName, cm.Name)
+		assert.Equal(t, tenantNamespace, cm.Namespace)
+		assert.Equal(t, expectedURL, cm.Data[urlKey])
+		assert.Equal(t, "true", cm.Labels[discoveryConfigMapLabel])
+	})
+
+	t.Run("should update URL key when service URL drifts", func(t *testing.T) {
+		// Pre-existing CM with stale URL
+		existingCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      discoveryConfigMapName,
+				Namespace: tenantNamespace,
+				Labels:    map[string]string{discoveryConfigMapLabel: "true"},
+			},
+			Data: map[string]string{urlKey: "https://old-url.example.com:9999"},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(evalHub, existingCM).Build()
+		reconciler := &EvalHubReconciler{Client: fakeClient, Scheme: scheme, EventRecorder: record.NewFakeRecorder(10)}
+
+		err := reconciler.reconcileDiscoveryConfigMap(ctx, evalHub, tenantNamespace)
+		require.NoError(t, err)
+
+		cm := &corev1.ConfigMap{}
+		require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: discoveryConfigMapName, Namespace: tenantNamespace}, cm))
+		assert.Equal(t, expectedURL, cm.Data[urlKey])
+	})
+
+	t.Run("should add key to existing CM without removing other instance keys", func(t *testing.T) {
+		otherKey := "other-evalhub.url"
+		otherURL := "https://other-evalhub.other-ns.svc.cluster.local:8443"
+		existingCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      discoveryConfigMapName,
+				Namespace: tenantNamespace,
+				Labels:    map[string]string{discoveryConfigMapLabel: "true"},
+			},
+			Data: map[string]string{otherKey: otherURL},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(evalHub, existingCM).Build()
+		reconciler := &EvalHubReconciler{Client: fakeClient, Scheme: scheme, EventRecorder: record.NewFakeRecorder(10)}
+
+		err := reconciler.reconcileDiscoveryConfigMap(ctx, evalHub, tenantNamespace)
+		require.NoError(t, err)
+
+		cm := &corev1.ConfigMap{}
+		require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: discoveryConfigMapName, Namespace: tenantNamespace}, cm))
+		assert.Equal(t, expectedURL, cm.Data[urlKey], "own key must be present")
+		assert.Equal(t, otherURL, cm.Data[otherKey], "other instance key must be preserved")
+	})
+
+	t.Run("should be idempotent when URL is unchanged", func(t *testing.T) {
+		existingCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            discoveryConfigMapName,
+				Namespace:       tenantNamespace,
+				Labels:          map[string]string{discoveryConfigMapLabel: "true"},
+				ResourceVersion: "1",
+			},
+			Data: map[string]string{urlKey: expectedURL},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(evalHub, existingCM).Build()
+		reconciler := &EvalHubReconciler{Client: fakeClient, Scheme: scheme, EventRecorder: record.NewFakeRecorder(10)}
+
+		// Call twice — second call must not trigger an Update
+		require.NoError(t, reconciler.reconcileDiscoveryConfigMap(ctx, evalHub, tenantNamespace))
+		require.NoError(t, reconciler.reconcileDiscoveryConfigMap(ctx, evalHub, tenantNamespace))
+
+		cm := &corev1.ConfigMap{}
+		require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: discoveryConfigMapName, Namespace: tenantNamespace}, cm))
+		assert.Equal(t, expectedURL, cm.Data[urlKey])
+	})
+}
+
+func TestEvalHubReconciler_cleanupDiscoveryConfigMaps(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, evalhubv1.AddToScheme(scheme))
+
+	ctx := context.Background()
+	instanceNamespace := "opendatahub"
+	evalHubName := "evalhub"
+	urlKey := evalHubName + ".url"
+
+	evalHub := &evalhubv1.EvalHub{
+		ObjectMeta: metav1.ObjectMeta{Name: evalHubName, Namespace: instanceNamespace},
+	}
+
+	t.Run("should delete discovery CM when it becomes empty", func(t *testing.T) {
+		// namespace "former-tenant" is NOT in activeTenants
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      discoveryConfigMapName,
+				Namespace: "former-tenant",
+				Labels:    map[string]string{discoveryConfigMapLabel: "true"},
+			},
+			Data: map[string]string{urlKey: "https://evalhub.opendatahub.svc.cluster.local:8443"},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(evalHub, cm).Build()
+		reconciler := &EvalHubReconciler{Client: fakeClient, Scheme: scheme, EventRecorder: record.NewFakeRecorder(10)}
+
+		err := reconciler.cleanupDiscoveryConfigMaps(ctx, evalHub, map[string]bool{})
+		require.NoError(t, err)
+
+		deleted := &corev1.ConfigMap{}
+		err = fakeClient.Get(ctx, types.NamespacedName{Name: discoveryConfigMapName, Namespace: "former-tenant"}, deleted)
+		assert.True(t, errors.IsNotFound(err), "CM should be deleted when it becomes empty")
+	})
+
+	t.Run("should remove only own key when other instance keys exist", func(t *testing.T) {
+		otherKey := "other-evalhub.url"
+		otherURL := "https://other-evalhub.other-ns.svc.cluster.local:8443"
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      discoveryConfigMapName,
+				Namespace: "former-tenant",
+				Labels:    map[string]string{discoveryConfigMapLabel: "true"},
+			},
+			Data: map[string]string{
+				urlKey:   "https://evalhub.opendatahub.svc.cluster.local:8443",
+				otherKey: otherURL,
+			},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(evalHub, cm).Build()
+		reconciler := &EvalHubReconciler{Client: fakeClient, Scheme: scheme, EventRecorder: record.NewFakeRecorder(10)}
+
+		err := reconciler.cleanupDiscoveryConfigMaps(ctx, evalHub, map[string]bool{})
+		require.NoError(t, err)
+
+		remaining := &corev1.ConfigMap{}
+		require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: discoveryConfigMapName, Namespace: "former-tenant"}, remaining))
+		assert.NotContains(t, remaining.Data, urlKey, "own key must be removed")
+		assert.Equal(t, otherURL, remaining.Data[otherKey], "other instance key must survive")
+	})
+
+	t.Run("should not touch CM in active tenant namespaces", func(t *testing.T) {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      discoveryConfigMapName,
+				Namespace: "active-tenant",
+				Labels:    map[string]string{discoveryConfigMapLabel: "true"},
+			},
+			Data: map[string]string{urlKey: "https://evalhub.opendatahub.svc.cluster.local:8443"},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(evalHub, cm).Build()
+		reconciler := &EvalHubReconciler{Client: fakeClient, Scheme: scheme, EventRecorder: record.NewFakeRecorder(10)}
+
+		err := reconciler.cleanupDiscoveryConfigMaps(ctx, evalHub, map[string]bool{"active-tenant": true})
+		require.NoError(t, err)
+
+		still := &corev1.ConfigMap{}
+		require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: discoveryConfigMapName, Namespace: "active-tenant"}, still))
+		assert.Equal(t, "https://evalhub.opendatahub.svc.cluster.local:8443", still.Data[urlKey])
+	})
+}
+
 func TestGenerateMCPAuthConfigData_MethodsPresent(t *testing.T) {
 	instance := &evalhubv1.EvalHub{
 		ObjectMeta: metav1.ObjectMeta{Name: "eh", Namespace: "team-a"},


### PR DESCRIPTION
## What and why

Adds a well-known `evalhub-discovery` ConfigMap that is injected into every tenant namespace during reconciliation. The ConfigMap holds one key per EvalHub instance (`{instanceName}.url`) pointing to its in-cluster service URL, so clients in tenant namespaces can resolve the EvalHub endpoint without cross-namespace API lookups.

Multiple EvalHub instances co-exist safely. Each owns exactly one key in the shared ConfigMap. When a namespace loses the tenant label, the instance's key is removed; if that empties the ConfigMap, it is deleted.

Closes [RHOAIENG-68253](https://redhat.atlassian.net/browse/RHOAIENG-68253)

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

Unit tests cover:
- ConfigMap creation in a new tenant namespace
- URL drift detection and update
- Multi-instance key coexistence (own key added, other keys preserved)
- Idempotency (no spurious updates when URL is unchanged)
- Cleanup: CM deleted when it becomes empty, only own key removed when others remain, active-tenant CMs left untouched

## Breaking changes

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * EvalHub instances now automatically register and discover each other's service URLs within tenant namespaces
  * Service location information is automatically maintained and cleaned up to remove stale entries, ensuring accurate routing

* **Tests**
  * Added comprehensive unit tests for service discovery and cleanup functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->