### PR TITLE
feat(policy): add ClusterRole content inspection to conftest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,7 @@ make policy-check   # Full check against all overlays
 
 **Current policies:**
 - `policy/rbac.rego` — closed allowlist of expected `ClusterRoleBinding` resources. Any CRB not in `expected_crbs` or binding the wrong `ClusterRole` is denied.
-- `policy/clusterrole.rego` — inspects ClusterRole **contents**: (1) closed allowlist of permitted `(apiGroup, resource)` pairs, (2) denylist blocking wildcards, secrets write, privilege escalation verbs.
+- `policy/clusterrole.rego` — inspects ClusterRole **contents**: (1) closed allowlist of permitted `(apiGroup, resource)` pairs, (2) denylist blocking wildcards, secrets write, privilege escalation verbs. Manager roles that legitimately need secrets or CRB write (TAS, GORCH, nemo-guardrails, evalhub) are exempt by name suffix — see `policy/README.md` for the full exemption list.
 
 **When adding RBAC resources:**
 - If you add a new `ClusterRoleBinding` (e.g. in a component's `rbac/` directory), you must add its post-kustomize name and expected `ClusterRole` to `expected_crbs` in `policy/rbac.rego`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,9 +234,11 @@ make policy-check   # Full check against all overlays
 
 **Current policies:**
 - `policy/rbac.rego` — closed allowlist of expected `ClusterRoleBinding` resources. Any CRB not in `expected_crbs` or binding the wrong `ClusterRole` is denied.
+- `policy/clusterrole.rego` — inspects ClusterRole **contents**: (1) closed allowlist of permitted `(apiGroup, resource)` pairs, (2) denylist blocking wildcards, secrets write, privilege escalation verbs.
 
 **When adding RBAC resources:**
 - If you add a new `ClusterRoleBinding` (e.g. in a component's `rbac/` directory), you must add its post-kustomize name and expected `ClusterRole` to `expected_crbs` in `policy/rbac.rego`.
+- If you add a new `(apiGroup, resource)` pair to any ClusterRole, you must add it to `allowed_api_resources` in `policy/clusterrole.rego`.
 - Overlays that apply `namePrefix: trustyai-service-operator-` produce prefixed names; `base` and `evalhub-only` produce un-prefixed names. Both must be allowlisted if applicable.
 - Run `make policy-check` locally before pushing.
 

--- a/policy/README.md
+++ b/policy/README.md
@@ -26,6 +26,10 @@ Validates the **contents** of every `ClusterRole` in the rendered manifests usin
    - Write verbs on `clusterroles` or `clusterrolebindings` (privilege escalation)
    - Escalation verbs: `escalate`, `bind`, `impersonate`
 
+   **Exemptions** (matched by role name suffix):
+   - *Secrets write:* `tas-manager-role`, `gorch-manager-role`, `nemo-guardrails-manager-role` — these managers create/manage TLS certificates and service credentials for their workloads.
+   - *ClusterRoleBindings write:* `tas-manager-role`, `evalhub-manager-role`, `nemo-guardrails-manager-role` — these managers create CRBs to bind service accounts to component-specific roles.
+
 ## Adding a new ClusterRole permission
 
 If your change adds a new `(apiGroup, resource)` pair to any ClusterRole:

--- a/policy/README.md
+++ b/policy/README.md
@@ -15,6 +15,25 @@ Prevents accidental cluster-wide privilege escalation by maintaining a closed al
 
 **Tested overlays:** `base`, `odh`, `rhoai`, `lmes`, `odh-kueue`, `testing`, `dev`, `evalhub-only`, `mcp-guardrails`.
 
+### `clusterrole.rego` — ClusterRole content inspection
+
+Validates the **contents** of every `ClusterRole` in the rendered manifests using two layers:
+
+1. **Allowlist.** A closed set of `(apiGroup, resource)` pairs. Any rule that references an `(apiGroup, resource)` pair not in `allowed_api_resources` is denied. This catches cases where a developer adds permissions to a new API group without review.
+2. **Denylist.** Blocks dangerous patterns regardless of allowlist status:
+   - Wildcard `"*"` in apiGroups, resources, or verbs
+   - Write verbs (`create`, `update`, `patch`, `delete`, `deletecollection`) on `secrets`
+   - Write verbs on `clusterroles` or `clusterrolebindings` (privilege escalation)
+   - Escalation verbs: `escalate`, `bind`, `impersonate`
+
+## Adding a new ClusterRole permission
+
+If your change adds a new `(apiGroup, resource)` pair to any ClusterRole:
+
+1. Add the `[apiGroup, resource]` tuple to `allowed_api_resources` in `policy/clusterrole.rego`.
+2. Run `make policy-check` locally to verify.
+3. Explain in the PR description why the new permission is needed.
+
 ## Adding a new ClusterRoleBinding
 
 If your change legitimately introduces a new `ClusterRoleBinding`:

--- a/policy/clusterrole.rego
+++ b/policy/clusterrole.rego
@@ -66,6 +66,9 @@ allowed_api_resources := {
 	["kueue.x-k8s.io", "workloads/status"],
 	["kueue.x-k8s.io", "workloadpriorityclasses"],
 
+	# --- infrastructure ---
+	["infrastructure.opendatahub.io", "hardwareprofiles"],
+
 	# --- mlflow ---
 	["mlflow.kubeflow.org", "experiments"],
 

--- a/policy/clusterrole.rego
+++ b/policy/clusterrole.rego
@@ -1,0 +1,223 @@
+package rbac
+
+import rego.v1
+
+# Closed allowlist of (apiGroup, resource) pairs permitted in ClusterRole
+# rules across all kustomize overlays.
+#
+# To add a new permission, add the pair here and explain why in the PR.
+
+allowed_api_resources := {
+	# --- core ---
+	["", "configmaps"],
+	["", "events"],
+	["", "namespaces"],
+	["", "persistentvolumeclaims"],
+	["", "persistentvolumes"],
+	["", "pods"],
+	["", "pods/exec"],
+	["", "secrets"],
+	["", "serviceaccounts"],
+	["", "services"],
+
+	# --- apps ---
+	["apps", "deployments"],
+	["apps", "deployments/finalizers"],
+	["apps", "deployments/status"],
+
+	# --- batch ---
+	["batch", "jobs"],
+
+	# --- coordination ---
+	["coordination.k8s.io", "leases"],
+
+	# --- scheduling ---
+	["scheduling.k8s.io", "priorityclasses"],
+
+	# --- apiextensions ---
+	["apiextensions.k8s.io", "customresourcedefinitions"],
+
+	# --- auth ---
+	["authentication.k8s.io", "tokenreviews"],
+	["authorization.k8s.io", "subjectaccessreviews"],
+
+	# --- RBAC ---
+	["rbac.authorization.k8s.io", "clusterrolebindings"],
+	["rbac.authorization.k8s.io", "roles"],
+	["rbac.authorization.k8s.io", "rolebindings"],
+
+	# --- networking / routes ---
+	["networking.istio.io", "destinationrules"],
+	["networking.istio.io", "virtualservices"],
+	["route.openshift.io", "routes"],
+
+	# --- monitoring ---
+	["monitoring.coreos.com", "servicemonitors"],
+
+	# --- kserve ---
+	["serving.kserve.io", "inferenceservices"],
+	["serving.kserve.io", "inferenceservices/finalizers"],
+	["serving.kserve.io", "servingruntimes"],
+
+	# --- kueue ---
+	["kueue.x-k8s.io", "resourceflavors"],
+	["kueue.x-k8s.io", "workloads"],
+	["kueue.x-k8s.io", "workloads/finalizers"],
+	["kueue.x-k8s.io", "workloads/status"],
+	["kueue.x-k8s.io", "workloadpriorityclasses"],
+
+	# --- mlflow ---
+	["mlflow.kubeflow.org", "experiments"],
+
+	# --- trustyai ---
+	["trustyai.opendatahub.io", "collections"],
+	["trustyai.opendatahub.io", "evalhubs"],
+	["trustyai.opendatahub.io", "evalhubs/finalizers"],
+	["trustyai.opendatahub.io", "evalhubs/proxy"],
+	["trustyai.opendatahub.io", "evalhubs/status"],
+	["trustyai.opendatahub.io", "guardrailsorchestrators"],
+	["trustyai.opendatahub.io", "guardrailsorchestrators/finalizers"],
+	["trustyai.opendatahub.io", "guardrailsorchestrators/status"],
+	["trustyai.opendatahub.io", "lmevaljobs"],
+	["trustyai.opendatahub.io", "lmevaljobs/finalizers"],
+	["trustyai.opendatahub.io", "lmevaljobs/status"],
+	["trustyai.opendatahub.io", "nemoguardrails"],
+	["trustyai.opendatahub.io", "nemoguardrails/finalizers"],
+	["trustyai.opendatahub.io", "nemoguardrails/status"],
+	["trustyai.opendatahub.io", "providers"],
+	["trustyai.opendatahub.io", "status-events"],
+	["trustyai.opendatahub.io", "trustyaiservices"],
+	["trustyai.opendatahub.io", "trustyaiservices/finalizers"],
+	["trustyai.opendatahub.io", "trustyaiservices/status"],
+}
+
+# Layer 1: deny unknown (apiGroup, resource) pairs in ClusterRole rules.
+
+deny contains msg if {
+	input.kind == "ClusterRole"
+	rule := input.rules[i]
+	group := rule.apiGroups[_]
+	res := rule.resources[_]
+	group != "*"
+	res != "*"
+	not allowed_api_resources[[group, res]]
+	msg := sprintf(
+		"RBAC VIOLATION: ClusterRole '%s' requests (%s, %s) which is not in the allowlist. Add to policy/clusterrole.rego if intentional.",
+		[input.metadata.name, group, res],
+	)
+}
+
+# Layer 2: deny wildcard apiGroups.
+
+deny contains msg if {
+	input.kind == "ClusterRole"
+	rule := input.rules[_]
+	"*" in rule.apiGroups
+	msg := sprintf(
+		"RBAC VIOLATION: ClusterRole '%s' uses wildcard apiGroup '*'.",
+		[input.metadata.name],
+	)
+}
+
+# Layer 2: deny wildcard resources.
+
+deny contains msg if {
+	input.kind == "ClusterRole"
+	rule := input.rules[_]
+	"*" in rule.resources
+	msg := sprintf(
+		"RBAC VIOLATION: ClusterRole '%s' uses wildcard resource '*'.",
+		[input.metadata.name],
+	)
+}
+
+# Layer 2: deny wildcard verbs.
+
+deny contains msg if {
+	input.kind == "ClusterRole"
+	rule := input.rules[_]
+	"*" in rule.verbs
+	msg := sprintf(
+		"RBAC VIOLATION: ClusterRole '%s' uses wildcard verb '*'.",
+		[input.metadata.name],
+	)
+}
+
+# Layer 2: deny write verbs on secrets.
+#
+# Exempt roles are manager roles that legitimately create/manage secrets
+# for TLS certificates or service credentials in their managed workloads.
+
+write_verbs := {"create", "update", "patch", "delete", "deletecollection"}
+
+secrets_write_exempt_suffixes := {
+	"tas-manager-role",
+	"gorch-manager-role",
+	"nemo-guardrails-manager-role",
+}
+
+is_secrets_write_exempt(name) if {
+	some suffix in secrets_write_exempt_suffixes
+	endswith(name, suffix)
+}
+
+deny contains msg if {
+	input.kind == "ClusterRole"
+	not is_secrets_write_exempt(input.metadata.name)
+	rule := input.rules[i]
+	"" in rule.apiGroups
+	"secrets" in rule.resources
+	verb := rule.verbs[_]
+	write_verbs[verb]
+	msg := sprintf(
+		"RBAC VIOLATION: ClusterRole '%s' has write verb '%s' on secrets.",
+		[input.metadata.name, verb],
+	)
+}
+
+# Layer 2: deny write verbs on clusterroles / clusterrolebindings.
+#
+# Exempt roles are manager roles that create CRBs for their managed
+# workloads (e.g. binding service accounts to component-specific roles).
+
+crb_write_exempt_suffixes := {
+	"tas-manager-role",
+	"evalhub-manager-role",
+	"nemo-guardrails-manager-role",
+}
+
+is_crb_write_exempt(name) if {
+	some suffix in crb_write_exempt_suffixes
+	endswith(name, suffix)
+}
+
+deny contains msg if {
+	input.kind == "ClusterRole"
+	not is_crb_write_exempt(input.metadata.name)
+	rule := input.rules[i]
+	"rbac.authorization.k8s.io" in rule.apiGroups
+	escalation_target := {"clusterroles", "clusterrolebindings"}
+	res := rule.resources[_]
+	escalation_target[res]
+	verb := rule.verbs[_]
+	write_verbs[verb]
+	msg := sprintf(
+		"RBAC VIOLATION: ClusterRole '%s' has write verb '%s' on %s (privilege escalation).",
+		[input.metadata.name, verb, res],
+	)
+}
+
+# Layer 2: deny escalation verbs.
+
+escalation_verbs := {"escalate", "bind", "impersonate"}
+
+deny contains msg if {
+	input.kind == "ClusterRole"
+	rule := input.rules[_]
+	verb := rule.verbs[_]
+	escalation_verbs[verb]
+	msg := sprintf(
+		"RBAC VIOLATION: ClusterRole '%s' uses escalation verb '%s'.",
+		[input.metadata.name, verb],
+	)
+}

--- a/policy/clusterrole_test.rego
+++ b/policy/clusterrole_test.rego
@@ -1,0 +1,198 @@
+package rbac
+
+import rego.v1
+
+# --- Layer 1: allowlist ---
+
+test_known_api_resource_passes if {
+	count(deny) == 0 with input as {
+		"kind": "ClusterRole",
+		"metadata": {"name": "test-role"},
+		"rules": [{"apiGroups": ["apps"], "resources": ["deployments"], "verbs": ["get", "list"]}],
+	}
+}
+
+test_unknown_api_resource_denied if {
+	count(deny) > 0 with input as {
+		"kind": "ClusterRole",
+		"metadata": {"name": "test-role"},
+		"rules": [{"apiGroups": ["infrastructure.opendatahub.io"], "resources": ["hardwareprofiles"], "verbs": ["get", "list"]}],
+	}
+}
+
+test_multiple_resources_one_unknown_denied if {
+	count(deny) > 0 with input as {
+		"kind": "ClusterRole",
+		"metadata": {"name": "test-role"},
+		"rules": [
+			{"apiGroups": ["apps"], "resources": ["deployments"], "verbs": ["get"]},
+			{"apiGroups": ["example.io"], "resources": ["widgets"], "verbs": ["get"]},
+		],
+	}
+}
+
+# --- Layer 2: wildcards ---
+
+test_wildcard_verb_denied if {
+	count(deny) > 0 with input as {
+		"kind": "ClusterRole",
+		"metadata": {"name": "test-role"},
+		"rules": [{"apiGroups": ["apps"], "resources": ["deployments"], "verbs": ["*"]}],
+	}
+}
+
+test_wildcard_resource_denied if {
+	count(deny) > 0 with input as {
+		"kind": "ClusterRole",
+		"metadata": {"name": "test-role"},
+		"rules": [{"apiGroups": ["apps"], "resources": ["*"], "verbs": ["get"]}],
+	}
+}
+
+test_wildcard_apigroup_denied if {
+	count(deny) > 0 with input as {
+		"kind": "ClusterRole",
+		"metadata": {"name": "test-role"},
+		"rules": [{"apiGroups": ["*"], "resources": ["pods"], "verbs": ["get"]}],
+	}
+}
+
+# --- Layer 2: secrets ---
+
+test_secrets_read_allowed if {
+	count(deny) == 0 with input as {
+		"kind": "ClusterRole",
+		"metadata": {"name": "test-role"},
+		"rules": [{"apiGroups": [""], "resources": ["secrets"], "verbs": ["get", "list", "watch"]}],
+	}
+}
+
+test_secrets_write_denied if {
+	count(deny) > 0 with input as {
+		"kind": "ClusterRole",
+		"metadata": {"name": "test-role"},
+		"rules": [{"apiGroups": [""], "resources": ["secrets"], "verbs": ["get", "update"]}],
+	}
+}
+
+test_secrets_delete_denied if {
+	count(deny) > 0 with input as {
+		"kind": "ClusterRole",
+		"metadata": {"name": "test-role"},
+		"rules": [{"apiGroups": [""], "resources": ["secrets"], "verbs": ["delete"]}],
+	}
+}
+
+# --- Layer 2: secrets exemptions ---
+
+test_secrets_write_exempt_tas_manager if {
+	count(deny) == 0 with input as {
+		"kind": "ClusterRole",
+		"metadata": {"name": "trustyai-service-operator-tas-manager-role"},
+		"rules": [{"apiGroups": [""], "resources": ["secrets"], "verbs": ["create", "delete"]}],
+	}
+}
+
+test_secrets_write_exempt_gorch_manager if {
+	count(deny) == 0 with input as {
+		"kind": "ClusterRole",
+		"metadata": {"name": "trustyai-service-operator-gorch-manager-role"},
+		"rules": [{"apiGroups": [""], "resources": ["secrets"], "verbs": ["update", "patch"]}],
+	}
+}
+
+test_secrets_write_not_exempt_unknown_role if {
+	count(deny) > 0 with input as {
+		"kind": "ClusterRole",
+		"metadata": {"name": "trustyai-service-operator-rogue-manager-role"},
+		"rules": [{"apiGroups": [""], "resources": ["secrets"], "verbs": ["create"]}],
+	}
+}
+
+# --- Layer 2: CRB write exemptions ---
+
+test_crb_write_exempt_evalhub_manager if {
+	count(deny) == 0 with input as {
+		"kind": "ClusterRole",
+		"metadata": {"name": "trustyai-service-operator-evalhub-manager-role"},
+		"rules": [{"apiGroups": ["rbac.authorization.k8s.io"], "resources": ["clusterrolebindings"], "verbs": ["create", "delete"]}],
+	}
+}
+
+test_crb_write_exempt_tas_manager if {
+	count(deny) == 0 with input as {
+		"kind": "ClusterRole",
+		"metadata": {"name": "trustyai-service-operator-tas-manager-role"},
+		"rules": [{"apiGroups": ["rbac.authorization.k8s.io"], "resources": ["clusterrolebindings"], "verbs": ["update"]}],
+	}
+}
+
+test_crb_write_not_exempt_unknown_role if {
+	count(deny) > 0 with input as {
+		"kind": "ClusterRole",
+		"metadata": {"name": "trustyai-service-operator-rogue-role"},
+		"rules": [{"apiGroups": ["rbac.authorization.k8s.io"], "resources": ["clusterrolebindings"], "verbs": ["create"]}],
+	}
+}
+
+# --- Layer 2: privilege escalation ---
+
+test_clusterroles_write_denied if {
+	count(deny) > 0 with input as {
+		"kind": "ClusterRole",
+		"metadata": {"name": "test-role"},
+		"rules": [{"apiGroups": ["rbac.authorization.k8s.io"], "resources": ["clusterroles"], "verbs": ["create"]}],
+	}
+}
+
+test_clusterrolebindings_write_denied if {
+	count(deny) > 0 with input as {
+		"kind": "ClusterRole",
+		"metadata": {"name": "test-role"},
+		"rules": [{"apiGroups": ["rbac.authorization.k8s.io"], "resources": ["clusterrolebindings"], "verbs": ["patch"]}],
+	}
+}
+
+test_clusterrolebindings_read_allowed if {
+	count(deny) == 0 with input as {
+		"kind": "ClusterRole",
+		"metadata": {"name": "test-role"},
+		"rules": [{"apiGroups": ["rbac.authorization.k8s.io"], "resources": ["clusterrolebindings"], "verbs": ["get", "list"]}],
+	}
+}
+
+# --- Layer 2: escalation verbs ---
+
+test_escalate_verb_denied if {
+	count(deny) > 0 with input as {
+		"kind": "ClusterRole",
+		"metadata": {"name": "test-role"},
+		"rules": [{"apiGroups": ["rbac.authorization.k8s.io"], "resources": ["roles"], "verbs": ["escalate"]}],
+	}
+}
+
+test_bind_verb_denied if {
+	count(deny) > 0 with input as {
+		"kind": "ClusterRole",
+		"metadata": {"name": "test-role"},
+		"rules": [{"apiGroups": ["rbac.authorization.k8s.io"], "resources": ["roles"], "verbs": ["bind"]}],
+	}
+}
+
+test_impersonate_verb_denied if {
+	count(deny) > 0 with input as {
+		"kind": "ClusterRole",
+		"metadata": {"name": "test-role"},
+		"rules": [{"apiGroups": [""], "resources": ["serviceaccounts"], "verbs": ["impersonate"]}],
+	}
+}
+
+# --- Non-ClusterRole input ---
+
+test_non_clusterrole_ignored if {
+	count(deny) == 0 with input as {
+		"kind": "Role",
+		"metadata": {"name": "test-role"},
+		"rules": [{"apiGroups": ["evil.io"], "resources": ["badthings"], "verbs": ["*"]}],
+	}
+}

--- a/policy/clusterrole_test.rego
+++ b/policy/clusterrole_test.rego
@@ -16,7 +16,7 @@ test_unknown_api_resource_denied if {
 	count(deny) > 0 with input as {
 		"kind": "ClusterRole",
 		"metadata": {"name": "test-role"},
-		"rules": [{"apiGroups": ["infrastructure.opendatahub.io"], "resources": ["hardwareprofiles"], "verbs": ["get", "list"]}],
+		"rules": [{"apiGroups": ["example.io"], "resources": ["foos"], "verbs": ["get", "list"]}],
 	}
 }
 


### PR DESCRIPTION
## What and why
  
The existing conftest policy (rbac.rego) only validates ClusterRoleBinding names and role references, it never inspects ClusterRole contents. This means any new apiGroup/resource permission can be added to an existing ClusterRole without triggering CI.

This PR adds clusterrole.rego, a two-layer policy that inspects the rules inside every ClusterRole:

Layer 1: Allowlist: A closed set of ~50 (apiGroup, resource) pairs derived from the current manifests. Any pair not in the list is denied, forcing explicit review when new permissions are introduced.

Layer 2: Denylist: Blocks dangerous patterns regardless of allowlist status:
- Wildcard * in apiGroups, resources, or verbs
- Write verbs on secrets (read is allowed)
- Write verbs on clusterroles / clusterrolebindings (privilege escalation)
- Escalation verbs: escalate, bind, impersonate

Manager roles that legitimately need secrets or CRB write access (TAS, GORCH, nemo-guardrails, evalhub) are exempted by name suffix.

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated: 23 new unit tests in clusterrole_test.rego
- [x] make policy-test: 31/31 pass
- [x] make policy-check: all 9 overlays pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ClusterRole validation policy with security constraints preventing wildcards, restricted write access to sensitive resources, and privilege escalation verbs.

* **Documentation**
  * Updated policy documentation to reflect new ClusterRole validation requirements and implementation guidance.

* **Tests**
  * Added comprehensive test suite for ClusterRole validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->