### PR TITLE
feat(ci): add OPA/Conftest manifest policy checks for RBAC allowlist

### DIFF
--- a/.github/workflows/conftest.yaml
+++ b/.github/workflows/conftest.yaml
@@ -1,0 +1,43 @@
+name: Tier 1 - Manifest policy check
+
+on: [push, pull_request]
+
+jobs:
+  conftest-rbac:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install kustomize
+        uses: imranismail/setup-kustomize@v2
+        with:
+          kustomize-version: "5.7.0"
+
+      - name: Install conftest
+        run: |
+          CONFTEST_VERSION=0.46.0
+          curl -sSL "https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz" \
+            | tar -xz -C /usr/local/bin conftest
+
+      - name: Run OPA unit tests
+        run: conftest verify --policy policy/
+
+      - name: Check RBAC policy (all kustomize targets)
+        run: |
+          failed=0
+          for target in \
+            config/base \
+            config/overlays/odh \
+            config/overlays/rhoai \
+            config/overlays/lmes \
+            config/overlays/odh-kueue \
+            config/overlays/testing \
+            config/overlays/dev \
+            config/overlays/evalhub-only \
+            config/overlays/mcp-guardrails; do
+            echo "=== Testing $target ==="
+            if ! kustomize build "$target" | conftest test --policy policy/ --namespace rbac -; then
+              failed=1
+            fi
+          done
+          exit $failed

--- a/.github/workflows/conftest.yaml
+++ b/.github/workflows/conftest.yaml
@@ -6,10 +6,12 @@ jobs:
   conftest-rbac:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install kustomize
-        uses: imranismail/setup-kustomize@v2
+        uses: imranismail/setup-kustomize@2ba527d4d055ab63514ba50a99456fc35684947f # v2
         with:
           kustomize-version: "5.7.0"
 

--- a/.github/workflows/conftest.yaml
+++ b/.github/workflows/conftest.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Install conftest
         run: |
-          CONFTEST_VERSION=0.46.0
+          CONFTEST_VERSION=0.68.2
           curl -sSL "https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz" \
             | tar -xz -C /usr/local/bin conftest
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,7 @@ make generate       # controller-gen object:headerFile="hack/boilerplate.go.txt"
 GitHub Actions in `.github/workflows/`:
 - `controller-tests.yaml` — runs `make test`
 - `lint-yaml.yaml` — yamllint on `config/**/*.yaml`
+- `conftest.yaml` — OPA manifest policy checks against all kustomize overlays
 - `gosec.yaml` — security scanning (SARIF output)
 - `smoke.yaml` — smoke tests
 - `operator-chaos.yml` — shift-left upgrade validation (L1: knowledge model + CRD diff)
@@ -221,3 +222,22 @@ chaos/knowledge/trustyai.yaml   # Knowledge model (operator control plane topolo
 The knowledge model covers the **operator control plane only** — the Deployment, RBAC, ServiceAccount, leader election, and ServiceMonitor. Per-CR workloads (TrustyAIService instances, EvalHub instances, etc.) are dynamic user-created resources and are not modelled.
 
 When modifying CRDs (`api/` types → `make manifests`) or RBAC/manager resources, the workflow automatically validates that no breaking changes are introduced. Update `chaos/knowledge/trustyai.yaml` whenever the operator's own managed resources change (new RBAC roles, renamed resources, etc.).
+
+## Manifest Policies (Conftest/OPA)
+
+OPA/Rego policies in `policy/` are evaluated against rendered kustomize manifests on every push/PR. The CI renders all 9 kustomize entry points (base + 8 overlays) and checks each.
+
+```bash
+make policy-test    # OPA unit tests only
+make policy-check   # Full check against all overlays
+```
+
+**Current policies:**
+- `policy/rbac.rego` — closed allowlist of expected `ClusterRoleBinding` resources. Any CRB not in `expected_crbs` or binding the wrong `ClusterRole` is denied.
+
+**When adding RBAC resources:**
+- If you add a new `ClusterRoleBinding` (e.g. in a component's `rbac/` directory), you must add its post-kustomize name and expected `ClusterRole` to `expected_crbs` in `policy/rbac.rego`.
+- Overlays that apply `namePrefix: trustyai-service-operator-` produce prefixed names; `base` and `evalhub-only` produce un-prefixed names. Both must be allowlisted if applicable.
+- Run `make policy-check` locally before pushing.
+
+See `policy/README.md` for full details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,10 +37,11 @@ Issues are tracked using [Github](https://github.com/trustyai-explainability/tru
 To ensure the contributed code adheres to the project goals, we have set up some automated quality gates:
 
 1. [linters](https://github.com/trustyai-explainability/trustyai-service-operator/actions/workflows/lint-yaml.yaml): Ensure the check for linters is successful.
-2. [smoke tests](https://github.com/trustyai-explainability/trustyai-service-operator/actions/workflows/smoke.yaml): Ensure the operator passes the smoke tests
-3. [unit-tests](https://github.com/trustyai-explainability/trustyai-service-operator/actions/workflows/controller-tests.yaml): Ensure unit tests pass.
-4. [operator-chaos](https://github.com/trustyai-explainability/trustyai-service-operator/actions/workflows/operator-chaos.yml): Ensure no breaking upgrade changes are introduced.
-5. e2e-tests: Ensure OpenShift CI job for e2e tests pass.
+2. [manifest policy check](https://github.com/trustyai-explainability/trustyai-service-operator/actions/workflows/conftest.yaml): Ensure rendered manifests pass all OPA policies (see `policy/README.md`).
+3. [smoke tests](https://github.com/trustyai-explainability/trustyai-service-operator/actions/workflows/smoke.yaml): Ensure the operator passes the smoke tests
+4. [unit-tests](https://github.com/trustyai-explainability/trustyai-service-operator/actions/workflows/controller-tests.yaml): Ensure unit tests pass.
+5. [operator-chaos](https://github.com/trustyai-explainability/trustyai-service-operator/actions/workflows/operator-chaos.yml): Ensure no breaking upgrade changes are introduced.
+6. e2e-tests: Ensure OpenShift CI job for e2e tests pass.
 
 ### Shift-left Upgrade Validation (operator-chaos)
 
@@ -64,6 +65,26 @@ The knowledge model at `chaos/knowledge/trustyai.yaml` describes the operator's 
 go install github.com/opendatahub-io/operator-chaos/cmd/operator-chaos@9e6ac9668b9aaca2f0f2ddf169867862b7925b80
 operator-chaos validate --knowledge chaos/knowledge/trustyai.yaml
 operator-chaos preflight --knowledge chaos/knowledge/trustyai.yaml --local
+```
+
+### Manifest Policies (Conftest/OPA)
+
+Rendered kustomize manifests are checked against [OPA/Rego](https://www.openpolicyagent.org/) policies in `policy/` using [Conftest](https://www.conftest.dev/). The CI workflow tests **all** kustomize entry points (base + every overlay).
+
+**Current policies:**
+- **RBAC allowlist** (`policy/rbac.rego`): a closed allowlist of expected `ClusterRoleBinding` resources. Any new or unexpected CRB will fail CI.
+
+**If your PR introduces a new `ClusterRoleBinding`:**
+1. Add the post-kustomize CRB name and its expected `ClusterRole` to `expected_crbs` in `policy/rbac.rego`.
+2. Run `make policy-check` locally to verify.
+3. Explain in the PR description why a `ClusterRoleBinding` is required rather than a namespace-scoped `RoleBinding`.
+
+See `policy/README.md` for full details on running and extending policies.
+
+```bash
+# Run locally
+make policy-test    # OPA unit tests
+make policy-check   # Full check against all overlays
 ```
 
 ### Code Style Guidelines

--- a/Makefile
+++ b/Makefile
@@ -141,10 +141,15 @@ CONFTEST_VERSION ?= 0.68.2
 
 .PHONY: conftest
 conftest: $(CONFTEST)
+CONFTEST_CHECKSUM ?= e8144c6d6d2ae0260b869caa60c7c262a1f95ac63ec1e5d2fb19be452d606347
 $(CONFTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/conftest || curl -sSL \
-	  "https://github.com/open-policy-agent/conftest/releases/download/v$(CONFTEST_VERSION)/conftest_$(CONFTEST_VERSION)_Linux_x86_64.tar.gz" \
-	  | tar -xz -C $(LOCALBIN) conftest
+	@test -s $(LOCALBIN)/conftest || { \
+	  curl -sSL -o $(LOCALBIN)/conftest.tar.gz \
+	    "https://github.com/open-policy-agent/conftest/releases/download/v$(CONFTEST_VERSION)/conftest_$(CONFTEST_VERSION)_Linux_x86_64.tar.gz" && \
+	  echo "$(CONFTEST_CHECKSUM)  $(LOCALBIN)/conftest.tar.gz" | sha256sum -c --quiet && \
+	  tar -xz -C $(LOCALBIN) -f $(LOCALBIN)/conftest.tar.gz conftest && \
+	  rm -f $(LOCALBIN)/conftest.tar.gz; \
+	}
 
 .PHONY: policy-test
 policy-test: conftest ## Run OPA policy unit tests.

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ test: manifests generate fmt vet envtest ## Run tests.
 ##@ Policy
 
 CONFTEST ?= $(LOCALBIN)/conftest
-CONFTEST_VERSION ?= 0.46.0
+CONFTEST_VERSION ?= 0.68.2
 
 .PHONY: conftest
 conftest: $(CONFTEST)

--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,31 @@ vet: ## Run go vet against code.
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out -v
 
+##@ Policy
+
+CONFTEST ?= $(LOCALBIN)/conftest
+CONFTEST_VERSION ?= 0.46.0
+
+.PHONY: conftest
+conftest: $(CONFTEST)
+$(CONFTEST): $(LOCALBIN)
+	test -s $(LOCALBIN)/conftest || curl -sSL \
+	  "https://github.com/open-policy-agent/conftest/releases/download/v$(CONFTEST_VERSION)/conftest_$(CONFTEST_VERSION)_Linux_x86_64.tar.gz" \
+	  | tar -xz -C $(LOCALBIN) conftest
+
+.PHONY: policy-test
+policy-test: conftest ## Run OPA policy unit tests.
+	$(CONFTEST) verify --policy policy/
+
+.PHONY: policy-check
+policy-check: kustomize conftest ## Check rendered manifests against RBAC policies.
+	@failed=0; \
+	for target in config/base config/overlays/odh config/overlays/rhoai config/overlays/lmes config/overlays/odh-kueue config/overlays/testing config/overlays/dev config/overlays/evalhub-only config/overlays/mcp-guardrails; do \
+	  echo "=== Testing $$target ==="; \
+	  $(KUSTOMIZE) build "$$target" | $(CONFTEST) test --policy policy/ --namespace rbac - || failed=1; \
+	done; \
+	exit $$failed
+
 ##@ Build
 
 .PHONY: build

--- a/policy/README.md
+++ b/policy/README.md
@@ -1,0 +1,49 @@
+# Manifest Policies
+
+This directory contains [OPA/Rego](https://www.openpolicyagent.org/) policies that are evaluated against the rendered kustomize manifests on every push and pull request. The CI workflow (`Tier 1 - Manifest policy check`) renders **every** kustomize entry point (base + all overlays) and checks each against these policies using [Conftest](https://www.conftest.dev/).
+
+## Current policies
+
+### `rbac.rego` — ClusterRoleBinding allowlist
+
+Prevents accidental cluster-wide privilege escalation by maintaining a closed allowlist of expected `ClusterRoleBinding` resources.
+
+**Rules:**
+
+1. **No unexpected ClusterRoleBindings.** Any CRB whose post-kustomize name is not in `expected_crbs` is denied. This catches cases where a developer accidentally changes a `RoleBinding` to a `ClusterRoleBinding`, or adds a new CRB without review.
+2. **No role-reference mismatches.** An allowlisted CRB that references a different `ClusterRole` than expected is denied. This catches copy-paste mistakes or rename errors.
+
+**Tested overlays:** `base`, `odh`, `rhoai`, `lmes`, `odh-kueue`, `testing`, `dev`, `evalhub-only`, `mcp-guardrails`.
+
+## Adding a new ClusterRoleBinding
+
+If your change legitimately introduces a new `ClusterRoleBinding`:
+
+1. Add the post-kustomize CRB name and its expected `ClusterRole` to the `expected_crbs` map in `policy/rbac.rego`.
+2. If the overlay does not apply a `namePrefix`, add the un-prefixed name as well.
+3. Run `make policy-check` locally to verify.
+4. Explain in the PR description why a `ClusterRoleBinding` is needed (rather than a namespace-scoped `RoleBinding`).
+
+## Adding a new policy
+
+1. Create a new `.rego` file in this directory under the appropriate package name.
+2. Add corresponding `_test.rego` unit tests.
+3. Run `make policy-test` to verify the unit tests pass.
+4. Run `make policy-check` to verify against all rendered manifests.
+
+## Running locally
+
+```bash
+# OPA unit tests only
+make policy-test
+
+# Full check against all kustomize overlays
+make policy-check
+
+# Quick check against a single overlay
+kustomize build config/overlays/odh | conftest test --policy policy/ --namespace rbac -
+```
+
+## CI
+
+The GitHub Actions workflow `.github/workflows/conftest.yaml` runs both steps on every push and PR. It installs kustomize and conftest, runs the OPA unit tests, then checks all 9 kustomize entry points.

--- a/policy/rbac.rego
+++ b/policy/rbac.rego
@@ -1,5 +1,7 @@
 package rbac
 
+import rego.v1
+
 # Closed allowlist of every legitimate ClusterRoleBinding across all
 # kustomize overlays (base, odh, rhoai, lmes, odh-kueue, testing, dev,
 # evalhub-only, mcp-guardrails).

--- a/policy/rbac.rego
+++ b/policy/rbac.rego
@@ -1,0 +1,66 @@
+package rbac
+
+# Closed allowlist of every legitimate ClusterRoleBinding across all
+# kustomize overlays (base, odh, rhoai, lmes, odh-kueue, testing, dev,
+# evalhub-only, mcp-guardrails).
+#
+# The map key is the post-kustomize CRB name, the value is the
+# ClusterRole it must reference.  Overlays that do not apply the
+# namePrefix (base, evalhub-only) produce un-prefixed names; those
+# are listed separately.
+#
+# To add a new legitimate CRB, add it here and explain why in the PR.
+
+expected_crbs := {
+	# --- rbac-base (all overlays) ---
+	"manager-auth-delegator": "system:auth-delegator",
+	"proxy-rolebinding": "proxy-role",
+	"trustyai-service-operator-manager-auth-delegator": "system:auth-delegator",
+	"trustyai-service-operator-proxy-rolebinding": "trustyai-service-operator-proxy-role",
+
+	# --- component: tas ---
+	"trustyai-service-operator-tas-manager-rolebinding": "trustyai-service-operator-tas-manager-role",
+
+	# --- component: lmes ---
+	"trustyai-service-operator-lmes-manager-rolebinding": "trustyai-service-operator-lmes-manager-role",
+	"trustyai-service-operator-default-lmeval-user-rolebinding": "trustyai-service-operator-lmeval-user-role",
+
+	# --- component: evalhub ---
+	"trustyai-service-operator-evalhub-manager-rolebinding": "trustyai-service-operator-evalhub-manager-role",
+	"trustyai-service-operator-evalhub-collections-access-binding": "trustyai-service-operator-evalhub-collections-access",
+	"trustyai-service-operator-evalhub-providers-access-binding": "trustyai-service-operator-evalhub-providers-access",
+	"trustyai-service-operator-evalhub-mlflow-access-binding": "trustyai-service-operator-evalhub-mlflow-access",
+	"trustyai-service-operator-evalhub-mlflow-jobs-access-binding": "trustyai-service-operator-evalhub-mlflow-jobs-access",
+	"trustyai-service-operator-evalhub-jobs-writer-binding": "trustyai-service-operator-evalhub-jobs-writer",
+	"trustyai-service-operator-evalhub-job-config-binding": "trustyai-service-operator-evalhub-job-config",
+
+	# --- component: gorch ---
+	"trustyai-service-operator-gorch-manager-rolebinding": "trustyai-service-operator-gorch-manager-role",
+
+	# --- component: nemo-guardrails ---
+	"trustyai-service-operator-nemo-guardrails-manager-rolebinding": "trustyai-service-operator-nemo-guardrails-manager-role",
+
+	# --- component: job-mgr ---
+	"trustyai-service-operator-job-mgr-manager-rolebinding": "trustyai-service-operator-job-mgr-manager-role",
+}
+
+deny contains msg if {
+	input.kind == "ClusterRoleBinding"
+	name := input.metadata.name
+	not expected_crbs[name]
+	msg := sprintf(
+		"RBAC VIOLATION: unexpected ClusterRoleBinding '%s' binding '%s'. Add to policy/rbac.rego allowlist if intentional.",
+		[name, input.roleRef.name],
+	)
+}
+
+deny contains msg if {
+	input.kind == "ClusterRoleBinding"
+	name := input.metadata.name
+	expected_crbs[name]
+	input.roleRef.name != expected_crbs[name]
+	msg := sprintf(
+		"RBAC VIOLATION: ClusterRoleBinding '%s' expected to bind '%s' but binds '%s'.",
+		[name, expected_crbs[name], input.roleRef.name],
+	)
+}

--- a/policy/rbac_test.rego
+++ b/policy/rbac_test.rego
@@ -1,0 +1,72 @@
+package rbac
+
+test_base_auth_delegator_passes if {
+	count(deny) == 0 with input as {
+		"kind": "ClusterRoleBinding",
+		"metadata": {"name": "manager-auth-delegator"},
+		"roleRef": {"name": "system:auth-delegator"},
+	}
+}
+
+test_prefixed_auth_delegator_passes if {
+	count(deny) == 0 with input as {
+		"kind": "ClusterRoleBinding",
+		"metadata": {"name": "trustyai-service-operator-manager-auth-delegator"},
+		"roleRef": {"name": "system:auth-delegator"},
+	}
+}
+
+test_proxy_rolebinding_passes if {
+	count(deny) == 0 with input as {
+		"kind": "ClusterRoleBinding",
+		"metadata": {"name": "trustyai-service-operator-proxy-rolebinding"},
+		"roleRef": {"name": "trustyai-service-operator-proxy-role"},
+	}
+}
+
+test_evalhub_manager_passes if {
+	count(deny) == 0 with input as {
+		"kind": "ClusterRoleBinding",
+		"metadata": {"name": "trustyai-service-operator-evalhub-manager-rolebinding"},
+		"roleRef": {"name": "trustyai-service-operator-evalhub-manager-role"},
+	}
+}
+
+test_lmes_manager_passes if {
+	count(deny) == 0 with input as {
+		"kind": "ClusterRoleBinding",
+		"metadata": {"name": "trustyai-service-operator-lmes-manager-rolebinding"},
+		"roleRef": {"name": "trustyai-service-operator-lmes-manager-role"},
+	}
+}
+
+test_unexpected_crb_denied if {
+	count(deny) > 0 with input as {
+		"kind": "ClusterRoleBinding",
+		"metadata": {"name": "rogue-crb"},
+		"roleRef": {"name": "manager-role"},
+	}
+}
+
+test_wrong_role_denied if {
+	count(deny) > 0 with input as {
+		"kind": "ClusterRoleBinding",
+		"metadata": {"name": "trustyai-service-operator-proxy-rolebinding"},
+		"roleRef": {"name": "some-other-role"},
+	}
+}
+
+test_non_crb_ignored if {
+	count(deny) == 0 with input as {
+		"kind": "RoleBinding",
+		"metadata": {"name": "anything"},
+		"roleRef": {"name": "anything"},
+	}
+}
+
+test_clusterrole_ignored if {
+	count(deny) == 0 with input as {
+		"kind": "ClusterRole",
+		"metadata": {"name": "trustyai-service-operator-manager-role"},
+	}
+}

--- a/policy/rbac_test.rego
+++ b/policy/rbac_test.rego
@@ -1,5 +1,7 @@
 package rbac
 
+import rego.v1
+
 test_base_auth_delegator_passes if {
 	count(deny) == 0 with input as {
 		"kind": "ClusterRoleBinding",


### PR DESCRIPTION
## What and why

Adds a Conftest (OPA) CI gate that validates rendered kustomize manifests against a closed allowlist of expected `ClusterRoleBinding` resources. If a developer accidentally changes a `RoleBinding` to a `ClusterRoleBinding`, or an overlay introduces one, the operator gains cluster-wide permissions  (a serious security regression that no existing CI check catches).

Closes [RHOAIENG-68910](https://redhat.atlassian.net/browse/RHOAIENG-68910)

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Changes

- `policy/rbac.rego`: closed allowlist of 16 legitimate CRBs across all 6 components
- `policy/rbac_test.rego`: 9 OPA unit tests
- `.github/workflows/conftest.yaml`: Tier 1 workflow testing all 9 kustomize entry points
- `Makefile`: `policy-test`, `policy-check`, `conftest` targets
- `policy/README.md`: policy framework documentation
- `CONTRIBUTING.md`: added manifest policy check to quality gates
- `CLAUDE.md`: added policy section for AI-assisted development

## Testing

- [x] Tests added or updated
- [x] Tested manually

```bash
make policy-test    # 9/9 OPA unit tests pass
make policy-check   # 846/846 resources pass across all 9 overlays
```

Verified failure case: injecting a rogue ClusterRoleBinding correctly triggers denial:
FAIL - rbac - RBAC VIOLATION: unexpected ClusterRoleBinding 'rogue-crb' binding 'manager-role'.

## Breaking changes

None. This is a new CI gate. Existing manifests pass as-is. Adding a new ClusterRoleBinding requires updating the allowlist in policy/rbac.rego.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Open Policy Agent (OPA) manifest policy validation for Kubernetes configurations.
  * New `make policy-test` and `make policy-check` commands available for local policy validation.
  * Automated policy checks now run on pull requests and push events.

* **Documentation**
  * Updated contributor guidance with manifest policy validation requirements and procedures.
  * Added policy validation instructions to development documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->