### PR TITLE
fix(evalhub): grant operator hardwareprofiles RBAC permission

### DIFF
--- a/config/components/evalhub/rbac/manager-rbac.yaml
+++ b/config/components/evalhub/rbac/manager-rbac.yaml
@@ -5,6 +5,61 @@ metadata:
   name: evalhub-manager-role
 rules:
 - apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - workloads
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+- apiGroups:
+  - trustyai.opendatahub.io
+  resources:
+  - evalhubs
+  verbs:
+  - get
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - trustyai.opendatahub.io
+  resources:
+  - evalhubs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - trustyai.opendatahub.io
   resources:
   - evalhubs
@@ -171,57 +226,9 @@ rules:
   - patch
   - delete
 - apiGroups:
-  - batch
+  - infrastructure.opendatahub.io
   resources:
-  - jobs
+  - hardwareprofiles
   verbs:
   - get
   - list
-  - watch
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - trustyai.opendatahub.io
-  resources:
-  - evalhubs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - kueue.x-k8s.io
-  resources:
-  - workloads
-  verbs:
-  - get
-  - list
-  - watch
-  - patch
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  verbs:
-  - get
-- apiGroups:
-  - trustyai.opendatahub.io
-  resources:
-  - evalhubs
-  verbs:
-  - get

--- a/controllers/evalhub/evalhub_controller.go
+++ b/controllers/evalhub/evalhub_controller.go
@@ -65,6 +65,7 @@ type EvalHubReconciler struct {
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch;update
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=infrastructure.opendatahub.io,resources=hardwareprofiles,verbs=get;list
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
## What and why

The operator creates a RoleBinding granting the EvalHub service account read access to HardwareProfile CRs in the instance namespace. However, the operator's own ClusterRole did not include infrastructure.opendatahub.io/hardwareprofiles. Kubernetes rejects any attempt to grant permissions the grantor does not itself hold, leaving EvalHub CRs stuck in Pending with:

```
  rolebindings.rbac.authorization.k8s.io "evalhub-hardware-profiles-reader-rb" is forbidden:
  user "system:serviceaccount:opendatahub:trustyai-service-operator-controller-manager"
  is attempting to grant RBAC permissions not currently held:
  {APIGroups:["infrastructure.opendatahub.io"], Resources:["hardwareprofiles"], Verbs:["get" "list"]}
```

Adds the missing +kubebuilder:rbac marker to evalhub_controller.go and the corresponding rule to config/components/evalhub/rbac/manager-rbac.yaml.

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

## Breaking changes

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated system permissions configuration for improved resource access management
* Enhanced authorization rules to optimize system operation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->