### PR TITLE
fix(kustomize): mark webhook secret volume as optional

### DIFF
--- a/config/components/evalhub/patches/manager_webhook_config.yaml
+++ b/config/components/evalhub/patches/manager_webhook_config.yaml
@@ -20,3 +20,4 @@ spec:
         - name: webhook-certs
           secret:
             secretName: webhook-server-cert
+            optional: true


### PR DESCRIPTION
## Summary

Mark the `webhook-server-cert` Secret volume as `optional: true` in the evalhub webhook kustomize patch. The operator pod starts even if the Secret does not exist yet (e.g. the webhook Service hasn't been reconciled by service-ca). Once the Secret appears, the kubelet mounts it automatically.

Without this, the pod is stuck in `ContainerCreating` whenever the webhook Service is created after the Deployment,  which happens during upgrades and fresh installs depending on ODH reconciler ordering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated webhook configuration to make the certificate secret optional, improving deployment flexibility and resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->