### PR TITLE
fix: wire RELATED_IMAGE env vars for disconnected readiness

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -93,3 +93,10 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.lmes-pod-image
+  - name: lmes-driver-image
+    objref:
+      kind: ConfigMap
+      name: config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.lmes-driver-image

--- a/config/base/params.yaml
+++ b/config/base/params.yaml
@@ -2,5 +2,7 @@
 varReference:
   - kind: Deployment
     path: spec/template/spec/containers[]/image
+  - kind: Deployment
+    path: spec/template/spec/containers[]/env[]/value
   - kind: ConfigMap
     path: data

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -38,6 +38,16 @@ spec:
           env:
             - name: GOMEMLIMIT
               value: "630MiB"
+            - name: RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE
+              value: $(trustyaiServiceImage)
+            - name: RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE
+              value: $(kube-rbac-proxy)
+            - name: RELATED_IMAGE_ODH_TA_LMES_JOB_IMAGE
+              value: $(lmes-pod-image)
+            - name: RELATED_IMAGE_ODH_TA_LMES_DRIVER_IMAGE
+              value: $(lmes-driver-image)
+            - name: RELATED_IMAGE_ODH_EVAL_HUB_IMAGE
+              value: $(evalHubImage)
           securityContext:
             runAsNonRoot: true
             allowPrivilegeEscalation: false

--- a/controllers/evalhub/constants.go
+++ b/controllers/evalhub/constants.go
@@ -1,16 +1,17 @@
 package evalhub
 
 import (
+	"os"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
+var defaultEvalHubImage = envOrDefault("RELATED_IMAGE_ODH_EVAL_HUB_IMAGE", "quay.io/evalhub/evalhub:latest")
+
 const (
 	// Service name for registration
 	ServiceName = "EVALHUB"
-
-	// Default image configuration
-	defaultEvalHubImage = "quay.io/evalhub/evalhub:latest"
 
 	// Container configuration
 	containerName = "evalhub"
@@ -180,3 +181,10 @@ var (
 		},
 	}
 )
+
+func envOrDefault(env, fallback string) string {
+	if v := os.Getenv(env); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/controllers/lmes/constants.go
+++ b/controllers/lmes/constants.go
@@ -17,28 +17,33 @@ limitations under the License.
 package lmes
 
 import (
+	"os"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 )
 
+var (
+	DefaultPodImage    = envOrDefault("RELATED_IMAGE_ODH_TA_LMES_JOB_IMAGE", "quay.io/trustyai/ta-lmes-job:latest")
+	DefaultDriverImage = envOrDefault("RELATED_IMAGE_ODH_TA_LMES_DRIVER_IMAGE", "quay.io/trustyai/ta-lmes-driver:latest")
+)
+
 const (
-	DriverPath                 = "/bin/driver"
-	DestDriverPath             = "/opt/app-root/src/bin/driver"
-	OutputPath                 = "/opt/app-root/src/output"
-	HuggingFaceHomePath        = "/opt/app-root/src/hf_home"
-	PodImageKey                = "lmes-pod-image"
-	DriverImageKey             = "lmes-driver-image"
-	PodCheckingIntervalKey     = "lmes-pod-checking-interval"
-	ImagePullPolicyKey         = "lmes-image-pull-policy"
-	MaxBatchSizeKey            = "lmes-max-batch-size"
-	DefaultBatchSizeKey        = "lmes-default-batch-size"
-	DetectDeviceKey            = "lmes-detect-device"
-	AllowOnline                = "lmes-allow-online"
-	AllowCodeExecution         = "lmes-allow-code-execution"
-	DriverPort                 = "lmes-driver-port"
-	DefaultPodImage            = "quay.io/trustyai/ta-lmes-job:latest"
-	DefaultDriverImage         = "quay.io/trustyai/ta-lmes-driver:latest"
+	DriverPath             = "/bin/driver"
+	DestDriverPath         = "/opt/app-root/src/bin/driver"
+	OutputPath             = "/opt/app-root/src/output"
+	HuggingFaceHomePath    = "/opt/app-root/src/hf_home"
+	PodImageKey            = "lmes-pod-image"
+	DriverImageKey         = "lmes-driver-image"
+	PodCheckingIntervalKey = "lmes-pod-checking-interval"
+	ImagePullPolicyKey     = "lmes-image-pull-policy"
+	MaxBatchSizeKey        = "lmes-max-batch-size"
+	DefaultBatchSizeKey    = "lmes-default-batch-size"
+	DetectDeviceKey        = "lmes-detect-device"
+	AllowOnline            = "lmes-allow-online"
+	AllowCodeExecution     = "lmes-allow-code-execution"
+	DriverPort             = "lmes-driver-port"
+
 	DefaultPodCheckingInterval = time.Second * 10
 	DefaultImagePullPolicy     = corev1.PullAlways
 	DefaultMaxBatchSize        = 24
@@ -69,3 +74,10 @@ const (
 	// knows the spec changed and resets the job so it can be re-run with the updated configuration.
 	LastScheduledGenerationAnnotation = "trustyai.opendatahub.io/last-scheduled-generation"
 )
+
+func envOrDefault(env, fallback string) string {
+	if v := os.Getenv(env); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/controllers/tas/constants.go
+++ b/controllers/tas/constants.go
@@ -1,10 +1,17 @@
 package tas
 
-import "time"
+import (
+	"os"
+	"time"
+)
+
+var (
+	defaultImage              = envOrDefault("RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE", "quay.io/trustyai/trustyai-service:latest")
+	defaultKubeRBACProxyImage = envOrDefault("RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE", "quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable")
+)
 
 const (
-	defaultImage         = string("quay.io/trustyai/trustyai-service:latest")
-	containerName        = "trustyai-service"
+	containerName = "trustyai-service"
 	componentName        = "trustyai"
 	serviceMonitorName   = "trustyai-metrics"
 	finalizerName        = "trustyai.opendatahub.io/finalizer"
@@ -38,7 +45,6 @@ const (
 	KubeRBACProxyServicePort     = 8443
 	KubeRBACProxyName            = "kube-rbac-proxy"
 	KubeRBACProxyServicePortName = "https"
-	defaultKubeRBACProxyImage    = "quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable"
 )
 
 // Status types
@@ -84,3 +90,10 @@ const (
 )
 
 const migrationAnnotationKey = "trustyai.opendatahub.io/db-migration"
+
+func envOrDefault(env, fallback string) string {
+	if v := os.Getenv(env); v != "" {
+		return v
+	}
+	return fallback
+}


### PR DESCRIPTION
## Summary
- Convert hardcoded default image constants to vars with `os.Getenv("RELATED_IMAGE_*")` fallback in `tas`, `lmes`, and `evalhub` controllers
- Add RELATED_IMAGE env vars to operator Deployment manifest via kustomize variable substitution from params.env
- Add `lmes-driver-image` kustomize var (was missing from vars list despite being in params.env)
- Add `spec/template/spec/containers[]/env[]/value` to kustomize varReference so env var values get substituted

Fixes 9 disconnected readiness scanner blockers ([RHOAIENG-69987](https://redhat.atlassian.net/browse/RHOAIENG-69987)):
- 4 `image-manifest-complete`: hardcoded images without RELATED_IMAGE wiring
- 5 `no-image-tags`: image tags instead of digests

### Files changed
| File | Change |
|------|--------|
| `controllers/lmes/constants.go` | `DefaultPodImage`, `DefaultDriverImage` → var with env fallback |
| `controllers/tas/constants.go` | `defaultImage`, `defaultKubeRBACProxyImage` → var with env fallback |
| `controllers/evalhub/constants.go` | `defaultEvalHubImage` → var with env fallback |
| `config/manager/manager.yaml` | Add 5 RELATED_IMAGE env vars using kustomize vars |
| `config/base/kustomization.yaml` | Add `lmes-driver-image` var definition |
| `config/base/params.yaml` | Add env value path to varReference |

## Test plan
- [x] `go build ./...` compiles clean
- [x] `kustomize build config/overlays/odh` renders all 5 RELATED_IMAGE env vars correctly
- [ ] Verify disconnected readiness scanner passes on this branch
- [ ] Verify images resolve to digests when deployed via OLM with relatedImages

🤖 Generated with [Claude Code](https://claude.com/claude-code)