### PR TITLE
fix(evalhub): change metrics port from 9090 to 8081

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -58,7 +58,7 @@ flowchart TB
 
     subgraph evalhub_pod["EvalHub Pod(s)"]
         evalhub_svc["EvalHub Service\n(REST API, job management)"]
-        evalhub_metrics["Metrics server\n(port 9090, plain HTTP)"]
+        evalhub_metrics["Metrics server\n(port 8081, plain HTTP)"]
     end
 
     subgraph gorch_pod["Guardrails Orchestrator Pod(s)"]
@@ -316,7 +316,7 @@ sequenceDiagram
 
     EH->>K8sAPI: Create Deployment (mount providers + collections)
     EH->>K8sAPI: Create API Service (port 8443, HTTPS via kube-rbac-proxy)
-    EH->>K8sAPI: Create metrics Service (port 9090, plain HTTP, cluster-internal)
+    EH->>K8sAPI: Create metrics Service (port 8081, plain HTTP, cluster-internal)
     EH->>K8sAPI: Create Route
 
     opt ServiceMonitor CRD available

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,9 +151,9 @@ All controllers follow the standard loop:
 
 ### EvalHub Metrics Architecture
 
-EvalHub exposes Prometheus metrics on a **dedicated port (9090)** bound to `0.0.0.0`, separate from the API (port 8444, loopback only, behind kube-rbac-proxy on 8443). The operator creates:
+EvalHub exposes Prometheus metrics on a **dedicated port (8081)** bound to `0.0.0.0`, separate from the API (port 8444, loopback only, behind kube-rbac-proxy on 8443). The operator creates:
 
-- A **metrics Service** (`<name>-metrics`, ClusterIP, port 9090, no TLS) — `metrics_service.go`
+- A **metrics Service** (`<name>-metrics`, ClusterIP, port 8081, no TLS) — `metrics_service.go`
 - A **ServiceMonitor** targeting the metrics Service over plain HTTP — `servicemonitor.go`
 
 The metrics port requires no authentication, is cluster-internal only (no Route), and is reachable by Prometheus via existing namespace NetworkPolicies. The `METRICS_PORT` and `METRICS_HOST` env vars are set on the EvalHub container and protected from CR overrides.

--- a/controllers/evalhub/constants.go
+++ b/controllers/evalhub/constants.go
@@ -27,7 +27,9 @@ const (
 	servicePort = 8443
 	// metricsPort is the dedicated Prometheus metrics port on the EvalHub container.
 	// Bound to 0.0.0.0, serves /metrics over plain HTTP with no auth (cluster-internal only).
-	metricsPort = 9090
+	// Port 8081 is used (not 9090) because the redhat-ods-applications namespace NetworkPolicy
+	// allowlists 8081 but not 9090, avoiding the need for a component-level NetworkPolicy.
+	metricsPort = 8081
 
 	// kube-rbac-proxy sidecar
 	kubeRBACProxyContainerName       = "kube-rbac-proxy"


### PR DESCRIPTION
## What and why

Changes the EvalHub dedicated metrics port from 9090 to 8081.

Port 9090 is not in the `redhat-ods-applications` namespace NetworkPolicy allowlist, which would block Prometheus scraping when EvalHub is deployed in that namespace. Port 8081 is already in the allowlist alongside the other standard ODH component ports (8080, 8443, etc.), so no component-level NetworkPolicy is required.

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [ ] Tested manually

## Breaking changes

The metrics Service (`<name>-metrics`) now exposes port 8081 instead of 9090. Any existing Prometheus scrape configs or ServiceMonitors that hardcode port 9090 must be updated. The ServiceMonitor created by the operator already targets the named port (`metrics`), so operator-managed monitoring is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated EvalHub metrics documentation and architecture diagrams to reflect the metrics endpoint port configuration.

* **Chores**
  * Updated metrics port configuration value to align with cluster network policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->