### PR TITLE
fix(evalhub): create discovery ConfigMap in instance namespace for non-admin users

### DIFF
--- a/controllers/evalhub/tenant_namespaces.go
+++ b/controllers/evalhub/tenant_namespaces.go
@@ -39,8 +39,14 @@ func (r *EvalHubReconciler) reconcileTenantNamespaces(ctx context.Context, insta
 	}
 
 	for ns := range activeTenants {
-		// Skip the instance namespace (already handled by main reconcile)
+		// The instance namespace already has SA and RBAC from the main reconcile,
+		// but still needs the discovery ConfigMap so non-admin users (who lack
+		// CR-level RBAC) can resolve the service URL via the BFF.
 		if ns == instance.Namespace {
+			if err := r.reconcileDiscoveryConfigMap(ctx, instance, ns); err != nil {
+				log.Error(err, "Failed to reconcile discovery ConfigMap in instance namespace", "namespace", ns)
+				return err
+			}
 			continue
 		}
 

--- a/controllers/evalhub/unit_test.go
+++ b/controllers/evalhub/unit_test.go
@@ -1835,8 +1835,7 @@ func TestEvalHubReconciler_reconcileTenantNamespaces(t *testing.T) {
 		assert.Equal(t, "true", cm.Annotations["service.beta.openshift.io/inject-cabundle"])
 	})
 
-	t.Run("should skip instance namespace", func(t *testing.T) {
-		// Label the instance namespace as a tenant — it should be skipped
+	t.Run("should skip SA and RBAC but create discovery ConfigMap in instance namespace", func(t *testing.T) {
 		instanceNS := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: instanceNamespace,
@@ -1869,6 +1868,17 @@ func TestEvalHubReconciler_reconcileTenantNamespaces(t *testing.T) {
 			Namespace: instanceNamespace,
 		}, cm)
 		assert.True(t, errors.IsNotFound(err))
+
+		// Discovery ConfigMap SHOULD exist in instance namespace so
+		// non-admin users can resolve the service URL via the BFF
+		discoveryCM := &corev1.ConfigMap{}
+		err = fakeClient.Get(ctx, types.NamespacedName{
+			Name:      discoveryConfigMapName,
+			Namespace: instanceNamespace,
+		}, discoveryCM)
+		require.NoError(t, err, "discovery ConfigMap must be created in instance namespace")
+		expectedURL := "https://evalhub.opendatahub.svc.cluster.local:8443"
+		assert.Equal(t, expectedURL, discoveryCM.Data[evalHubName+".url"])
 	})
 
 	t.Run("should not provision in unlabelled namespaces", func(t *testing.T) {


### PR DESCRIPTION
## What and why

Non-admin users in the namespace where the EvalHub CR lives cannot resolve the service URL. The controller was skipping the instance namespace entirely when creating the evalhub-discovery ConfigMap, assuming users there could read the CR directly. But non-admin users only have virtual resource RBAC (evaluations, collections, providers). They can't list evalhubs.trustyai.opendatahub.io, so the BFF gets a 403 and returns a 500.

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [ ] Tested manually

## Breaking changes

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed service URL discovery for non-admin users by ensuring discovery configuration is provisioned in instance namespaces.

* **Tests**
  * Updated tests to verify discovery configuration provisioning in instance namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->