### PR TITLE
feat(evalhub): add dedicated metrics Service and update ServiceMonitor

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -58,6 +58,7 @@ flowchart TB
 
     subgraph evalhub_pod["EvalHub Pod(s)"]
         evalhub_svc["EvalHub Service\n(REST API, job management)"]
+        evalhub_metrics["Metrics server\n(port 9090, plain HTTP)"]
     end
 
     subgraph gorch_pod["Guardrails Orchestrator Pod(s)"]
@@ -314,7 +315,13 @@ sequenceDiagram
     EH->>InstanceNS: Copy matched ConfigMaps
 
     EH->>K8sAPI: Create Deployment (mount providers + collections)
-    EH->>K8sAPI: Create Service + Route
+    EH->>K8sAPI: Create API Service (port 8443, HTTPS via kube-rbac-proxy)
+    EH->>K8sAPI: Create metrics Service (port 9090, plain HTTP, cluster-internal)
+    EH->>K8sAPI: Create Route
+
+    opt ServiceMonitor CRD available
+        EH->>K8sAPI: Create ServiceMonitor (targets metrics Service, HTTP, no TLS)
+    end
 
     EHPod->>EHPod: Load providers from /providers/
     EHPod->>EHPod: Load collections from /collections/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,15 @@ All controllers follow the standard loop:
 - Events via `recorder.Event(instance, EventType, reason, message)`
 - Sub-reconcilers (TAS pattern): separate functions with signature `func(ctx, req, instance) (*Result, error)`
 
+### EvalHub Metrics Architecture
+
+EvalHub exposes Prometheus metrics on a **dedicated port (9090)** bound to `0.0.0.0`, separate from the API (port 8444, loopback only, behind kube-rbac-proxy on 8443). The operator creates:
+
+- A **metrics Service** (`<name>-metrics`, ClusterIP, port 9090, no TLS) — `metrics_service.go`
+- A **ServiceMonitor** targeting the metrics Service over plain HTTP — `servicemonitor.go`
+
+The metrics port requires no authentication, is cluster-internal only (no Route), and is reachable by Prometheus via existing namespace NetworkPolicies. The `METRICS_PORT` and `METRICS_HOST` env vars are set on the EvalHub container and protected from CR overrides.
+
 ### Scheme Registration (cmd/main.go init())
 
 Registers all API groups in order:

--- a/controllers/evalhub/constants.go
+++ b/controllers/evalhub/constants.go
@@ -25,6 +25,9 @@ const (
 
 	// Service configuration (public HTTPS targets kube-rbac-proxy on this port)
 	servicePort = 8443
+	// metricsPort is the dedicated Prometheus metrics port on the EvalHub container.
+	// Bound to 0.0.0.0, serves /metrics over plain HTTP with no auth (cluster-internal only).
+	metricsPort = 9090
 
 	// kube-rbac-proxy sidecar
 	kubeRBACProxyContainerName       = "kube-rbac-proxy"

--- a/controllers/evalhub/deployment.go
+++ b/controllers/evalhub/deployment.go
@@ -131,11 +131,20 @@ func (r *EvalHubReconciler) buildDeploymentSpec(ctx context.Context, instance *e
 			Name:  "MLFLOW_TOKEN_PATH",
 			Value: mlflowTokenMountPath + "/" + mlflowTokenFile,
 		},
+		{
+			Name:  "METRICS_PORT",
+			Value: fmt.Sprintf("%d", metricsPort),
+		},
+		{
+			Name:  "METRICS_HOST",
+			Value: "0.0.0.0",
+		},
 	}
 
 	// Merge environment variables with CR values taking precedence.
 	// API_HOST and PORT are fixed for the loopback HTTP listener; TLS is terminated by kube-rbac-proxy only.
-	env := mergeEnvVars(defaultEnvVars, instance.Spec.Env, "API_HOST", "PORT", "TLS_CERT_FILE", "TLS_KEY_FILE")
+	// METRICS_PORT and METRICS_HOST are fixed for the dedicated Prometheus metrics server.
+	env := mergeEnvVars(defaultEnvVars, instance.Spec.Env, "API_HOST", "PORT", "TLS_CERT_FILE", "TLS_KEY_FILE", "METRICS_PORT", "METRICS_HOST")
 
 	// Build volume mounts for the evalhub container
 	volumeMounts := []corev1.VolumeMount{
@@ -185,6 +194,11 @@ func (r *EvalHubReconciler) buildDeploymentSpec(ctx context.Context, instance *e
 			{
 				Name:          "evalhub",
 				ContainerPort: evalHubAppPort,
+				Protocol:      corev1.ProtocolTCP,
+			},
+			{
+				Name:          "metrics",
+				ContainerPort: metricsPort,
 				Protocol:      corev1.ProtocolTCP,
 			},
 		},

--- a/controllers/evalhub/evalhub_controller.go
+++ b/controllers/evalhub/evalhub_controller.go
@@ -220,6 +220,14 @@ func (r *EvalHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return RequeueWithError(err)
 	}
 
+	// Reconcile metrics Service (dedicated ClusterIP for Prometheus scraping on metricsPort)
+	if err := r.reconcileMetricsService(ctx, instance); err != nil {
+		log.Error(err, "Failed to reconcile metrics Service")
+		instance.SetStatus("Ready", "Error", fmt.Sprintf("Failed to reconcile metrics Service: %v", err), corev1.ConditionFalse)
+		r.Status().Update(ctx, instance)
+		return RequeueWithError(err)
+	}
+
 	// Reconcile monitoring resources (ServiceMonitor).
 	// Monitoring failures are non-fatal: log, set a degraded condition, and continue.
 	// The condition is set in memory only — updateStatus() at the end of the loop

--- a/controllers/evalhub/metrics_service.go
+++ b/controllers/evalhub/metrics_service.go
@@ -1,0 +1,81 @@
+package evalhub
+
+import (
+	"context"
+
+	evalhubv1 "github.com/trustyai-explainability/trustyai-service-operator/api/evalhub/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func metricsServiceName(instance *evalhubv1.EvalHub) string {
+	return instance.Name + "-metrics"
+}
+
+func metricsServiceLabels(instance *evalhubv1.EvalHub) map[string]string {
+	return map[string]string{
+		"app":       "eval-hub",
+		"instance":  instance.Name,
+		"component": "metrics",
+	}
+}
+
+func (r *EvalHubReconciler) reconcileMetricsService(ctx context.Context, instance *evalhubv1.EvalHub) error {
+	log := log.FromContext(ctx)
+	name := metricsServiceName(instance)
+	log.Info("Reconciling metrics Service", "name", name)
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: instance.Namespace,
+		},
+	}
+
+	getErr := r.Get(ctx, client.ObjectKeyFromObject(service), service)
+	if getErr != nil && !errors.IsNotFound(getErr) {
+		return getErr
+	}
+
+	desiredSpec := r.buildMetricsServiceSpec(instance)
+
+	if errors.IsNotFound(getErr) {
+		service.Spec = desiredSpec
+		service.Labels = metricsServiceLabels(instance)
+		if err := controllerutil.SetControllerReference(instance, service, r.Scheme); err != nil {
+			return err
+		}
+		log.Info("Creating metrics Service", "name", name)
+		return r.Create(ctx, service)
+	}
+
+	service.Spec.Ports = desiredSpec.Ports
+	service.Spec.Selector = desiredSpec.Selector
+	service.Spec.Type = desiredSpec.Type
+	log.Info("Updating metrics Service", "name", name)
+	return r.Update(ctx, service)
+}
+
+func (r *EvalHubReconciler) buildMetricsServiceSpec(instance *evalhubv1.EvalHub) corev1.ServiceSpec {
+	return corev1.ServiceSpec{
+		Selector: map[string]string{
+			"app":       "eval-hub",
+			"instance":  instance.Name,
+			"component": "api",
+		},
+		Type: corev1.ServiceTypeClusterIP,
+		Ports: []corev1.ServicePort{
+			{
+				Name:       "metrics",
+				Port:       metricsPort,
+				TargetPort: intstr.FromString("metrics"),
+				Protocol:   corev1.ProtocolTCP,
+			},
+		},
+	}
+}

--- a/controllers/evalhub/servicemonitor.go
+++ b/controllers/evalhub/servicemonitor.go
@@ -5,7 +5,6 @@ import (
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	evalhubv1 "github.com/trustyai-explainability/trustyai-service-operator/api/evalhub/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -37,13 +36,7 @@ func serviceMonitorName(instance *evalhubv1.EvalHub) string {
 }
 
 func (r *EvalHubReconciler) buildServiceMonitor(instance *evalhubv1.EvalHub) *monitoringv1.ServiceMonitor {
-	labels := map[string]string{
-		"app":       "eval-hub",
-		"component": "api",
-		"instance":  instance.Name,
-	}
-
-	serverName := instance.Name + "." + instance.Namespace + ".svc"
+	labels := metricsServiceLabels(instance)
 
 	return &monitoringv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
@@ -57,21 +50,8 @@ func (r *EvalHubReconciler) buildServiceMonitor(instance *evalhubv1.EvalHub) *mo
 					HonorLabels: true,
 					Interval:    scrapeInterval,
 					Path:        metricsPath,
-					Scheme:      "https",
-					Port:        "https",
-					TLSConfig: &monitoringv1.TLSConfig{
-						SafeTLSConfig: monitoringv1.SafeTLSConfig{
-							ServerName: serverName,
-							CA: monitoringv1.SecretOrConfigMap{
-								ConfigMap: &corev1.ConfigMapKeySelector{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: instance.Name + "-service-ca",
-									},
-									Key: serviceCACertFile,
-								},
-							},
-						},
-					},
+					Scheme:      "http",
+					Port:        "metrics",
 				},
 			},
 			Selector: metav1.LabelSelector{


### PR DESCRIPTION
## Summary

Adds operator-side support for [RHAISTRAT-1507](https://redhat.atlassian.net/browse/RHAISTRAT-1507): EvalHub metrics must be automatically discoverable by the OpenShift platform monitoring stack.

The EvalHub application now serves `/metrics` on a dedicated port (9090) over plain HTTP, separate from the API (behind kube-rbac-proxy on 8443). This PR creates the Kubernetes resources needed to make that port discoverable by Prometheus.

Ref: [RHAISTRAT-1507](https://redhat.atlassian.net/browse/RHAISTRAT-1507)

## Changes

- **`controllers/evalhub/constants.go`** — Added `metricsPort = 9090` constant
- **`controllers/evalhub/deployment.go`** — Added `metrics` container port (9090) to EvalHub container, `METRICS_PORT`/`METRICS_HOST` env vars, and protected both from CR overrides
- **`controllers/evalhub/metrics_service.go`** — New file: dedicated ClusterIP Service (`<name>-metrics`) on port 9090, no TLS annotation, with owner reference for GC
- **`controllers/evalhub/servicemonitor.go`** — Updated ServiceMonitor to scrape the metrics Service over plain HTTP (`port: metrics`, `scheme: http`), removed TLS config
- **`controllers/evalhub/evalhub_controller.go`** — Added `reconcileMetricsService()` to the reconciliation loop after the API Service
- **`ARCHITECTURE.md`** — Updated EvalHub pod diagram and reconciliation sequence
- **`CLAUDE.md`** — Added EvalHub Metrics Architecture section

## Kubernetes resources created

| Resource | Name | Purpose |
|----------|------|---------|
| Service (ClusterIP) | `<name>-metrics` | Exposes pod port 9090 for cluster-internal Prometheus scraping |
| ServiceMonitor | `<name>-metrics` | Declares scrape target: HTTP, port `metrics`, `/metrics` path, 30s interval |

## What does NOT change

- The API Service (port 8443, HTTPS, TLS annotation) is unchanged
- No new CRD fields — metrics port is fixed at 9090
- The Route continues targeting the HTTPS API service
- No new NetworkPolicy required — existing namespace policies allow Prometheus ingress
- kube-rbac-proxy configuration is untouched

## Test plan

- [ ] `go test ./controllers/evalhub/...` — unit tests pass
- [ ] `make test` — all operator tests pass
- [ ] Deploy to cluster and verify:
  - `oc get svc` shows both `<name>` (8443) and `<name>-metrics` (9090) services
  - `oc get servicemonitor` shows the monitor targeting port `metrics` with scheme `http`
  - **Observe > Targets** in OpenShift console shows EvalHub target as UP
  - `up{job="<name>-metrics"}` returns `1` in **Observe > Metrics**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prometheus metrics now exposed on dedicated port 9090 with dedicated metrics service for scraping.
  * Metrics configured through METRICS_PORT and METRICS_HOST environment variables.
  * Automatic ServiceMonitor creation for Prometheus scraping when available.

* **Documentation**
  * Updated architecture diagrams and documentation describing metrics exposure architecture and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->