### PR TITLE
feat: SA enhancements for hardware profile

### DIFF
--- a/config/components/evalhub/kustomization.yaml
+++ b/config/components/evalhub/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - rbac/evalhub_auth_reviewer_role.yaml
   - rbac/evalhub_collections_access_binding.yaml
   - rbac/evalhub_collections_access_role.yaml
+  - rbac/evalhub_hardware_profiles_reader_role.yaml
   - rbac/evalhub_job_config_binding.yaml
   - rbac/evalhub_job_config_role.yaml
   - rbac/evalhub_jobs_writer_binding.yaml

--- a/config/components/evalhub/rbac/evalhub_hardware_profiles_reader_role.yaml
+++ b/config/components/evalhub/rbac/evalhub_hardware_profiles_reader_role.yaml
@@ -1,0 +1,14 @@
+---
+# ClusterRole for EvalHub API service account to read HardwareProfile CRs
+# in tenant namespaces. Bound per-tenant via RoleBindings created by the operator.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: evalhub-hardware-profiles-reader
+  labels:
+    app.kubernetes.io/name: trustyai-service-operator
+    app.kubernetes.io/component: evalhub
+rules:
+  - apiGroups: ["infrastructure.opendatahub.io"]
+    resources: ["hardwareprofiles"]
+    verbs: ["get", "list"]

--- a/controllers/evalhub/proxy_rbac_test.go
+++ b/controllers/evalhub/proxy_rbac_test.go
@@ -292,6 +292,18 @@ var _ = Describe("EvalHub API RBAC", func() {
 			Expect(jcRB.Subjects).To(HaveLen(1))
 			Expect(jcRB.Subjects[0].Name).To(Equal(evalHubName + "-service"))
 
+			By("Verifying hardware-profiles-reader RoleBinding exists")
+			hpRB := &rbacv1.RoleBinding{}
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      evalHubName + "-hardware-profiles-reader-rb",
+				Namespace: testNamespace,
+			}, hpRB)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hpRB.RoleRef.Kind).To(Equal("ClusterRole"))
+			Expect(hpRB.RoleRef.Name).To(Equal(hardwareProfilesReaderClusterRoleName))
+			Expect(hpRB.Subjects).To(HaveLen(1))
+			Expect(hpRB.Subjects[0].Name).To(Equal(evalHubName + "-service"))
+
 			By("Verifying providers-access RoleBinding exists")
 			pRB := &rbacv1.RoleBinding{}
 			err = k8sClient.Get(ctx, types.NamespacedName{

--- a/controllers/evalhub/rbac_manifests_test.go
+++ b/controllers/evalhub/rbac_manifests_test.go
@@ -11,6 +11,55 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+func TestEvalHubHardwareProfilesReaderClusterRoleVerbsAreMinimalAndSufficient(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+
+	moduleRoot := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+	manifestPath := filepath.Join(moduleRoot, "config", "components", "evalhub", "rbac", "evalhub_hardware_profiles_reader_role.yaml")
+
+	raw, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", manifestPath, err)
+	}
+
+	var cr rbacv1.ClusterRole
+	if err := yaml.Unmarshal(raw, &cr); err != nil {
+		t.Fatalf("unmarshal %s: %v", manifestPath, err)
+	}
+
+	var gotVerbs []string
+	for _, rule := range cr.Rules {
+		for _, res := range rule.Resources {
+			if res == "hardwareprofiles" {
+				gotVerbs = append([]string(nil), rule.Verbs...)
+				break
+			}
+		}
+		if len(gotVerbs) > 0 {
+			break
+		}
+	}
+	if len(gotVerbs) == 0 {
+		t.Fatalf("expected %s to contain a policy rule for resource 'hardwareprofiles'", manifestPath)
+	}
+
+	wantVerbs := []string{"get", "list"}
+	sort.Strings(gotVerbs)
+	sort.Strings(wantVerbs)
+
+	if len(gotVerbs) != len(wantVerbs) {
+		t.Fatalf("unexpected verbs for hardwareprofiles: got=%v want=%v", gotVerbs, wantVerbs)
+	}
+	for i := range wantVerbs {
+		if gotVerbs[i] != wantVerbs[i] {
+			t.Fatalf("unexpected verbs for hardwareprofiles: got=%v want=%v", gotVerbs, wantVerbs)
+		}
+	}
+}
+
 func TestEvalHubJobConfigClusterRoleVerbsAreMinimalAndSufficient(t *testing.T) {
 	// EvalHub sets ConfigMap ownerReferences after creating the Job:
 	// it does a Get+Update on the ConfigMap (see eval-hub/internal/runtimes/k8s/k8s_helper.go:SetConfigMapOwner).

--- a/controllers/evalhub/service_accounts.go
+++ b/controllers/evalhub/service_accounts.go
@@ -190,6 +190,11 @@ func (r *EvalHubReconciler) createServiceAccount(ctx context.Context, instance *
 		return err
 	}
 
+	err = r.createHardwareProfilesReaderRoleBinding(ctx, instance, serviceAccountName)
+	if err != nil {
+		return err
+	}
+
 	// Create MLFlow access RoleBinding for service SA only.
 	// The job SA MLFlow binding is created alongside the job SA in createJobsServiceAccount.
 	err = r.createMLFlowAccessRoleBinding(ctx, instance, serviceAccountName, "service", mlflowAccessClusterRoleName)
@@ -228,8 +233,9 @@ const authReviewerClusterRoleName = "trustyai-service-operator-evalhub-auth-revi
 // Split resource-manager ClusterRole names.
 // These replace the monolithic evalhub-resource-manager with function-specific roles.
 const (
-	jobsWriterClusterRoleName = "trustyai-service-operator-evalhub-jobs-writer"
-	jobConfigClusterRoleName  = "trustyai-service-operator-evalhub-job-config"
+	jobsWriterClusterRoleName            = "trustyai-service-operator-evalhub-jobs-writer"
+	jobConfigClusterRoleName             = "trustyai-service-operator-evalhub-job-config"
+	hardwareProfilesReaderClusterRoleName = "trustyai-service-operator-evalhub-hardware-profiles-reader"
 )
 
 // EvalHub API access ClusterRoles for SAR-protected endpoints.
@@ -526,6 +532,17 @@ func (r *EvalHubReconciler) createJobConfigRoleBinding(ctx context.Context, inst
 	return r.createGenericRoleBinding(ctx, instance, instance.Name+"-job-config-rb", serviceAccountName, rbacv1.RoleRef{
 		Kind:     "ClusterRole",
 		Name:     jobConfigClusterRoleName,
+		APIGroup: rbacv1.GroupName,
+	})
+}
+
+// createHardwareProfilesReaderRoleBinding creates a RoleBinding for the API SA to
+// the hardware-profiles-reader ClusterRole (hardwareprofiles get,list) in the
+// instance namespace. Tenant namespaces receive a separate binding via reconcileTenantNamespaces.
+func (r *EvalHubReconciler) createHardwareProfilesReaderRoleBinding(ctx context.Context, instance *evalhubv1.EvalHub, serviceAccountName string) error {
+	return r.createGenericRoleBinding(ctx, instance, instance.Name+"-hardware-profiles-reader-rb", serviceAccountName, rbacv1.RoleRef{
+		Kind:     "ClusterRole",
+		Name:     hardwareProfilesReaderClusterRoleName,
 		APIGroup: rbacv1.GroupName,
 	})
 }

--- a/controllers/evalhub/tenant_namespaces.go
+++ b/controllers/evalhub/tenant_namespaces.go
@@ -78,6 +78,18 @@ func (r *EvalHubReconciler) reconcileTenantNamespaces(ctx context.Context, insta
 			return err
 		}
 
+		// Create hardware-profiles-reader RoleBinding for the API SA in the tenant
+		// namespace so the EvalHub service can list and read HardwareProfile CRs there.
+		hardwareProfilesRBName := normalizeDNS1123LabelValue(instance.Name + "-" + ns + "-hardware-profiles-reader-rb")
+		if err := r.createJobRoleBinding(ctx, instance, hardwareProfilesRBName, serviceAccountName, ns, rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			Name:     hardwareProfilesReaderClusterRoleName,
+			APIGroup: rbacv1.GroupName,
+		}, instance.Namespace); err != nil {
+			log.Error(err, "Failed to create hardware-profiles-reader RoleBinding in tenant namespace", "namespace", ns)
+			return err
+		}
+
 		// Create service CA ConfigMap in the tenant namespace so job pods can
 		// mount the cluster service CA for TLS callbacks to EvalHub.
 		if err := r.createTenantServiceCAConfigMap(ctx, instance, ns); err != nil {

--- a/controllers/evalhub/unit_test.go
+++ b/controllers/evalhub/unit_test.go
@@ -1972,6 +1972,47 @@ func TestEvalHubReconciler_reconcileTenantNamespaces(t *testing.T) {
 		assert.True(t, errors.IsNotFound(err), "stale ConfigMap should be deleted")
 	})
 
+	t.Run("should create hardware-profiles-reader RoleBinding in tenant namespace", func(t *testing.T) {
+		tenantNS := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   tenantNamespace,
+				Labels: map[string]string{tenantLabel: ""},
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(evalHub, tenantNS).
+			Build()
+
+		reconciler := &EvalHubReconciler{
+			Client:        fakeClient,
+			Scheme:        scheme,
+			EventRecorder: record.NewFakeRecorder(10),
+		}
+
+		err := reconciler.reconcileTenantNamespaces(ctx, evalHub)
+		require.NoError(t, err)
+
+		rbName := normalizeDNS1123LabelValue(evalHubName + "-" + tenantNamespace + "-hardware-profiles-reader-rb")
+		rb := &rbacv1.RoleBinding{}
+		err = fakeClient.Get(ctx, types.NamespacedName{
+			Name:      rbName,
+			Namespace: tenantNamespace,
+		}, rb)
+		require.NoError(t, err, "hardware-profiles-reader RoleBinding should exist in tenant namespace")
+
+		assert.Equal(t, "ClusterRole", rb.RoleRef.Kind)
+		assert.Equal(t, hardwareProfilesReaderClusterRoleName, rb.RoleRef.Name)
+		assert.Equal(t, rbacv1.GroupName, rb.RoleRef.APIGroup)
+
+		svcSAName := generateServiceAccountName(evalHub)
+		require.Len(t, rb.Subjects, 1)
+		assert.Equal(t, "ServiceAccount", rb.Subjects[0].Kind)
+		assert.Equal(t, svcSAName, rb.Subjects[0].Name)
+		assert.Equal(t, instanceNamespace, rb.Subjects[0].Namespace)
+	})
+
 	t.Run("should create MLFlow service SA RoleBinding in tenant namespace", func(t *testing.T) {
 		// This is the cross-namespace case: EvalHub runs in instanceNamespace but jobs
 		// run in tenantNamespace. The service SA must be able to create MLFlow experiments


### PR DESCRIPTION
Closes https://redhat.atlassian.net/browse/RHOAIENG-68241

Handles the below scenarios:
1. Evalhub has access to hardware profile CRs created in tenant namespace - fresh namespace (created **after** the changes in this PR are deployed)
2. Evalhub has access to hardware profile CRs created in tenant namespace - existing namespace (created **before** the changes in this PR are deployed)
3. Evalhub has access to hardware profile CRs created in instance namespace (opendatahub). These could be standard profiles created by the cluster admin.
4. EvalHub has access to hardware profile CRs when evalhub and jobs run in the same namespace (single-tenant)

### Tests

⏺ EvalHub Testing Summary

  Deployment

  - Operator: quay.io/rh-ee-nbs/nbs-dev:sagar-trustyai-operator_15jun_1
  - EvalHub: quay.io/rh-ee-nbs/nbs-dev:eval-hub_11jun_2
  - RBAC Added: ClusterRoles for hardwareprofile access and rolebinding management

  ---
  Test Scenarios & Results

  Scenario 1: New Tenant Namespace

  Setup:
  - Created namespace test-api-tenant with evalhub tenant label
  - Created hardware profile: 1-4 CPU, 2-8Gi memory (defaults: 2 CPU, 4Gi)
  - Created eval job via API with hardware_config referencing the profile

  Results: ✅ PASS
  - Job created successfully via API
  - Kubernetes Job & Pod created
  - Hardware profile role binding auto-created: evalhub-test-api-tenant-hardware-profiles-reader-rb
  - Resources applied correctly: Requests: 2 CPU, 4Gi | Limits: 4 CPU, 8Gi

  ---
  Scenario 2: Reconciliation Test

  Setup:
  - Deleted hardware profile role binding in sagar namespace
  - Created new hardware profile: 1-6 CPU, 2-12Gi memory (defaults: 3 CPU, 6Gi)
  - Created eval job via API with hardware_config

  Results: ✅ PASS
  - Job created successfully via API
  - Role binding auto-recreated within 49 seconds (reconciliation worked)
  - Kubernetes Job & Pod created
  - Resources applied correctly: Requests: 3 CPU, 6Gi | Limits: 6 CPU, 12Gi

  ---
  Scenario 3: Cross-Namespace (OpenDataHub)

  Setup:
  - Created hardware profile in opendatahub namespace: 1-2 CPU, 1-4Gi memory (defaults: 1 CPU, 2Gi)
  - Created eval job in sagar namespace via API with hardware_config referencing profile in opendatahub

  Results: ✅ PASS
  - Cross-namespace reference worked
  - Job created in sagar, profile read from opendatahub
  - Kubernetes Job & Pod created
  - Resources applied correctly: Requests: 1 CPU, 2Gi | Limits: 2 CPU, 4Gi

  ---
  Overall Results
  
  3/3 scenarios PASSED (100% success rate)

  All tests confirmed:
  - ✅ Hardware profiles correctly applied to job pods
  - ✅ RBAC auto-provisioning works
  - ✅ Reconciliation restores missing permissions
  - ✅ Cross-namespace hardware profile references work
  - ✅ API correctly handles hardware_config in benchmark specifications


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RBAC (Role-Based Access Control) configuration enabling EvalHub to read and list hardware profiles across tenant namespaces.
  * Service accounts now have appropriate permissions to access hardware profile resources with minimal required privileges (`get` and `list` operations).

* **Tests**
  * Added test coverage to verify hardware profiles reader role bindings are created correctly in tenant namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->