### PR TITLE
Grant EvalHub MCP API access via instance-namespace Role rules

### DIFF
--- a/controllers/evalhub/proxy_rbac_test.go
+++ b/controllers/evalhub/proxy_rbac_test.go
@@ -163,10 +163,16 @@ var _ = Describe("EvalHub API RBAC", func() {
 			}, role)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Checking Role has resourceNames set to instance name")
-			Expect(role.Rules).To(HaveLen(2))
+			By("Checking Role has resourceNames set to instance name and virtual API resources")
+			Expect(role.Rules).To(HaveLen(5))
 			Expect(role.Rules[0].ResourceNames).To(Equal([]string{evalHubName}))
 			Expect(role.Rules[1].ResourceNames).To(Equal([]string{evalHubName}))
+			for _, resource := range []string{"evaluations", "providers", "collections"} {
+				rule, ok := findPolicyRuleByResource(role.Rules, resource)
+				Expect(ok).To(BeTrue(), "expected rule for resource %q", resource)
+				Expect(rule.APIGroups).To(Equal([]string{"trustyai.opendatahub.io"}))
+				Expect(rule.Verbs).To(Equal(evalHubVirtualAPIResourceVerbs))
+			}
 		})
 
 		It("should create namespace-scoped API access RoleBinding referencing per-instance Role", func() {
@@ -303,30 +309,24 @@ var _ = Describe("EvalHub API RBAC", func() {
 			Expect(hpRB.RoleRef.Name).To(Equal(hardwareProfilesReaderClusterRoleName))
 			Expect(hpRB.Subjects).To(HaveLen(1))
 			Expect(hpRB.Subjects[0].Name).To(Equal(evalHubName + "-service"))
+		})
 
-			By("Verifying providers-access RoleBinding exists")
-			pRB := &rbacv1.RoleBinding{}
-			err = k8sClient.Get(ctx, types.NamespacedName{
-				Name:      evalHubName + "-providers-access-rb",
-				Namespace: testNamespace,
-			}, pRB)
+		It("should not create legacy providers/collections ClusterRole RoleBindings", func() {
+			By("Creating service account (which creates all RoleBindings)")
+			err := reconciler.createServiceAccount(ctx, evalHub)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(pRB.RoleRef.Kind).To(Equal("ClusterRole"))
-			Expect(pRB.RoleRef.Name).To(Equal(providersAccessClusterRoleName))
-			Expect(pRB.Subjects).To(HaveLen(1))
-			Expect(pRB.Subjects[0].Name).To(Equal(evalHubName + "-service"))
 
-			By("Verifying collections-access RoleBinding exists")
-			cRB := &rbacv1.RoleBinding{}
-			err = k8sClient.Get(ctx, types.NamespacedName{
-				Name:      evalHubName + "-collections-access-rb",
-				Namespace: testNamespace,
-			}, cRB)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(cRB.RoleRef.Kind).To(Equal("ClusterRole"))
-			Expect(cRB.RoleRef.Name).To(Equal(collectionsAccessClusterRoleName))
-			Expect(cRB.Subjects).To(HaveLen(1))
-			Expect(cRB.Subjects[0].Name).To(Equal(evalHubName + "-service"))
+			for _, rbName := range []string{
+				evalHubName + "-providers-access-rb",
+				evalHubName + "-collections-access-rb",
+			} {
+				legacyRB := &rbacv1.RoleBinding{}
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      rbName,
+					Namespace: testNamespace,
+				}, legacyRB)
+				Expect(err).To(HaveOccurred(), "legacy RoleBinding %q should not exist", rbName)
+			}
 		})
 
 		It("should not bind jobs SA to resource-manager roles", func() {

--- a/controllers/evalhub/service_accounts.go
+++ b/controllers/evalhub/service_accounts.go
@@ -202,24 +202,8 @@ func (r *EvalHubReconciler) createServiceAccount(ctx context.Context, instance *
 		return err
 	}
 
-	// Create RoleBindings for EvalHub API endpoints protected by SAR.
-	// These bind the service SA to ClusterRoles that satisfy the kube-rbac-proxy
-	// SAR checks for providers and collections endpoints.
-	err = r.createGenericRoleBinding(ctx, instance, instance.Name+"-providers-access-rb", serviceAccountName, rbacv1.RoleRef{
-		Kind:     "ClusterRole",
-		Name:     providersAccessClusterRoleName,
-		APIGroup: rbacv1.GroupName,
-	})
-	if err != nil {
-		return err
-	}
-
-	err = r.createGenericRoleBinding(ctx, instance, instance.Name+"-collections-access-rb", serviceAccountName, rbacv1.RoleRef{
-		Kind:     "ClusterRole",
-		Name:     collectionsAccessClusterRoleName,
-		APIGroup: rbacv1.GroupName,
-	})
-	if err != nil {
+	// Remove legacy ClusterRole bindings superseded by the per-instance API access Role.
+	if err := r.deleteLegacyVirtualResourceClusterRoleBindings(ctx, instance); err != nil {
 		return err
 	}
 
@@ -238,12 +222,9 @@ const (
 	hardwareProfilesReaderClusterRoleName = "trustyai-service-operator-evalhub-hardware-profiles-reader"
 )
 
-// EvalHub API access ClusterRoles for SAR-protected endpoints.
-// The kube-rbac-proxy auth config checks these virtual resources via SubjectAccessReview.
-const (
-	providersAccessClusterRoleName   = "trustyai-service-operator-evalhub-providers-access"
-	collectionsAccessClusterRoleName = "trustyai-service-operator-evalhub-collections-access"
-)
+// evalHubVirtualAPIResourceVerbs are the SAR verbs checked by kube-rbac-proxy for
+// EvalHub REST endpoints (/api/v1/evaluations/{evaluations,providers,collections}).
+var evalHubVirtualAPIResourceVerbs = []string{"get", "list", "create", "update", "patch", "delete"}
 
 // MLFlow access uses custom ClusterRoles scoped to the "mlflow.kubeflow.org" API group.
 // MLFlow's kubernetes-workspace-provider checks permissions via SelfSubjectAccessReview
@@ -256,9 +237,43 @@ const mlflowAccessClusterRoleName = "trustyai-service-operator-evalhub-mlflow-ac
 // Jobs only need create, get, list -- not update or delete.
 const mlflowJobsAccessClusterRoleName = "trustyai-service-operator-evalhub-mlflow-jobs-access"
 
-// createAPIAccessRole creates a per-instance namespaced Role with resourceNames
-// scoped to this specific EvalHub instance. This ensures the SA can only access
-// its own instance's evalhubs/proxy subresource.
+// buildAPIAccessRoleRules returns RBAC rules for the per-instance API access Role.
+// Virtual resources (evaluations, providers, collections) satisfy kube-rbac-proxy SAR
+// checks for EvalHub REST endpoints. evalhubs/proxy is for MCP ingress auth.
+func buildAPIAccessRoleRules(instance *evalhubv1.EvalHub) []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		{
+			APIGroups:     []string{"trustyai.opendatahub.io"},
+			Resources:     []string{"evalhubs"},
+			ResourceNames: []string{instance.Name},
+			Verbs:         []string{"get"},
+		},
+		{
+			APIGroups:     []string{"trustyai.opendatahub.io"},
+			Resources:     []string{"evalhubs/proxy"},
+			ResourceNames: []string{instance.Name},
+			Verbs:         []string{"get", "create"},
+		},
+		{
+			APIGroups: []string{"trustyai.opendatahub.io"},
+			Resources: []string{"evaluations"},
+			Verbs:     evalHubVirtualAPIResourceVerbs,
+		},
+		{
+			APIGroups: []string{"trustyai.opendatahub.io"},
+			Resources: []string{"providers"},
+			Verbs:     evalHubVirtualAPIResourceVerbs,
+		},
+		{
+			APIGroups: []string{"trustyai.opendatahub.io"},
+			Resources: []string{"collections"},
+			Verbs:     evalHubVirtualAPIResourceVerbs,
+		},
+	}
+}
+
+// createAPIAccessRole creates a per-instance namespaced Role in the EvalHub instance
+// namespace for the API/MCP service account.
 func (r *EvalHubReconciler) createAPIAccessRole(ctx context.Context, instance *evalhubv1.EvalHub) error {
 	log := log.FromContext(ctx)
 
@@ -275,20 +290,7 @@ func (r *EvalHubReconciler) createAPIAccessRole(ctx context.Context, instance *e
 				"app.kubernetes.io/version":  constants.Version,
 			},
 		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups:     []string{"trustyai.opendatahub.io"},
-				Resources:     []string{"evalhubs"},
-				ResourceNames: []string{instance.Name},
-				Verbs:         []string{"get"},
-			},
-			{
-				APIGroups:     []string{"trustyai.opendatahub.io"},
-				Resources:     []string{"evalhubs/proxy"},
-				ResourceNames: []string{instance.Name},
-				Verbs:         []string{"get", "create"},
-			},
-		},
+		Rules: buildAPIAccessRoleRules(instance),
 	}
 
 	if err := ctrl.SetControllerReference(instance, role, r.Scheme); err != nil {
@@ -501,6 +503,32 @@ func (r *EvalHubReconciler) createAPIAccessRoleBinding(ctx context.Context, inst
 		Name:     roleName,
 		APIGroup: rbacv1.GroupName,
 	})
+}
+
+// deleteLegacyVirtualResourceClusterRoleBindings removes per-instance RoleBindings that
+// previously referenced ClusterRoles for providers/collections SAR access.
+func (r *EvalHubReconciler) deleteLegacyVirtualResourceClusterRoleBindings(ctx context.Context, instance *evalhubv1.EvalHub) error {
+	log := log.FromContext(ctx)
+
+	for _, name := range []string{
+		instance.Name + "-providers-access-rb",
+		instance.Name + "-collections-access-rb",
+	} {
+		rb := &rbacv1.RoleBinding{}
+		err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: instance.Namespace}, rb)
+		if errors.IsNotFound(err) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		log.Info("Deleting legacy virtual-resource ClusterRole RoleBinding", "name", name, "namespace", instance.Namespace)
+		if err := r.Delete(ctx, rb); err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // createJobsAPIAccessRoleBinding creates a namespace-scoped RoleBinding for the job

--- a/controllers/evalhub/unit_test.go
+++ b/controllers/evalhub/unit_test.go
@@ -558,6 +558,17 @@ func TestEvalHubReconciler_createJobsAPIAccessRoleBinding(t *testing.T) {
 	})
 }
 
+func findPolicyRuleByResource(rules []rbacv1.PolicyRule, resource string) (rbacv1.PolicyRule, bool) {
+	for _, rule := range rules {
+		for _, res := range rule.Resources {
+			if res == resource {
+				return rule, true
+			}
+		}
+	}
+	return rbacv1.PolicyRule{}, false
+}
+
 // TestEvalHubReconciler_createAPIAccessRole verifies that the per-instance API access Role
 // is created with resourceNames scoped to the instance, with correct owner ref and idempotency.
 func TestEvalHubReconciler_createAPIAccessRole(t *testing.T) {
@@ -604,7 +615,7 @@ func TestEvalHubReconciler_createAPIAccessRole(t *testing.T) {
 		assert.Equal(t, evalHubName+"-service-access-role", role.Name)
 
 		// Check rules have resourceNames scoped to this instance
-		require.Len(t, role.Rules, 2)
+		require.Len(t, role.Rules, 5)
 
 		// First rule: evalhubs get
 		assert.Equal(t, []string{"trustyai.opendatahub.io"}, role.Rules[0].APIGroups)
@@ -617,6 +628,13 @@ func TestEvalHubReconciler_createAPIAccessRole(t *testing.T) {
 		assert.Equal(t, []string{"evalhubs/proxy"}, role.Rules[1].Resources)
 		assert.Equal(t, []string{evalHubName}, role.Rules[1].ResourceNames)
 		assert.Equal(t, []string{"get", "create"}, role.Rules[1].Verbs)
+
+		for _, resource := range []string{"evaluations", "providers", "collections"} {
+			rule, ok := findPolicyRuleByResource(role.Rules, resource)
+			require.True(t, ok, "expected rule for resource %q", resource)
+			assert.Equal(t, []string{"trustyai.opendatahub.io"}, rule.APIGroups)
+			assert.Equal(t, evalHubVirtualAPIResourceVerbs, rule.Verbs)
+		}
 
 		// Check owner reference
 		require.Len(t, role.OwnerReferences, 1)


### PR DESCRIPTION
## Summary
- Extend the per-instance `{name}-service-access-role` with virtual SAR resources for `evaluations`, `providers`, and `collections` (full get/list/create/update/patch/delete verbs) so the EvalHub/MCP service account can access EvalHub REST endpoints from the instance namespace.
- Stop creating legacy `{name}-providers-access-rb` and `{name}-collections-access-rb` ClusterRole bindings for the service SA.
- Delete those legacy RoleBindings on reconcile when upgrading existing instances.

## Test plan
- [x] `go test ./controllers/evalhub/... -run 'TestEvalHubReconciler_createAPIAccessRole|EvalHub API RBAC'`
- [ ] Verify MCP `resources/read` for `evalhub://collections` succeeds when `EVALHUB_TENANT` matches the EvalHub instance namespace and `authSecret` contains the `{name}-service` token


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Streamlined EvalHub access control by removing outdated legacy bindings and configurations.
  * Enhanced resource-specific access permissions for evaluations, providers, and collections through refined API rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->