### PR TITLE
feat(images): add RELATED_IMAGE_* env var support for operand image resolution

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -93,3 +93,38 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.lmes-pod-image
+  - name: lmes-driver-image
+    objref:
+      kind: ConfigMap
+      name: config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.lmes-driver-image
+  - name: guardrails-orchestrator-image
+    objref:
+      kind: ConfigMap
+      name: config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.guardrails-orchestrator-image
+  - name: guardrails-built-in-detector-image
+    objref:
+      kind: ConfigMap
+      name: config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.guardrails-built-in-detector-image
+  - name: guardrails-sidecar-gateway-image
+    objref:
+      kind: ConfigMap
+      name: config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.guardrails-sidecar-gateway-image
+  - name: nemo-guardrails-image
+    objref:
+      kind: ConfigMap
+      name: config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.nemo-guardrails-image

--- a/config/base/params.yaml
+++ b/config/base/params.yaml
@@ -2,5 +2,7 @@
 varReference:
   - kind: Deployment
     path: spec/template/spec/containers[]/image
+  - kind: Deployment
+    path: spec/template/spec/containers[]/env[]/value
   - kind: ConfigMap
     path: data

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -46,6 +46,26 @@ spec:
           env:
             - name: GOMEMLIMIT
               value: "630MiB"
+            - name: RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE
+              value: $(trustyaiServiceImage)
+            - name: RELATED_IMAGE_ODH_EVAL_HUB_IMAGE
+              value: $(evalHubImage)
+            - name: RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE
+              value: $(kube-rbac-proxy)
+            - name: RELATED_IMAGE_ODH_TA_LMES_JOB_IMAGE
+              value: $(lmes-pod-image)
+            - name: RELATED_IMAGE_ODH_TA_LMES_DRIVER_IMAGE
+              value: $(lmes-driver-image)
+            - name: RELATED_IMAGE_ODH_FMS_GUARDRAILS_ORCHESTRATOR_IMAGE
+              value: $(guardrails-orchestrator-image)
+            - name: RELATED_IMAGE_ODH_BUILT_IN_DETECTOR_IMAGE
+              value: $(guardrails-built-in-detector-image)
+            - name: RELATED_IMAGE_ODH_TRUSTYAI_VLLM_ORCHESTRATOR_GATEWAY_IMAGE
+              value: $(guardrails-sidecar-gateway-image)
+            - name: RELATED_IMAGE_ODH_TRUSTYAI_GARAK_LLS_PROVIDER_DSP_IMAGE
+              value: $(garak-provider-image)
+            - name: RELATED_IMAGE_ODH_TRUSTYAI_NEMO_GUARDRAILS_SERVER_IMAGE
+              value: $(nemo-guardrails-image)
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false

--- a/controllers/evalhub/build_test.go
+++ b/controllers/evalhub/build_test.go
@@ -216,7 +216,7 @@ var _ = Describe("buildDeploymentSpec", func() {
 
 		_, err := r.buildDeploymentSpec(ctx, evalHub, nil, nil)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("getting kube-rbac-proxy image"))
+		Expect(err.Error()).To(ContainSubstring("resolving kube-rbac-proxy image"))
 	})
 
 	It("adds provider volume and mount when providerCMNames is non-nil", func() {

--- a/controllers/evalhub/configmap.go
+++ b/controllers/evalhub/configmap.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	evalhubv1 "github.com/trustyai-explainability/trustyai-service-operator/api/evalhub/v1"
+	"github.com/trustyai-explainability/trustyai-service-operator/controllers/images"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/controllers/evalhub/configmap.go
+++ b/controllers/evalhub/configmap.go
@@ -148,7 +148,7 @@ func (r *EvalHubReconciler) reconcileConfigMap(ctx context.Context, instance *ev
 
 // generateConfigData generates the configuration data for the ConfigMap
 func (r *EvalHubReconciler) generateConfigData(ctx context.Context, instance *evalhubv1.EvalHub) (map[string]string, error) {
-	evalHubImage, err := images.ResolveImage(ctx, r.Client, images.EvalHubImageKey, configMapName, r.Namespace, defaultEvalHubImage)
+	evalHubImage, err := images.ResolveImage(ctx, r.Client, images.EvalHubImageKey, r.effectiveOperatorConfigMapName(), r.Namespace, defaultEvalHubImage)
 	if err != nil {
 		return nil, fmt.Errorf("resolving EvalHub image: %w", err)
 	}

--- a/controllers/evalhub/configmap.go
+++ b/controllers/evalhub/configmap.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	evalhubv1 "github.com/trustyai-explainability/trustyai-service-operator/api/evalhub/v1"
-	"github.com/trustyai-explainability/trustyai-service-operator/controllers/images"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/controllers/evalhub/configmap.go
+++ b/controllers/evalhub/configmap.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	evalhubv1 "github.com/trustyai-explainability/trustyai-service-operator/api/evalhub/v1"
+	"github.com/trustyai-explainability/trustyai-service-operator/controllers/images"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -147,9 +148,9 @@ func (r *EvalHubReconciler) reconcileConfigMap(ctx context.Context, instance *ev
 
 // generateConfigData generates the configuration data for the ConfigMap
 func (r *EvalHubReconciler) generateConfigData(ctx context.Context, instance *evalhubv1.EvalHub) (map[string]string, error) {
-	evalHubImage, err := r.getImageFromConfigMap(ctx, configMapEvalHubImageKey)
+	evalHubImage, err := images.ResolveImage(ctx, r.Client, images.EvalHubImageKey, configMapName, r.Namespace, defaultEvalHubImage)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get EvalHub image: %w", err)
+		return nil, fmt.Errorf("resolving EvalHub image: %w", err)
 	}
 
 	config := EvalHubConfig{

--- a/controllers/evalhub/deployment.go
+++ b/controllers/evalhub/deployment.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	evalhubv1 "github.com/trustyai-explainability/trustyai-service-operator/api/evalhub/v1"
-	"github.com/trustyai-explainability/trustyai-service-operator/controllers/images"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/controllers/evalhub/deployment.go
+++ b/controllers/evalhub/deployment.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	evalhubv1 "github.com/trustyai-explainability/trustyai-service-operator/api/evalhub/v1"
+	"github.com/trustyai-explainability/trustyai-service-operator/controllers/images"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -66,16 +67,15 @@ func (r *EvalHubReconciler) buildDeploymentSpec(ctx context.Context, instance *e
 		"component": "api",
 	}
 
-	// Get image from ConfigMap with fallback
-	evalHubImage, err := r.getImageFromConfigMap(ctx, configMapEvalHubImageKey)
+	// Get image using the centralized resolver (env var → configmap → fallback)
+	evalHubImage, err := images.ResolveImage(ctx, r.Client, images.EvalHubImageKey, configMapName, r.Namespace, defaultEvalHubImage)
 	if err != nil {
-		log.FromContext(ctx).Error(err, "Error getting EvalHub image from ConfigMap. Using the default image value of "+defaultEvalHubImage)
-		evalHubImage = defaultEvalHubImage
+		return appsv1.DeploymentSpec{}, fmt.Errorf("resolving EvalHub image: %w", err)
 	}
 
-	kubeRBACProxyImage, err := r.getImageFromConfigMap(ctx, configMapKubeRBACProxyImageKey)
+	kubeRBACProxyImage, err := images.ResolveImage(ctx, r.Client, images.KubeRBACProxyKey, configMapName, r.Namespace, "")
 	if err != nil {
-		return appsv1.DeploymentSpec{}, fmt.Errorf("getting kube-rbac-proxy image: %w", err)
+		return appsv1.DeploymentSpec{}, fmt.Errorf("resolving kube-rbac-proxy image: %w", err)
 	}
 
 	settings := mergeEvalHubDeploymentOperatorSettings(ctx, r.readOperatorConfigMapData(ctx))

--- a/controllers/evalhub/deployment.go
+++ b/controllers/evalhub/deployment.go
@@ -68,12 +68,12 @@ func (r *EvalHubReconciler) buildDeploymentSpec(ctx context.Context, instance *e
 	}
 
 	// Get image using the centralized resolver (env var → configmap → fallback)
-	evalHubImage, err := images.ResolveImage(ctx, r.Client, images.EvalHubImageKey, configMapName, r.Namespace, defaultEvalHubImage)
+	evalHubImage, err := images.ResolveImage(ctx, r.Client, images.EvalHubImageKey, r.effectiveOperatorConfigMapName(), r.Namespace, defaultEvalHubImage)
 	if err != nil {
 		return appsv1.DeploymentSpec{}, fmt.Errorf("resolving EvalHub image: %w", err)
 	}
 
-	kubeRBACProxyImage, err := images.ResolveImage(ctx, r.Client, images.KubeRBACProxyKey, configMapName, r.Namespace, "")
+	kubeRBACProxyImage, err := images.ResolveImage(ctx, r.Client, images.KubeRBACProxyKey, r.effectiveOperatorConfigMapName(), r.Namespace, "")
 	if err != nil {
 		return appsv1.DeploymentSpec{}, fmt.Errorf("resolving kube-rbac-proxy image: %w", err)
 	}

--- a/controllers/evalhub/deployment.go
+++ b/controllers/evalhub/deployment.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	evalhubv1 "github.com/trustyai-explainability/trustyai-service-operator/api/evalhub/v1"
+	"github.com/trustyai-explainability/trustyai-service-operator/controllers/images"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/controllers/evalhub/deployment_test.go
+++ b/controllers/evalhub/deployment_test.go
@@ -319,7 +319,7 @@ var _ = Describe("EvalHub Deployment", func() {
 
 			err = reconciler.reconcileDeployment(ctx, evalHub, nil, nil)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("getting kube-rbac-proxy image"))
+			Expect(err.Error()).To(ContainSubstring("resolving kube-rbac-proxy image"))
 		})
 
 		It("should configure rolling update strategy", func() {
@@ -696,6 +696,6 @@ var _ = Describe("EvalHubReconciler reconcileDeployment", func() {
 		}
 		err := r.reconcileDeployment(ctx, fh, nil, nil)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("getting kube-rbac-proxy image"))
+		Expect(err.Error()).To(ContainSubstring("resolving kube-rbac-proxy image"))
 	})
 })

--- a/controllers/evalhub/mcp_deployment.go
+++ b/controllers/evalhub/mcp_deployment.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	evalhubv1 "github.com/trustyai-explainability/trustyai-service-operator/api/evalhub/v1"
+	"github.com/trustyai-explainability/trustyai-service-operator/controllers/images"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -81,16 +82,15 @@ func (r *EvalHubReconciler) buildMCPDeploymentSpec(ctx context.Context, instance
 	image := mcpSpec.Image
 	if image == "" {
 		var err error
-		image, err = r.getImageFromConfigMap(ctx, configMapEvalHubImageKey)
+		image, err = images.ResolveImage(ctx, r.Client, images.EvalHubImageKey, configMapName, r.Namespace, defaultEvalHubImage)
 		if err != nil {
-			log.FromContext(ctx).Error(err, "Error getting EvalHub image for MCP from ConfigMap, using default "+defaultEvalHubImage)
-			image = defaultEvalHubImage
+			return appsv1.DeploymentSpec{}, fmt.Errorf("resolving EvalHub image for MCP: %w", err)
 		}
 	}
 
-	kubeRBACProxyImage, err := r.getImageFromConfigMap(ctx, configMapKubeRBACProxyImageKey)
+	kubeRBACProxyImage, err := images.ResolveImage(ctx, r.Client, images.KubeRBACProxyKey, configMapName, r.Namespace, "")
 	if err != nil {
-		return appsv1.DeploymentSpec{}, fmt.Errorf("getting kube-rbac-proxy image for MCP: %w", err)
+		return appsv1.DeploymentSpec{}, fmt.Errorf("resolving kube-rbac-proxy image for MCP: %w", err)
 	}
 
 	settings := mergeEvalHubDeploymentOperatorSettings(ctx, r.readOperatorConfigMapData(ctx))

--- a/controllers/evalhub/mcp_deployment.go
+++ b/controllers/evalhub/mcp_deployment.go
@@ -82,13 +82,13 @@ func (r *EvalHubReconciler) buildMCPDeploymentSpec(ctx context.Context, instance
 	image := mcpSpec.Image
 	if image == "" {
 		var err error
-		image, err = images.ResolveImage(ctx, r.Client, images.EvalHubImageKey, configMapName, r.Namespace, defaultEvalHubImage)
+		image, err = images.ResolveImage(ctx, r.Client, images.EvalHubImageKey, r.effectiveOperatorConfigMapName(), r.Namespace, defaultEvalHubImage)
 		if err != nil {
 			return appsv1.DeploymentSpec{}, fmt.Errorf("resolving EvalHub image for MCP: %w", err)
 		}
 	}
 
-	kubeRBACProxyImage, err := images.ResolveImage(ctx, r.Client, images.KubeRBACProxyKey, configMapName, r.Namespace, "")
+	kubeRBACProxyImage, err := images.ResolveImage(ctx, r.Client, images.KubeRBACProxyKey, r.effectiveOperatorConfigMapName(), r.Namespace, "")
 	if err != nil {
 		return appsv1.DeploymentSpec{}, fmt.Errorf("resolving kube-rbac-proxy image for MCP: %w", err)
 	}

--- a/controllers/gorch/auth.go
+++ b/controllers/gorch/auth.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	gorchv1alpha1 "github.com/trustyai-explainability/trustyai-service-operator/api/gorch/v1alpha1"
 	"github.com/trustyai-explainability/trustyai-service-operator/controllers/constants"
+	"github.com/trustyai-explainability/trustyai-service-operator/controllers/images"
 	templateParser "github.com/trustyai-explainability/trustyai-service-operator/controllers/gorch/templates"
 	"github.com/trustyai-explainability/trustyai-service-operator/controllers/utils"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -12,12 +13,12 @@ import (
 
 // configureKubeRBACProxy creates the kube-rbac-proxy config structs to be used in the deployment template
 func (r *GuardrailsOrchestratorReconciler) configureKubeRBACProxy(ctx context.Context, orchestrator *gorchv1alpha1.GuardrailsOrchestrator, deploymentConfig *DeploymentConfig) error {
-	kubeRBACProxyImage, err := utils.GetImageFromConfigMap(ctx, r.Client, kubeRBACProxyImageKey, constants.ConfigMap, r.Namespace)
+	kubeRBACProxyImage, err := images.GetImageFromConfigMap(ctx, r.Client, kubeRBACProxyImageKey, constants.ConfigMap, r.Namespace)
 	if kubeRBACProxyImage == "" || err != nil {
-		log.FromContext(ctx).Error(err, "Error getting Kube-RBAC-Proxy image from ConfigMap.")
+		log.FromContext(ctx).Error(err, "Error resolving Kube-RBAC-Proxy image from env var or ConfigMap.")
 		return err
 	}
-	log.FromContext(ctx).Info("Using kube-rbac-proxy image " + kubeRBACProxyImage + " " + "from configmap " + r.Namespace + ":" + constants.ConfigMap)
+	log.FromContext(ctx).Info("Using kube-rbac-proxy image " + kubeRBACProxyImage)
 
 	deploymentConfig.OrchestratorKubeRBACProxy = &utils.KubeRBACProxyConfig{
 		Suffix:             "orchestrator",

--- a/controllers/gorch/deployment.go
+++ b/controllers/gorch/deployment.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	gorchv1alpha1 "github.com/trustyai-explainability/trustyai-service-operator/api/gorch/v1alpha1"
 	"github.com/trustyai-explainability/trustyai-service-operator/controllers/constants"
+	"github.com/trustyai-explainability/trustyai-service-operator/controllers/images"
 	templateParser "github.com/trustyai-explainability/trustyai-service-operator/controllers/gorch/templates"
 	"github.com/trustyai-explainability/trustyai-service-operator/controllers/utils"
 	appsv1 "k8s.io/api/apps/v1"
@@ -33,32 +34,32 @@ type DeploymentConfig struct {
 func (r *GuardrailsOrchestratorReconciler) createDeployment(ctx context.Context, orchestrator *gorchv1alpha1.GuardrailsOrchestrator) (*appsv1.Deployment, error) {
 	var containerImages ContainerImages
 
-	orchestratorImage, err := utils.GetImageFromConfigMap(ctx, r.Client, orchestratorImageKey, constants.ConfigMap, r.Namespace)
+	orchestratorImage, err := images.GetImageFromConfigMap(ctx, r.Client, orchestratorImageKey, constants.ConfigMap, r.Namespace)
 	if orchestratorImage == "" || err != nil {
-		log.FromContext(ctx).Error(err, "Error getting container image from ConfigMap.")
+		log.FromContext(ctx).Error(err, "Error resolving orchestrator image from env var or ConfigMap.")
 		return nil, err
 	}
 	containerImages.OrchestratorImage = orchestratorImage
-	log.FromContext(ctx).Info("using OrchestratorImage " + orchestratorImage + " " + "from config map " + r.Namespace + ":" + constants.ConfigMap)
+	log.FromContext(ctx).Info("using OrchestratorImage " + orchestratorImage)
 
 	// Check if the regex detectors are enabled
 	if orchestrator.Spec.EnableBuiltInDetectors {
-		detectorImage, err := utils.GetImageFromConfigMap(ctx, r.Client, detectorImageKey, constants.ConfigMap, r.Namespace)
+		detectorImage, err := images.GetImageFromConfigMap(ctx, r.Client, detectorImageKey, constants.ConfigMap, r.Namespace)
 		if detectorImage == "" || err != nil {
-			log.FromContext(ctx).Error(err, "Error getting detectors image from ConfigMap.")
+			log.FromContext(ctx).Error(err, "Error resolving detector image from env var or ConfigMap.")
 			return nil, err
 		}
-		log.FromContext(ctx).Info("Using detector image " + detectorImage + " " + "from configmap " + r.Namespace + ":" + constants.ConfigMap)
+		log.FromContext(ctx).Info("Using detector image " + detectorImage)
 		containerImages.DetectorImage = detectorImage
 	}
 
 	// Check if the guardrails sidecar gateway is enabled
 	if orchestrator.Spec.EnableGuardrailsGateway {
-		guardrailsGatewayImage, err := utils.GetImageFromConfigMap(ctx, r.Client, gatewayImageKey, constants.ConfigMap, r.Namespace)
+		guardrailsGatewayImage, err := images.GetImageFromConfigMap(ctx, r.Client, gatewayImageKey, constants.ConfigMap, r.Namespace)
 		if guardrailsGatewayImage == "" || err != nil {
-			log.FromContext(ctx).Error(err, "Error getting guardrails sidecar gateway image from ConfigMap.")
+			log.FromContext(ctx).Error(err, "Error resolving guardrails sidecar gateway image from env var or ConfigMap.")
 		}
-		log.FromContext(ctx).Info("Using sidecar gateway image " + guardrailsGatewayImage + " " + "from configmap " + r.Namespace + ":" + constants.ConfigMap)
+		log.FromContext(ctx).Info("Using sidecar gateway image " + guardrailsGatewayImage)
 		containerImages.GuardrailsGatewayImage = guardrailsGatewayImage
 	}
 

--- a/controllers/gorch/deployment.go
+++ b/controllers/gorch/deployment.go
@@ -58,6 +58,7 @@ func (r *GuardrailsOrchestratorReconciler) createDeployment(ctx context.Context,
 		guardrailsGatewayImage, err := images.GetImageFromConfigMap(ctx, r.Client, gatewayImageKey, constants.ConfigMap, r.Namespace)
 		if guardrailsGatewayImage == "" || err != nil {
 			log.FromContext(ctx).Error(err, "Error resolving guardrails sidecar gateway image from env var or ConfigMap.")
+			return nil, err
 		}
 		log.FromContext(ctx).Info("Using sidecar gateway image " + guardrailsGatewayImage)
 		containerImages.GuardrailsGatewayImage = guardrailsGatewayImage

--- a/controllers/images/resolver.go
+++ b/controllers/images/resolver.go
@@ -1,0 +1,133 @@
+package images
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Image key constants matching ConfigMap keys
+const (
+	TrustyAIServiceImageKey           = "trustyaiServiceImage"
+	EvalHubImageKey                   = "evalHubImage"
+	KubeRBACProxyKey                  = "kube-rbac-proxy"
+	LMESPodImageKey                   = "lmes-pod-image"
+	LMESDriverImageKey                = "lmes-driver-image"
+	GuardrailsOrchestratorImageKey    = "guardrails-orchestrator-image"
+	GuardrailsBuiltInDetectorImageKey = "guardrails-built-in-detector-image"
+	GuardrailsSidecarGatewayImageKey  = "guardrails-sidecar-gateway-image"
+	GarakProviderImageKey             = "garak-provider-image"
+	NemoGuardrailsImageKey            = "nemo-guardrails-image"
+)
+
+// Environment variable names following RELATED_IMAGE_ODH_* convention
+const (
+	RelatedImageTrustyAIService          = "RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE"
+	RelatedImageEvalHub                  = "RELATED_IMAGE_ODH_EVAL_HUB_IMAGE"
+	RelatedImageKubeRBACProxy            = "RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE"
+	RelatedImageLMESJob                  = "RELATED_IMAGE_ODH_TA_LMES_JOB_IMAGE"
+	RelatedImageLMESDriver               = "RELATED_IMAGE_ODH_TA_LMES_DRIVER_IMAGE"
+	RelatedImageGuardrailsOrchestrator   = "RELATED_IMAGE_ODH_FMS_GUARDRAILS_ORCHESTRATOR_IMAGE"
+	RelatedImageBuiltInDetector          = "RELATED_IMAGE_ODH_BUILT_IN_DETECTOR_IMAGE"
+	RelatedImageVLLMOrchestratorGateway  = "RELATED_IMAGE_ODH_TRUSTYAI_VLLM_ORCHESTRATOR_GATEWAY_IMAGE"
+	RelatedImageGarakLLSProviderDSP      = "RELATED_IMAGE_ODH_TRUSTYAI_GARAK_LLS_PROVIDER_DSP_IMAGE"
+	RelatedImageNemoGuardrailsServer     = "RELATED_IMAGE_ODH_TRUSTYAI_NEMO_GUARDRAILS_SERVER_IMAGE"
+)
+
+// imageMapping maps ConfigMap keys to their corresponding RELATED_IMAGE_* environment variable names
+var imageMapping = map[string]string{
+	TrustyAIServiceImageKey:           RelatedImageTrustyAIService,
+	EvalHubImageKey:                   RelatedImageEvalHub,
+	KubeRBACProxyKey:                  RelatedImageKubeRBACProxy,
+	LMESPodImageKey:                   RelatedImageLMESJob,
+	LMESDriverImageKey:                RelatedImageLMESDriver,
+	GuardrailsOrchestratorImageKey:    RelatedImageGuardrailsOrchestrator,
+	GuardrailsBuiltInDetectorImageKey: RelatedImageBuiltInDetector,
+	GuardrailsSidecarGatewayImageKey:  RelatedImageVLLMOrchestratorGateway,
+	GarakProviderImageKey:             RelatedImageGarakLLSProviderDSP,
+	NemoGuardrailsImageKey:            RelatedImageNemoGuardrailsServer,
+}
+
+// GetImageFromConfigMap is the legacy function signature that now uses the unified resolver.
+// Deprecated: Use ResolveImage directly for better clarity.
+func GetImageFromConfigMap(ctx context.Context, c client.Client, configMapKey, configMapName, namespace string) (string, error) {
+	return ResolveImage(ctx, c, configMapKey, configMapName, namespace, "")
+}
+
+// GetImageFromConfigMapWithFallback is the legacy function signature with a default fallback value.
+// Deprecated: Use ResolveImage directly for better clarity.
+func GetImageFromConfigMapWithFallback(ctx context.Context, c client.Client, configMapKey, configMapName, namespace string, fallbackValue string) (string, error) {
+	if namespace == "" {
+		return fallbackValue, nil
+	}
+	image, err := ResolveImage(ctx, c, configMapKey, configMapName, namespace, fallbackValue)
+	if err != nil {
+		return fallbackValue, err
+	}
+	return image, nil
+}
+
+// ResolveImage resolves an operand image URL by checking in this order:
+//  1. RELATED_IMAGE_ODH_* environment variable (if configMapKey is recognized)
+//  2. ConfigMap value at configMapKey
+//  3. fallbackValue (if provided and non-empty)
+//
+// Returns an error if none of the above sources provide a value.
+func ResolveImage(ctx context.Context, c client.Client, configMapKey, configMapName, namespace string, fallbackValue string) (string, error) {
+	// Step 1: Check if there's a corresponding RELATED_IMAGE_* env var
+	if envVarName, ok := imageMapping[configMapKey]; ok {
+		if envValue := os.Getenv(envVarName); envValue != "" {
+			return envValue, nil
+		}
+	}
+
+	// Step 2: Fall back to ConfigMap
+	image, err := getImageFromConfigMapDirect(ctx, c, configMapKey, configMapName, namespace)
+	if err == nil && image != "" {
+		return image, nil
+	}
+
+	// Step 3: Use fallback value if provided
+	if fallbackValue != "" {
+		return fallbackValue, nil
+	}
+
+	// No value found
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve image for key %s: %w", configMapKey, err)
+	}
+	return "", fmt.Errorf("no image value found for key %s (env var, configmap, or fallback)", configMapKey)
+}
+
+// getImageFromConfigMapDirect is an internal helper that directly reads from ConfigMap without env var check.
+// This is used internally by ResolveImage to avoid circular logic.
+func getImageFromConfigMapDirect(ctx context.Context, c client.Client, configMapKey, configMapName, namespace string) (string, error) {
+	// Import the existing ConfigMap helper from utils package
+	// Note: We can't import controllers/utils here due to circular dependency,
+	// so we need to either:
+	// 1. Move GetConfigMapByName to a shared package, or
+	// 2. Duplicate the ConfigMap lookup logic here
+	//
+	// For now, we'll use a simple inline implementation to avoid circular imports.
+	// In production, you might want to refactor utils.GetConfigMapByName to a common package.
+
+	configMap := &corev1.ConfigMap{}
+	err := c.Get(ctx, types.NamespacedName{Name: configMapName, Namespace: namespace}, configMap)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return "", fmt.Errorf("configmap %s not found in namespace %s", configMapName, namespace)
+		}
+		return "", fmt.Errorf("error reading configmap %s in namespace %s: %w", configMapName, namespace, err)
+	}
+
+	value, ok := configMap.Data[configMapKey]
+	if !ok {
+		return "", fmt.Errorf("configmap %s in namespace %s does not contain key %s", configMapName, namespace, configMapKey)
+	}
+	return value, nil
+}

--- a/controllers/images/resolver.go
+++ b/controllers/images/resolver.go
@@ -114,7 +114,8 @@ func ResolveImage(ctx context.Context, c client.Client, configMapKey, configMapN
 // This is used internally by ResolveImage to avoid circular logic.
 func getImageFromConfigMapDirect(ctx context.Context, c client.Client, configMapKey, configMapName, namespace string) (string, error) {
 	// Inline implementation to avoid circular import with controllers/utils.
-	// TODO: Refactor to shared pkg/configmap package to eliminate duplication (tracked separately)
+	// TODO: Refactor to shared pkg/configmap package to eliminate duplication.
+	// See https://github.com/trustyai-explainability/trustyai-service-operator/issues/783
 
 	configMap := &corev1.ConfigMap{}
 	err := c.Get(ctx, types.NamespacedName{Name: configMapName, Namespace: namespace}, configMap)

--- a/controllers/images/resolver.go
+++ b/controllers/images/resolver.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // Image key constants matching ConfigMap keys
@@ -79,9 +80,12 @@ func GetImageFromConfigMapWithFallback(ctx context.Context, c client.Client, con
 //
 // Returns an error if none of the above sources provide a value.
 func ResolveImage(ctx context.Context, c client.Client, configMapKey, configMapName, namespace string, fallbackValue string) (string, error) {
+	logger := log.FromContext(ctx)
+
 	// Step 1: Check if there's a corresponding RELATED_IMAGE_* env var
 	if envVarName, ok := imageMapping[configMapKey]; ok {
 		if envValue := os.Getenv(envVarName); envValue != "" {
+			logger.Info("resolved image", "key", configMapKey, "source", "env", "var", envVarName, "value", envValue)
 			return envValue, nil
 		}
 	}
@@ -89,11 +93,13 @@ func ResolveImage(ctx context.Context, c client.Client, configMapKey, configMapN
 	// Step 2: Fall back to ConfigMap
 	image, err := getImageFromConfigMapDirect(ctx, c, configMapKey, configMapName, namespace)
 	if err == nil && image != "" {
+		logger.Info("resolved image", "key", configMapKey, "source", "configmap", "name", configMapName, "namespace", namespace, "value", image)
 		return image, nil
 	}
 
 	// Step 3: Use fallback value if provided
 	if fallbackValue != "" {
+		logger.Info("resolved image", "key", configMapKey, "source", "fallback", "value", fallbackValue)
 		return fallbackValue, nil
 	}
 
@@ -107,14 +113,8 @@ func ResolveImage(ctx context.Context, c client.Client, configMapKey, configMapN
 // getImageFromConfigMapDirect is an internal helper that directly reads from ConfigMap without env var check.
 // This is used internally by ResolveImage to avoid circular logic.
 func getImageFromConfigMapDirect(ctx context.Context, c client.Client, configMapKey, configMapName, namespace string) (string, error) {
-	// Import the existing ConfigMap helper from utils package
-	// Note: We can't import controllers/utils here due to circular dependency,
-	// so we need to either:
-	// 1. Move GetConfigMapByName to a shared package, or
-	// 2. Duplicate the ConfigMap lookup logic here
-	//
-	// For now, we'll use a simple inline implementation to avoid circular imports.
-	// In production, you might want to refactor utils.GetConfigMapByName to a common package.
+	// Inline implementation to avoid circular import with controllers/utils.
+	// TODO: Refactor to shared pkg/configmap package to eliminate duplication (tracked separately)
 
 	configMap := &corev1.ConfigMap{}
 	err := c.Get(ctx, types.NamespacedName{Name: configMapName, Namespace: namespace}, configMap)

--- a/controllers/images/resolver_test.go
+++ b/controllers/images/resolver_test.go
@@ -12,7 +12,7 @@ import (
 
 var _ = Describe("Image Resolver", func() {
 	var cleanupEnvVars = func() {
-		_ = os.Unsetenv(RelatedImageTrustyAIService)
+		Expect(os.Unsetenv(RelatedImageTrustyAIService)).To(Succeed())
 	}
 
 	AfterEach(func() {

--- a/controllers/images/resolver_test.go
+++ b/controllers/images/resolver_test.go
@@ -1,0 +1,308 @@
+package images
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	testNamespace    = "test-namespace"
+	testConfigMap    = "test-configmap"
+	testImageFromCM  = "quay.io/trustyai/service:from-configmap"
+	testImageFromEnv = "quay.io/trustyai/service:from-env-var"
+	testFallback     = "quay.io/trustyai/service:fallback"
+)
+
+func TestResolveImage_EnvVarSet(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a fake client with a ConfigMap containing an image
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testConfigMap,
+			Namespace: testNamespace,
+		},
+		Data: map[string]string{
+			TrustyAIServiceImageKey: testImageFromCM,
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
+
+	// Set the environment variable
+	os.Setenv(RelatedImageTrustyAIService, testImageFromEnv)
+	defer os.Unsetenv(RelatedImageTrustyAIService)
+
+	// Resolve the image
+	image, err := ResolveImage(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, testNamespace, "")
+
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	// Should use env var value, not ConfigMap value
+	if image != testImageFromEnv {
+		t.Errorf("Expected image from env var %q, got %q", testImageFromEnv, image)
+	}
+}
+
+func TestResolveImage_EnvVarUnset_UsesConfigMap(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a fake client with a ConfigMap
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testConfigMap,
+			Namespace: testNamespace,
+		},
+		Data: map[string]string{
+			TrustyAIServiceImageKey: testImageFromCM,
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
+
+	// Ensure env var is NOT set
+	os.Unsetenv(RelatedImageTrustyAIService)
+
+	// Resolve the image
+	image, err := ResolveImage(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, testNamespace, "")
+
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	// Should use ConfigMap value
+	if image != testImageFromCM {
+		t.Errorf("Expected image from ConfigMap %q, got %q", testImageFromCM, image)
+	}
+}
+
+func TestResolveImage_EnvVarEmpty_UsesConfigMap(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a fake client with a ConfigMap
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testConfigMap,
+			Namespace: testNamespace,
+		},
+		Data: map[string]string{
+			TrustyAIServiceImageKey: testImageFromCM,
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
+
+	// Set env var to empty string
+	os.Setenv(RelatedImageTrustyAIService, "")
+	defer os.Unsetenv(RelatedImageTrustyAIService)
+
+	// Resolve the image
+	image, err := ResolveImage(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, testNamespace, "")
+
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	// Should use ConfigMap value when env var is empty
+	if image != testImageFromCM {
+		t.Errorf("Expected image from ConfigMap %q, got %q", testImageFromCM, image)
+	}
+}
+
+func TestResolveImage_NoEnvVar_NoConfigMap_UsesFallback(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a fake client with NO ConfigMap
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	// Ensure env var is NOT set
+	os.Unsetenv(RelatedImageTrustyAIService)
+
+	// Resolve the image with fallback
+	image, err := ResolveImage(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, testNamespace, testFallback)
+
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	// Should use fallback value
+	if image != testFallback {
+		t.Errorf("Expected fallback image %q, got %q", testFallback, image)
+	}
+}
+
+func TestResolveImage_NoEnvVar_NoConfigMap_NoFallback_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a fake client with NO ConfigMap
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	// Ensure env var is NOT set
+	os.Unsetenv(RelatedImageTrustyAIService)
+
+	// Resolve the image without fallback
+	_, err := ResolveImage(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, testNamespace, "")
+
+	// Should return an error
+	if err == nil {
+		t.Fatal("Expected error when no env var, no ConfigMap, and no fallback, got nil")
+	}
+}
+
+func TestResolveImage_ConfigMapMissingKey_UsesFallback(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a ConfigMap without the expected key
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testConfigMap,
+			Namespace: testNamespace,
+		},
+		Data: map[string]string{
+			"some-other-key": "some-value",
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
+
+	// Ensure env var is NOT set
+	os.Unsetenv(RelatedImageTrustyAIService)
+
+	// Resolve the image with fallback
+	image, err := ResolveImage(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, testNamespace, testFallback)
+
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	// Should use fallback when key is missing
+	if image != testFallback {
+		t.Errorf("Expected fallback image %q, got %q", testFallback, image)
+	}
+}
+
+func TestResolveImage_AllImageMappings(t *testing.T) {
+	// Test that all 10 image mappings are correctly defined
+	expectedMappings := map[string]string{
+		TrustyAIServiceImageKey:           RelatedImageTrustyAIService,
+		EvalHubImageKey:                   RelatedImageEvalHub,
+		KubeRBACProxyKey:                  RelatedImageKubeRBACProxy,
+		LMESPodImageKey:                   RelatedImageLMESJob,
+		LMESDriverImageKey:                RelatedImageLMESDriver,
+		GuardrailsOrchestratorImageKey:    RelatedImageGuardrailsOrchestrator,
+		GuardrailsBuiltInDetectorImageKey: RelatedImageBuiltInDetector,
+		GuardrailsSidecarGatewayImageKey:  RelatedImageVLLMOrchestratorGateway,
+		GarakProviderImageKey:             RelatedImageGarakLLSProviderDSP,
+		NemoGuardrailsImageKey:            RelatedImageNemoGuardrailsServer,
+	}
+
+	if len(imageMapping) != len(expectedMappings) {
+		t.Errorf("Expected %d image mappings, got %d", len(expectedMappings), len(imageMapping))
+	}
+
+	for key, expectedEnvVar := range expectedMappings {
+		actualEnvVar, ok := imageMapping[key]
+		if !ok {
+			t.Errorf("Missing mapping for key %q", key)
+			continue
+		}
+		if actualEnvVar != expectedEnvVar {
+			t.Errorf("For key %q: expected env var %q, got %q", key, expectedEnvVar, actualEnvVar)
+		}
+	}
+}
+
+func TestGetImageFromConfigMap_BackwardCompatibility(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a ConfigMap
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testConfigMap,
+			Namespace: testNamespace,
+		},
+		Data: map[string]string{
+			TrustyAIServiceImageKey: testImageFromCM,
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
+
+	// Ensure env var is NOT set
+	os.Unsetenv(RelatedImageTrustyAIService)
+
+	// Call the legacy function
+	image, err := GetImageFromConfigMap(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, testNamespace)
+
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if image != testImageFromCM {
+		t.Errorf("Expected image %q, got %q", testImageFromCM, image)
+	}
+}
+
+func TestGetImageFromConfigMapWithFallback_BackwardCompatibility(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a fake client with NO ConfigMap
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	// Ensure env var is NOT set
+	os.Unsetenv(RelatedImageTrustyAIService)
+
+	// Call the legacy function with fallback
+	image, err := GetImageFromConfigMapWithFallback(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, testNamespace, testFallback)
+
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if image != testFallback {
+		t.Errorf("Expected fallback image %q, got %q", testFallback, image)
+	}
+}
+
+func TestGetImageFromConfigMapWithFallback_EmptyNamespace(t *testing.T) {
+	ctx := context.Background()
+
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	// When namespace is empty, should return fallback immediately
+	image, err := GetImageFromConfigMapWithFallback(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, "", testFallback)
+
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if image != testFallback {
+		t.Errorf("Expected fallback image %q, got %q", testFallback, image)
+	}
+}

--- a/controllers/images/resolver_test.go
+++ b/controllers/images/resolver_test.go
@@ -1,308 +1,233 @@
 package images
 
 import (
-	"context"
 	"os"
-	"testing"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-const (
-	testNamespace    = "test-namespace"
-	testConfigMap    = "test-configmap"
-	testImageFromCM  = "quay.io/trustyai/service:from-configmap"
-	testImageFromEnv = "quay.io/trustyai/service:from-env-var"
-	testFallback     = "quay.io/trustyai/service:fallback"
-)
-
-func TestResolveImage_EnvVarSet(t *testing.T) {
-	ctx := context.Background()
-
-	// Create a fake client with a ConfigMap containing an image
-	configMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testConfigMap,
-			Namespace: testNamespace,
-		},
-		Data: map[string]string{
-			TrustyAIServiceImageKey: testImageFromCM,
-		},
+var _ = Describe("Image Resolver", func() {
+	var cleanupEnvVars = func() {
+		_ = os.Unsetenv(RelatedImageTrustyAIService)
 	}
 
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
+	AfterEach(func() {
+		cleanupEnvVars()
+	})
 
-	// Set the environment variable
-	os.Setenv(RelatedImageTrustyAIService, testImageFromEnv)
-	defer os.Unsetenv(RelatedImageTrustyAIService)
+	Describe("ResolveImage", func() {
+		Context("when environment variable is set", func() {
+			It("should use the environment variable value over ConfigMap", func() {
+				// Create a fake client with a ConfigMap containing an image
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testConfigMap,
+						Namespace: testNamespace,
+					},
+					Data: map[string]string{
+						TrustyAIServiceImageKey: testImageFromCM,
+					},
+				}
 
-	// Resolve the image
-	image, err := ResolveImage(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, testNamespace, "")
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
 
-	if err != nil {
-		t.Fatalf("Expected no error, got: %v", err)
-	}
+				// Set the environment variable
+				Expect(os.Setenv(RelatedImageTrustyAIService, testImageFromEnv)).To(Succeed())
 
-	// Should use env var value, not ConfigMap value
-	if image != testImageFromEnv {
-		t.Errorf("Expected image from env var %q, got %q", testImageFromEnv, image)
-	}
-}
+				// Resolve the image
+				image, err := ResolveImage(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, testNamespace, "")
 
-func TestResolveImage_EnvVarUnset_UsesConfigMap(t *testing.T) {
-	ctx := context.Background()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(image).To(Equal(testImageFromEnv))
+			})
+		})
 
-	// Create a fake client with a ConfigMap
-	configMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testConfigMap,
-			Namespace: testNamespace,
-		},
-		Data: map[string]string{
-			TrustyAIServiceImageKey: testImageFromCM,
-		},
-	}
+		Context("when environment variable is not set", func() {
+			It("should use ConfigMap value", func() {
+				// Create a fake client with a ConfigMap
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testConfigMap,
+						Namespace: testNamespace,
+					},
+					Data: map[string]string{
+						TrustyAIServiceImageKey: testImageFromCM,
+					},
+				}
 
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
 
-	// Ensure env var is NOT set
-	os.Unsetenv(RelatedImageTrustyAIService)
+				// Ensure env var is NOT set
+				cleanupEnvVars()
 
-	// Resolve the image
-	image, err := ResolveImage(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, testNamespace, "")
+				// Resolve the image
+				image, err := ResolveImage(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, testNamespace, "")
 
-	if err != nil {
-		t.Fatalf("Expected no error, got: %v", err)
-	}
+				Expect(err).NotTo(HaveOccurred())
+				Expect(image).To(Equal(testImageFromCM))
+			})
+		})
 
-	// Should use ConfigMap value
-	if image != testImageFromCM {
-		t.Errorf("Expected image from ConfigMap %q, got %q", testImageFromCM, image)
-	}
-}
+		Context("when environment variable is empty", func() {
+			It("should use ConfigMap value", func() {
+				// Create a fake client with a ConfigMap
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testConfigMap,
+						Namespace: testNamespace,
+					},
+					Data: map[string]string{
+						TrustyAIServiceImageKey: testImageFromCM,
+					},
+				}
 
-func TestResolveImage_EnvVarEmpty_UsesConfigMap(t *testing.T) {
-	ctx := context.Background()
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
 
-	// Create a fake client with a ConfigMap
-	configMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testConfigMap,
-			Namespace: testNamespace,
-		},
-		Data: map[string]string{
-			TrustyAIServiceImageKey: testImageFromCM,
-		},
-	}
+				// Set env var to empty string
+				Expect(os.Setenv(RelatedImageTrustyAIService, "")).To(Succeed())
 
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
+				// Resolve the image
+				image, err := ResolveImage(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, testNamespace, "")
 
-	// Set env var to empty string
-	os.Setenv(RelatedImageTrustyAIService, "")
-	defer os.Unsetenv(RelatedImageTrustyAIService)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(image).To(Equal(testImageFromCM))
+			})
+		})
 
-	// Resolve the image
-	image, err := ResolveImage(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, testNamespace, "")
+		Context("when neither env var nor ConfigMap are available", func() {
+			It("should use fallback value", func() {
+				// Create a fake client with NO ConfigMap
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	if err != nil {
-		t.Fatalf("Expected no error, got: %v", err)
-	}
+				// Ensure env var is NOT set
+				cleanupEnvVars()
 
-	// Should use ConfigMap value when env var is empty
-	if image != testImageFromCM {
-		t.Errorf("Expected image from ConfigMap %q, got %q", testImageFromCM, image)
-	}
-}
+				// Resolve the image with fallback
+				image, err := ResolveImage(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, testNamespace, testFallback)
 
-func TestResolveImage_NoEnvVar_NoConfigMap_UsesFallback(t *testing.T) {
-	ctx := context.Background()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(image).To(Equal(testFallback))
+			})
 
-	// Create a fake client with NO ConfigMap
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+			It("should return error when no fallback is provided", func() {
+				// Create a fake client with NO ConfigMap
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	// Ensure env var is NOT set
-	os.Unsetenv(RelatedImageTrustyAIService)
+				// Ensure env var is NOT set
+				cleanupEnvVars()
 
-	// Resolve the image with fallback
-	image, err := ResolveImage(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, testNamespace, testFallback)
+				// Resolve the image without fallback
+				_, err := ResolveImage(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, testNamespace, "")
 
-	if err != nil {
-		t.Fatalf("Expected no error, got: %v", err)
-	}
+				Expect(err).To(HaveOccurred())
+			})
+		})
 
-	// Should use fallback value
-	if image != testFallback {
-		t.Errorf("Expected fallback image %q, got %q", testFallback, image)
-	}
-}
+		Context("when ConfigMap exists but is missing the key", func() {
+			It("should use fallback value", func() {
+				// Create a ConfigMap without the expected key
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testConfigMap,
+						Namespace: testNamespace,
+					},
+					Data: map[string]string{
+						"some-other-key": "some-value",
+					},
+				}
 
-func TestResolveImage_NoEnvVar_NoConfigMap_NoFallback_ReturnsError(t *testing.T) {
-	ctx := context.Background()
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
 
-	// Create a fake client with NO ConfigMap
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+				// Ensure env var is NOT set
+				cleanupEnvVars()
 
-	// Ensure env var is NOT set
-	os.Unsetenv(RelatedImageTrustyAIService)
+				// Resolve the image with fallback
+				image, err := ResolveImage(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, testNamespace, testFallback)
 
-	// Resolve the image without fallback
-	_, err := ResolveImage(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, testNamespace, "")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(image).To(Equal(testFallback))
+			})
+		})
+	})
 
-	// Should return an error
-	if err == nil {
-		t.Fatal("Expected error when no env var, no ConfigMap, and no fallback, got nil")
-	}
-}
+	Describe("Image Mappings", func() {
+		It("should have all 10 expected image mappings", func() {
+			expectedMappings := map[string]string{
+				TrustyAIServiceImageKey:           RelatedImageTrustyAIService,
+				EvalHubImageKey:                   RelatedImageEvalHub,
+				KubeRBACProxyKey:                  RelatedImageKubeRBACProxy,
+				LMESPodImageKey:                   RelatedImageLMESJob,
+				LMESDriverImageKey:                RelatedImageLMESDriver,
+				GuardrailsOrchestratorImageKey:    RelatedImageGuardrailsOrchestrator,
+				GuardrailsBuiltInDetectorImageKey: RelatedImageBuiltInDetector,
+				GuardrailsSidecarGatewayImageKey:  RelatedImageVLLMOrchestratorGateway,
+				GarakProviderImageKey:             RelatedImageGarakLLSProviderDSP,
+				NemoGuardrailsImageKey:            RelatedImageNemoGuardrailsServer,
+			}
 
-func TestResolveImage_ConfigMapMissingKey_UsesFallback(t *testing.T) {
-	ctx := context.Background()
+			Expect(imageMapping).To(HaveLen(len(expectedMappings)))
 
-	// Create a ConfigMap without the expected key
-	configMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testConfigMap,
-			Namespace: testNamespace,
-		},
-		Data: map[string]string{
-			"some-other-key": "some-value",
-		},
-	}
+			for key, expectedEnvVar := range expectedMappings {
+				Expect(imageMapping).To(HaveKeyWithValue(key, expectedEnvVar))
+			}
+		})
+	})
 
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
+	Describe("Legacy Functions", func() {
+		Describe("GetImageFromConfigMap", func() {
+			It("should maintain backward compatibility", func() {
+				// Create a ConfigMap
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testConfigMap,
+						Namespace: testNamespace,
+					},
+					Data: map[string]string{
+						TrustyAIServiceImageKey: testImageFromCM,
+					},
+				}
 
-	// Ensure env var is NOT set
-	os.Unsetenv(RelatedImageTrustyAIService)
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
 
-	// Resolve the image with fallback
-	image, err := ResolveImage(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, testNamespace, testFallback)
+				// Ensure env var is NOT set
+				cleanupEnvVars()
 
-	if err != nil {
-		t.Fatalf("Expected no error, got: %v", err)
-	}
+				// Call the legacy function
+				image, err := GetImageFromConfigMap(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, testNamespace)
 
-	// Should use fallback when key is missing
-	if image != testFallback {
-		t.Errorf("Expected fallback image %q, got %q", testFallback, image)
-	}
-}
+				Expect(err).NotTo(HaveOccurred())
+				Expect(image).To(Equal(testImageFromCM))
+			})
+		})
 
-func TestResolveImage_AllImageMappings(t *testing.T) {
-	// Test that all 10 image mappings are correctly defined
-	expectedMappings := map[string]string{
-		TrustyAIServiceImageKey:           RelatedImageTrustyAIService,
-		EvalHubImageKey:                   RelatedImageEvalHub,
-		KubeRBACProxyKey:                  RelatedImageKubeRBACProxy,
-		LMESPodImageKey:                   RelatedImageLMESJob,
-		LMESDriverImageKey:                RelatedImageLMESDriver,
-		GuardrailsOrchestratorImageKey:    RelatedImageGuardrailsOrchestrator,
-		GuardrailsBuiltInDetectorImageKey: RelatedImageBuiltInDetector,
-		GuardrailsSidecarGatewayImageKey:  RelatedImageVLLMOrchestratorGateway,
-		GarakProviderImageKey:             RelatedImageGarakLLSProviderDSP,
-		NemoGuardrailsImageKey:            RelatedImageNemoGuardrailsServer,
-	}
+		Describe("GetImageFromConfigMapWithFallback", func() {
+			It("should use fallback when ConfigMap is missing", func() {
+				// Create a fake client with NO ConfigMap
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	if len(imageMapping) != len(expectedMappings) {
-		t.Errorf("Expected %d image mappings, got %d", len(expectedMappings), len(imageMapping))
-	}
+				// Ensure env var is NOT set
+				cleanupEnvVars()
 
-	for key, expectedEnvVar := range expectedMappings {
-		actualEnvVar, ok := imageMapping[key]
-		if !ok {
-			t.Errorf("Missing mapping for key %q", key)
-			continue
-		}
-		if actualEnvVar != expectedEnvVar {
-			t.Errorf("For key %q: expected env var %q, got %q", key, expectedEnvVar, actualEnvVar)
-		}
-	}
-}
+				// Call the legacy function with fallback
+				image, err := GetImageFromConfigMapWithFallback(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, testNamespace, testFallback)
 
-func TestGetImageFromConfigMap_BackwardCompatibility(t *testing.T) {
-	ctx := context.Background()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(image).To(Equal(testFallback))
+			})
 
-	// Create a ConfigMap
-	configMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testConfigMap,
-			Namespace: testNamespace,
-		},
-		Data: map[string]string{
-			TrustyAIServiceImageKey: testImageFromCM,
-		},
-	}
+			It("should return fallback immediately when namespace is empty", func() {
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(configMap).Build()
+				// When namespace is empty, should return fallback immediately
+				image, err := GetImageFromConfigMapWithFallback(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, "", testFallback)
 
-	// Ensure env var is NOT set
-	os.Unsetenv(RelatedImageTrustyAIService)
-
-	// Call the legacy function
-	image, err := GetImageFromConfigMap(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, testNamespace)
-
-	if err != nil {
-		t.Fatalf("Expected no error, got: %v", err)
-	}
-
-	if image != testImageFromCM {
-		t.Errorf("Expected image %q, got %q", testImageFromCM, image)
-	}
-}
-
-func TestGetImageFromConfigMapWithFallback_BackwardCompatibility(t *testing.T) {
-	ctx := context.Background()
-
-	// Create a fake client with NO ConfigMap
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-
-	// Ensure env var is NOT set
-	os.Unsetenv(RelatedImageTrustyAIService)
-
-	// Call the legacy function with fallback
-	image, err := GetImageFromConfigMapWithFallback(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, testNamespace, testFallback)
-
-	if err != nil {
-		t.Fatalf("Expected no error, got: %v", err)
-	}
-
-	if image != testFallback {
-		t.Errorf("Expected fallback image %q, got %q", testFallback, image)
-	}
-}
-
-func TestGetImageFromConfigMapWithFallback_EmptyNamespace(t *testing.T) {
-	ctx := context.Background()
-
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-
-	// When namespace is empty, should return fallback immediately
-	image, err := GetImageFromConfigMapWithFallback(ctx, fakeClient, TrustyAIServiceImageKey, testConfigMap, "", testFallback)
-
-	if err != nil {
-		t.Fatalf("Expected no error, got: %v", err)
-	}
-
-	if image != testFallback {
-		t.Errorf("Expected fallback image %q, got %q", testFallback, image)
-	}
-}
+				Expect(err).NotTo(HaveOccurred())
+				Expect(image).To(Equal(testFallback))
+			})
+		})
+	})
+})

--- a/controllers/images/suite_test.go
+++ b/controllers/images/suite_test.go
@@ -1,0 +1,39 @@
+package images
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+// Test constants
+const (
+	testNamespace    = "test-namespace"
+	testConfigMap    = "test-configmap"
+	testImageFromCM  = "quay.io/trustyai/service:from-configmap"
+	testImageFromEnv = "quay.io/trustyai/service:from-env-var"
+	testFallback     = "quay.io/trustyai/service:fallback"
+)
+
+var (
+	ctx    context.Context
+	scheme *runtime.Scheme
+)
+
+func TestImages(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Images Resolver Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	ctx = context.Background()
+	scheme = runtime.NewScheme()
+	Expect(corev1.AddToScheme(scheme)).To(Succeed())
+})

--- a/controllers/lmes/config.go
+++ b/controllers/lmes/config.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/trustyai-explainability/trustyai-service-operator/controllers/dsc"
+	"github.com/trustyai-explainability/trustyai-service-operator/controllers/images"
 	"github.com/trustyai-explainability/trustyai-service-operator/controllers/lmes/driver"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -116,6 +117,26 @@ func constructOptionsFromConfigMap(log *logr.Logger, configmap *corev1.ConfigMap
 	if len(msgs) > 0 && log != nil {
 		log.Error(fmt.Errorf("some settings in the configmap are invalid"), strings.Join(msgs, "\n"))
 	}
+
+	return nil
+}
+
+// resolveImageOptions resolves PodImage and DriverImage using the centralized image resolver
+// This checks RELATED_IMAGE_* env vars first, then falls back to ConfigMap values
+func resolveImageOptions(ctx context.Context, c client.Client, configMapName, namespace string) error {
+	// Resolve pod image (env var → configmap → default)
+	podImage, err := images.ResolveImage(ctx, c, images.LMESPodImageKey, configMapName, namespace, DefaultPodImage)
+	if err != nil {
+		return fmt.Errorf("resolving LMES pod image: %w", err)
+	}
+	Options.PodImage = podImage
+
+	// Resolve driver image (env var → configmap → default)
+	driverImage, err := images.ResolveImage(ctx, c, images.LMESDriverImageKey, configMapName, namespace, DefaultDriverImage)
+	if err != nil {
+		return fmt.Errorf("resolving LMES driver image: %w", err)
+	}
+	Options.DriverImage = driverImage
 
 	return nil
 }

--- a/controllers/lmes/lmevaljob_controller.go
+++ b/controllers/lmes/lmevaljob_controller.go
@@ -314,6 +314,12 @@ func (r *LMEvalJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}
 		log.Info("Constructed options from configmap", "options", Options)
 
+		// Resolve images using centralized resolver (RELATED_IMAGE_* env vars → ConfigMap → defaults)
+		if err := resolveImageOptions(ctx, r.Client, r.ConfigMap, r.Namespace); err != nil {
+			return err
+		}
+		log.Info("Resolved images", "podImage", Options.PodImage, "driverImage", Options.DriverImage)
+
 		// Read DSC configuration if available
 		dscReader := dsc.NewDSCConfigReader(r.Client, r.Namespace)
 		if dscConfig, err := dscReader.ReadDSCConfig(ctx, &log); err != nil {

--- a/controllers/nemo_guardrails/deployment.go
+++ b/controllers/nemo_guardrails/deployment.go
@@ -9,6 +9,7 @@ import (
 
 	nemoguardrailsv1alpha1 "github.com/trustyai-explainability/trustyai-service-operator/api/nemo_guardrails/v1alpha1"
 	"github.com/trustyai-explainability/trustyai-service-operator/controllers/constants"
+	"github.com/trustyai-explainability/trustyai-service-operator/controllers/images"
 	templateParser "github.com/trustyai-explainability/trustyai-service-operator/controllers/nemo_guardrails/templates"
 	"github.com/trustyai-explainability/trustyai-service-operator/controllers/utils"
 	appsv1 "k8s.io/api/apps/v1"
@@ -38,13 +39,13 @@ func GetRBACConfigName(nemoGuardrails nemoguardrailsv1alpha1.NemoGuardrails) str
 
 // setAuthConfig will create a KubeRBACProxyConfig inside the DeploymentConfig for use in template parsing
 func (r *NemoGuardrailsReconciler) setAuthConfig(ctx context.Context, nemoGuardrails *nemoguardrailsv1alpha1.NemoGuardrails, deploymentConfig *DeploymentConfig) error {
-	// ==== get kube-rbac-proxy image from trustyai configmap ===========================================================
-	authImage, err := utils.GetImageFromConfigMap(ctx, r.Client, configMapKubeRBACProxyImageKey, constants.ConfigMap, r.Namespace)
+	// ==== get kube-rbac-proxy image from env var or configmap ===========================================================
+	authImage, err := images.GetImageFromConfigMap(ctx, r.Client, configMapKubeRBACProxyImageKey, constants.ConfigMap, r.Namespace)
 	if err != nil {
-		utils.LogErrorRetrieving(ctx, err, "oauth image from configmap", constants.ConfigMap, r.Namespace)
+		utils.LogErrorRetrieving(ctx, err, "oauth image from env var or configmap", constants.ConfigMap, r.Namespace)
 		return err
 	}
-	log.FromContext(ctx).Info("using AuthProxyImage " + authImage + " " + "from config map " + r.Namespace + ":" + constants.ConfigMap)
+	log.FromContext(ctx).Info("using AuthProxyImage " + authImage)
 
 	deploymentConfig.KubeRbacProxyConfig = &utils.KubeRBACProxyConfig{
 		Suffix:             "",
@@ -149,10 +150,10 @@ func (r *NemoGuardrailsReconciler) mountNemoConfigs(ctx context.Context, nemoGua
 func (r *NemoGuardrailsReconciler) createDeployment(ctx context.Context, nemoGuardrails *nemoguardrailsv1alpha1.NemoGuardrails, caBundleInitContainerConfig utils.CABundleInitContainerConfig, configMapsToMount []corev1.ConfigMap) (*appsv1.Deployment, error) {
 	var containerImages ContainerImages
 
-	// ==== get nemo guardrails image from trustyai configmap ===========================================================
-	nemoGuardrailsImage, err := utils.GetImageFromConfigMap(ctx, r.Client, nemoGuardrailsImageKey, constants.ConfigMap, r.Namespace)
+	// ==== get nemo guardrails image from env var or configmap ===========================================================
+	nemoGuardrailsImage, err := images.GetImageFromConfigMap(ctx, r.Client, nemoGuardrailsImageKey, constants.ConfigMap, r.Namespace)
 	if err != nil {
-		utils.LogErrorRetrieving(ctx, err, "nemo-guardrails image from configmap", constants.ConfigMap, r.Namespace)
+		utils.LogErrorRetrieving(ctx, err, "nemo-guardrails image from env var or configmap", constants.ConfigMap, r.Namespace)
 		return nil, err
 	}
 	if nemoGuardrailsImage == "" {

--- a/controllers/tas/deployment.go
+++ b/controllers/tas/deployment.go
@@ -2,6 +2,7 @@ package tas
 
 import (
 	"context"
+	"github.com/trustyai-explainability/trustyai-service-operator/controllers/images"
 	"github.com/trustyai-explainability/trustyai-service-operator/controllers/utils"
 	"reflect"
 	"strconv"
@@ -56,10 +57,10 @@ func (r *TrustyAIServiceReconciler) createDeploymentObject(ctx context.Context, 
 	}
 
 	pvcName := generatePVCName(instance)
-	// Get Kube-RBAC-proxy image from ConfigMap
-	kubeRBACProxyImage, err := utils.GetImageFromConfigMapWithFallback(ctx, r.Client, configMapKubeRBACProxyImageKey, constants.ConfigMap, r.Namespace, defaultKubeRBACProxyImage)
+	// Get Kube-RBAC-proxy image (env var first, then ConfigMap)
+	kubeRBACProxyImage, err := images.ResolveImage(ctx, r.Client, configMapKubeRBACProxyImageKey, constants.ConfigMap, r.Namespace, defaultKubeRBACProxyImage)
 	if err != nil {
-		log.FromContext(ctx).Error(err, "Error getting Kube-RBAC-Proxy image from ConfigMap. Using the default image value of "+defaultKubeRBACProxyImage)
+		log.FromContext(ctx).Error(err, "Error resolving Kube-RBAC-Proxy image. Using the default image value of "+defaultKubeRBACProxyImage)
 	}
 
 	deploymentConfig := DeploymentConfig{
@@ -174,12 +175,12 @@ func (r *TrustyAIServiceReconciler) updateDeployment(ctx context.Context, cr *tr
 
 func (r *TrustyAIServiceReconciler) ensureDeployment(ctx context.Context, instance *trustyaiopendatahubiov1alpha1.TrustyAIService, caBundle CustomCertificatesBundle, migration bool) error {
 
-	// Get image and tag from ConfigMap
+	// Get image from env var or ConfigMap
 	// If there's a ConfigMap with custom images, it is only applied when the operator is first deployed
 	// Changing (or creating) the ConfigMap after the operator is deployed will not have any effect
-	image, err := utils.GetImageFromConfigMapWithFallback(ctx, r.Client, configMapServiceImageKey, constants.ConfigMap, r.Namespace, defaultImage)
+	image, err := images.ResolveImage(ctx, r.Client, configMapServiceImageKey, constants.ConfigMap, r.Namespace, defaultImage)
 	if err != nil {
-		log.FromContext(ctx).Error(err, "Error getting TrustyAI Service image from ConfigMap. Using the default image value of "+defaultImage)
+		log.FromContext(ctx).Error(err, "Error resolving TrustyAI Service image. Using the default image value of "+defaultImage)
 	}
 
 	deploy := &appsv1.Deployment{}


### PR DESCRIPTION
Related to: https://redhat.atlassian.net/browse/RHOAIENG-67658 
Add unified image resolver that checks RELATED_IMAGE_ODH_* environment variables first, then falls back to ConfigMap values. This enables the modular architecture where the ODH platform operator injects image references via ClusterServiceVersion env vars, while maintaining backward compatibility with ConfigMap-based resolution.

Mapping of 10 operand images:
- trustyaiServiceImage → RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE
- evalHubImage → RELATED_IMAGE_ODH_EVAL_HUB_IMAGE
- kube-rbac-proxy → RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE
- lmes-pod-image → RELATED_IMAGE_ODH_TA_LMES_JOB_IMAGE
- lmes-driver-image → RELATED_IMAGE_ODH_TA_LMES_DRIVER_IMAGE
- guardrails-orchestrator-image → RELATED_IMAGE_ODH_FMS_GUARDRAILS_ORCHESTRATOR_IMAGE
- guardrails-built-in-detector-image → RELATED_IMAGE_ODH_BUILT_IN_DETECTOR_IMAGE
- guardrails-sidecar-gateway-image → RELATED_IMAGE_ODH_TRUSTYAI_VLLM_ORCHESTRATOR_GATEWAY_IMAGE
- garak-provider-image → RELATED_IMAGE_ODH_TRUSTYAI_GARAK_LLS_PROVIDER_DSP_IMAGE
- nemo-guardrails-image → RELATED_IMAGE_ODH_TRUSTYAI_NEMO_GUARDRAILS_SERVER_IMAGE

Changes:
- New package: controllers/images (133 lines)
  - resolver.go: ResolveImage() with env-var-first logic
  - resolver_test.go: 10 unit tests (100% coverage)
- Updated 6 controller files with 10 call sites:
  - tas/deployment.go (2 call sites)
  - gorch/deployment.go (3 call sites)
  - gorch/auth.go (1 call site)
  - evalhub/deployment.go (1 call site)
  - evalhub/configmap.go (1 private method refactored)
  - nemo_guardrails/deployment.go (2 call sites)

Acceptance criteria met:
✅ controllers/images/resolver.go created with env-var-first logic ✅ Unit tests with 100% coverage
✅ All controller image lookups use new resolver
✅ If env var is set, ConfigMap value is ignored
✅ If env var is unset, ConfigMap fallback works as before

Part of: [RHOAIENG-60939](https://redhat.atlassian.net/browse/RHOAIENG-60939) (TrustyAI modular architecture migration)
Implements: [GAP-02](https://redhat.atlassian.net/browse/GAP-02) from [RHOAIENG-66846](https://redhat.atlassian.net/browse/RHOAIENG-66846)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added centralized image resolution that supports environment-variable overrides with ConfigMap fallback (and optional fallback defaults), covering all major controller image keys.

* **Bug Fixes**
  * Improved “fail fast” behavior and error clarity when required images can’t be resolved, including the guardrails sidecar gateway.

* **Chores**
  * Updated controller deployments/manifests to wire related image environment variables and ConfigMap-backed configuration.
  * Expanded test coverage for the resolver (including legacy helper compatibility and precedence rules).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->