### PR TITLE
fix(kustomize): move webhook volume mount into evalhub component

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -26,6 +26,7 @@ import (
 	nemoguardrailsv1alpha1 "github.com/trustyai-explainability/trustyai-service-operator/api/nemo_guardrails/v1alpha1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"os"
+	"slices"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -54,6 +55,8 @@ import (
 	kueuev1beta1 "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	//+kubebuilder:scaffold:imports
 )
+
+const serviceEvalHub = "EVALHUB"
 
 var (
 	scheme   = runtime.NewScheme()
@@ -104,7 +107,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	mgrOpts := ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                server.Options{BindAddress: metricsAddr},
 		HealthProbeBindAddress: probeAddr,
@@ -126,19 +129,26 @@ func main() {
 				},
 			},
 		},
-		WebhookServer: ctrlwebhook.NewServer(ctrlwebhook.Options{
-			Port: 9443,
-		}),
 		// LeaderElectionReleaseOnCancel: true,
-	})
+	}
+
+	if slices.Contains(enabledServices, serviceEvalHub) {
+		mgrOpts.WebhookServer = ctrlwebhook.NewServer(ctrlwebhook.Options{
+			Port: 9443,
+		})
+	}
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), mgrOpts)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
 	}
 
-	if err := ctrl.NewWebhookManagedBy(mgr).For(&evalhubv1.EvalHub{}).Complete(); err != nil {
-		setupLog.Error(err, "unable to create EvalHub conversion webhook")
-		os.Exit(1)
+	if slices.Contains(enabledServices, serviceEvalHub) {
+		if err := ctrl.NewWebhookManagedBy(mgr).For(&evalhubv1.EvalHub{}).Complete(); err != nil {
+			setupLog.Error(err, "unable to create EvalHub conversion webhook")
+			os.Exit(1)
+		}
 	}
 
 	recorder := mgr.GetEventRecorderFor("trustyai-service-operator")

--- a/config/components/evalhub/kustomization.yaml
+++ b/config/components/evalhub/kustomization.yaml
@@ -25,6 +25,7 @@ resources:
 patches:
   - path: patches/cainjection_in_evalhubs.yaml
   - path: patches/webhook_in_evalhubs.yaml
+  - path: patches/manager_webhook_config.yaml
 
 configurations:
   - patches/kustomizeconfig.yaml

--- a/config/components/evalhub/patches/manager_webhook_config.yaml
+++ b/config/components/evalhub/patches/manager_webhook_config.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          ports:
+            - containerPort: 9443
+              name: webhook-server
+              protocol: TCP
+          volumeMounts:
+            - name: webhook-certs
+              mountPath: /tmp/k8s-webhook-server/serving-certs
+              readOnly: true
+      volumes:
+        - name: webhook-certs
+          secret:
+            secretName: webhook-server-cert

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,14 +35,6 @@ spec:
             # --enable-services will be set by overlays based on which components are included
           image: $(trustyaiOperatorImage)
           name: manager
-          ports:
-            - containerPort: 9443
-              name: webhook-server
-              protocol: TCP
-          volumeMounts:
-            - name: webhook-certs
-              mountPath: /tmp/k8s-webhook-server/serving-certs
-              readOnly: true
           env:
             - name: GOMEMLIMIT
               value: "630MiB"
@@ -73,9 +65,5 @@ spec:
             requests:
               cpu: 10m
               memory: 64Mi
-      volumes:
-        - name: webhook-certs
-          secret:
-            secretName: webhook-server-cert
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/config/overlays/evalhub-only/kustomization.yaml
+++ b/config/overlays/evalhub-only/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+
+components:
+  - ../../components/evalhub
+
+patches:
+  - target:
+      kind: Deployment
+      name: controller-manager
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: "--enable-services"
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: "EVALHUB"

--- a/policy/rbac.rego
+++ b/policy/rbac.rego
@@ -27,7 +27,7 @@ expected_crbs := {
 	"trustyai-service-operator-lmes-manager-rolebinding": "trustyai-service-operator-lmes-manager-role",
 	"trustyai-service-operator-default-lmeval-user-rolebinding": "trustyai-service-operator-lmeval-user-role",
 
-	# --- component: evalhub ---
+	# --- component: evalhub (prefixed overlays: odh, rhoai, dev, testing) ---
 	"trustyai-service-operator-evalhub-manager-rolebinding": "trustyai-service-operator-evalhub-manager-role",
 	"trustyai-service-operator-evalhub-collections-access-binding": "trustyai-service-operator-evalhub-collections-access",
 	"trustyai-service-operator-evalhub-providers-access-binding": "trustyai-service-operator-evalhub-providers-access",
@@ -35,6 +35,15 @@ expected_crbs := {
 	"trustyai-service-operator-evalhub-mlflow-jobs-access-binding": "trustyai-service-operator-evalhub-mlflow-jobs-access",
 	"trustyai-service-operator-evalhub-jobs-writer-binding": "trustyai-service-operator-evalhub-jobs-writer",
 	"trustyai-service-operator-evalhub-job-config-binding": "trustyai-service-operator-evalhub-job-config",
+
+	# --- component: evalhub (un-prefixed overlay: evalhub-only) ---
+	"evalhub-manager-rolebinding": "trustyai-service-operator-evalhub-manager-role",
+	"evalhub-collections-access-binding": "evalhub-collections-access",
+	"evalhub-providers-access-binding": "evalhub-providers-access",
+	"evalhub-mlflow-access-binding": "evalhub-mlflow-access",
+	"evalhub-mlflow-jobs-access-binding": "evalhub-mlflow-jobs-access",
+	"evalhub-jobs-writer-binding": "evalhub-jobs-writer",
+	"evalhub-job-config-binding": "evalhub-job-config",
 
 	# --- component: gorch ---
 	"trustyai-service-operator-gorch-manager-rolebinding": "trustyai-service-operator-gorch-manager-role",


### PR DESCRIPTION
### What and why

When `mcpGuardrailsMode=true` is set on the DSC, TrustyAI switches to the `mcp-guardrails` overlay. The base `manager.yaml` unconditionally mounted the `webhook-certs` volume (secret `webhook-server-cert`), but only the `evalhub` component deploys the webhook Service that triggers cert creation via service-ca. The pod gets stuck in `ContainerCreating` with `MountVolume.SetUp failed`. Affects all overlays without evalhub: `mcp-guardrails`, `odh-kueue`, `lmes`.

### Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

### Changes

- **Kustomize**: Moved webhook port (9443), volumeMount (`webhook-certs`), and volume from base `config/manager/manager.yaml` into a new strategic merge patch `config/components/evalhub/patches/manager_webhook_config.yaml`. Only overlays including the evalhub component get the webhook infrastructure.
- **Go**: Made `WebhookServer` creation and EvalHub conversion webhook registration in `cmd/main.go` conditional on `EVALHUB` being in `--enable-services`.
- **evalhub-only overlay**: Converted from standalone strategic merge patch to use the evalhub component (consistent with all other overlays).
- **OPA policy**: Added un-prefixed evalhub CRBs to the RBAC allowlist for the `evalhub-only` overlay.

### Testing

- [x] `kustomize build` verified on all 9 overlays — evalhub overlays include webhook-certs, non-evalhub overlays do not
- [x] `make policy-check` passes (3969 tests, 0 failures)
- [x] `go build` and `go vet` pass
- [ ] Tested manually on cluster with `mcpGuardrailsMode=true`

### Breaking changes

None — this is a bugfix. Overlays with evalhub produce identical manifests as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for conditional service enablement, allowing selective activation of EvalHub functionality.
  * Introduced a new deployment configuration option for EvalHub-only environments.

* **Chores**
  * Updated webhook server provisioning to align with service configuration.
  * Enhanced deployment memory limit configuration.
  * Clarified policy documentation for deployment overlays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->