### PR TITLE
fix(evalhub): update deployment tests to expect metrics port

### DIFF
--- a/controllers/evalhub/build_test.go
+++ b/controllers/evalhub/build_test.go
@@ -114,10 +114,13 @@ var _ = Describe("buildDeploymentSpec", func() {
 		Expect(container.Image).To(Equal("quay.io/test/eval-hub:v1.2.3"))
 		Expect(container.ImagePullPolicy).To(Equal(corev1.PullAlways))
 
-		Expect(container.Ports).To(HaveLen(1))
+		Expect(container.Ports).To(HaveLen(2))
 		Expect(container.Ports[0].Name).To(Equal("evalhub"))
 		Expect(container.Ports[0].ContainerPort).To(Equal(int32(evalHubAppPort)))
 		Expect(container.Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
+		Expect(container.Ports[1].Name).To(Equal("metrics"))
+		Expect(container.Ports[1].ContainerPort).To(Equal(int32(metricsPort)))
+		Expect(container.Ports[1].Protocol).To(Equal(corev1.ProtocolTCP))
 
 		envVarMap := make(map[string]string)
 		for _, env := range container.Env {

--- a/controllers/evalhub/deployment_test.go
+++ b/controllers/evalhub/deployment_test.go
@@ -129,11 +129,14 @@ var _ = Describe("EvalHub Deployment", func() {
 			Expect(evalHubContainer.Image).To(Equal("quay.io/ruimvieira/eval-hub:test")) // From test configmap
 			Expect(evalHubContainer.ImagePullPolicy).To(Equal(corev1.PullAlways))
 
-			// Check ports (loopback app port; Service targets kube-rbac-proxy on 8443)
-			Expect(evalHubContainer.Ports).To(HaveLen(1))
+			// Check ports (loopback app port + metrics port; Service targets kube-rbac-proxy on 8443)
+			Expect(evalHubContainer.Ports).To(HaveLen(2))
 			Expect(evalHubContainer.Ports[0].Name).To(Equal("evalhub"))
 			Expect(evalHubContainer.Ports[0].ContainerPort).To(Equal(int32(evalHubAppPort)))
 			Expect(evalHubContainer.Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
+			Expect(evalHubContainer.Ports[1].Name).To(Equal("metrics"))
+			Expect(evalHubContainer.Ports[1].ContainerPort).To(Equal(int32(metricsPort)))
+			Expect(evalHubContainer.Ports[1].Protocol).To(Equal(corev1.ProtocolTCP))
 
 			var krp *corev1.Container
 			for i := range deployment.Spec.Template.Spec.Containers {
@@ -619,9 +622,11 @@ var _ = Describe("EvalHubReconciler reconcileDeployment", func() {
 
 		Expect(evalHubC.Image).To(Equal("quay.io/test/eval-hub:latest"))
 		Expect(evalHubC.ImagePullPolicy).To(Equal(corev1.PullAlways))
-		Expect(evalHubC.Ports).To(HaveLen(1))
+		Expect(evalHubC.Ports).To(HaveLen(2))
 		Expect(evalHubC.Ports[0].Name).To(Equal("evalhub"))
 		Expect(evalHubC.Ports[0].ContainerPort).To(Equal(int32(evalHubAppPort)))
+		Expect(evalHubC.Ports[1].Name).To(Equal("metrics"))
+		Expect(evalHubC.Ports[1].ContainerPort).To(Equal(int32(metricsPort)))
 
 		envs := map[string]string{}
 		for _, e := range evalHubC.Env {


### PR DESCRIPTION
## What and why

The EvalHub container now exposes two ports — `evalhub:8444` (loopback API) and `metrics:9090` (Prometheus), but three deployment tests still asserted `HaveLen(1)` on the container's port list, causing CI to fail.

Updates the port assertions in `build_test.go` and `deployment_test.go` to expect both ports.

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

## Breaking changes

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * EvalHub now exposes a metrics port in addition to its main application port, enabling metrics collection and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->