### PR TITLE
feat(evalhub): add tenancy mode field and tenant ConfigMap support

### DIFF
--- a/api/evalhub/v1/evalhub_types.go
+++ b/api/evalhub/v1/evalhub_types.go
@@ -125,8 +125,28 @@ type EvalHubMCPStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
+const (
+	// TenancySingle deploys EvalHub in single-tenant (self-service) mode: the instance serves
+	// only its own namespace. No cross-namespace tenant label discovery is performed.
+	// The operator provisions evalhub-tenant-admin and evalhub-user Roles automatically.
+	TenancySingle = "single"
+
+	// TenancyMulti is the default mode: one EvalHub instance in the RHOAI control-plane namespace
+	// serves tenant namespaces that carry the evalhub.trustyai.opendatahub.io/tenant label.
+	// A multi-tenant EvalHub instance must never be deployed in a tenant namespace.
+	TenancyMulti = "multi"
+)
+
 // EvalHubSpec defines the desired state of EvalHub
 type EvalHubSpec struct {
+	// Tenancy controls the deployment model for this EvalHub instance.
+	// "multi" (default) — shared control-plane instance; tenant namespaces opt in via label.
+	// "single" — self-service per-namespace instance; operator provisions namespace-scoped RBAC automatically.
+	// +kubebuilder:validation:Enum=single;multi
+	// +kubebuilder:default:=multi
+	// +optional
+	Tenancy string `json:"tenancy,omitempty"`
+
 	// Number of replicas for the eval-hub deployment
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:default:=1
@@ -277,6 +297,11 @@ func (e *EvalHubSpec) IsOTELConfigured() bool {
 // IsMCPEnabled returns true if the MCP server is explicitly enabled
 func (e *EvalHubSpec) IsMCPEnabled() bool {
 	return e.MCP != nil && e.MCP.Enabled != nil && *e.MCP.Enabled
+}
+
+// IsSingleTenancy returns true when this instance runs in self-service single-tenant mode.
+func (e *EvalHubSpec) IsSingleTenancy() bool {
+	return e.Tenancy == TenancySingle
 }
 
 // GetMCPReplicas returns the number of MCP server replicas, defaulting to 1 when the spec,

--- a/config/components/evalhub/crd/trustyai.opendatahub.io_evalhubs.yaml
+++ b/config/components/evalhub/crd/trustyai.opendatahub.io_evalhubs.yaml
@@ -560,6 +560,16 @@ spec:
                 format: int32
                 minimum: 1
                 type: integer
+              tenancy:
+                default: multi
+                description: |-
+                  Tenancy controls the deployment model for this EvalHub instance.
+                  "multi" (default) — shared control-plane instance; tenant namespaces opt in via label.
+                  "single" — self-service per-namespace instance; operator provisions namespace-scoped RBAC automatically.
+                enum:
+                - single
+                - multi
+                type: string
             type: object
           status:
             description: EvalHubStatus defines the observed state of EvalHub

--- a/config/components/evalhub/kustomization.yaml
+++ b/config/components/evalhub/kustomization.yaml
@@ -25,8 +25,8 @@ resources:
 
 patches:
   - path: patches/cainjection_in_evalhubs.yaml
-  - path: patches/webhook_in_evalhubs.yaml
   - path: patches/manager_webhook_config.yaml
+  - path: patches/webhook_in_evalhubs.yaml
 
 configurations:
   - patches/kustomizeconfig.yaml

--- a/config/components/evalhub/rbac/manager-rbac.yaml
+++ b/config/components/evalhub/rbac/manager-rbac.yaml
@@ -229,6 +229,16 @@ rules:
   - rbac.authorization.k8s.io
   resources:
   - clusterroles
+  resourceNames:
+  - trustyai-service-operator-evalhub-auth-reviewer-role
+  - trustyai-service-operator-evalhub-jobs-writer
+  - trustyai-service-operator-evalhub-job-config
+  - trustyai-service-operator-evalhub-hardware-profiles-reader
+  - trustyai-service-operator-evalhub-providers-access
+  - trustyai-service-operator-evalhub-collections-access
+  - trustyai-service-operator-evalhub-model-secret
+  - trustyai-service-operator-evalhub-mlflow-access
+  - trustyai-service-operator-evalhub-mlflow-jobs-access
   verbs:
   - bind
 - apiGroups:

--- a/config/components/evalhub/rbac/manager-rbac.yaml
+++ b/config/components/evalhub/rbac/manager-rbac.yaml
@@ -226,17 +226,15 @@ rules:
   - patch
   - delete
 - apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - bind
+- apiGroups:
   - infrastructure.opendatahub.io
   resources:
   - hardwareprofiles
   verbs:
   - get
   - list
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - clusterroles
-  resourceNames:
-  - trustyai-service-operator-evalhub-model-secret
-  verbs:
-  - bind

--- a/controllers/evalhub/build_test.go
+++ b/controllers/evalhub/build_test.go
@@ -91,7 +91,7 @@ var _ = Describe("buildDeploymentSpec", func() {
 	})
 
 	It("builds the expected DeploymentSpec (labels, eval-hub, kube-rbac-proxy, strategy)", func() {
-		deploymentSpec, err := reconciler.buildDeploymentSpec(ctx, evalHub, nil, nil)
+		deploymentSpec, err := reconciler.buildDeploymentSpec(ctx, evalHub, nil, nil, nil, nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(*deploymentSpec.Replicas).To(Equal(replicas))
@@ -187,7 +187,7 @@ var _ = Describe("buildDeploymentSpec", func() {
 		operatorCM.Data["kubeRBACProxyMemoryRequest"] = "64Mi"
 		Expect(k8sClient.Update(ctx, operatorCM)).To(Succeed())
 
-		deploymentSpec, err := reconciler.buildDeploymentSpec(ctx, evalHub, nil, nil)
+		deploymentSpec, err := reconciler.buildDeploymentSpec(ctx, evalHub, nil, nil, nil, nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		app := findContainerByName(deploymentSpec.Template.Spec.Containers, containerName)
@@ -214,14 +214,14 @@ var _ = Describe("buildDeploymentSpec", func() {
 			EventRecorder:         record.NewFakeRecorder(10),
 		}
 
-		_, err := r.buildDeploymentSpec(ctx, evalHub, nil, nil)
+		_, err := r.buildDeploymentSpec(ctx, evalHub, nil, nil, nil, nil)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("getting kube-rbac-proxy image"))
 	})
 
 	It("adds provider volume and mount when providerCMNames is non-nil", func() {
 		providerCMNames := []string{"test-evalhub-provider-lm-eval", "test-evalhub-provider-garak"}
-		deploymentSpec, err := reconciler.buildDeploymentSpec(ctx, evalHub, providerCMNames, nil)
+		deploymentSpec, err := reconciler.buildDeploymentSpec(ctx, evalHub, providerCMNames, nil, nil, nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		podSpec := deploymentSpec.Template.Spec
@@ -257,7 +257,7 @@ var _ = Describe("buildDeploymentSpec", func() {
 
 	It("adds collection volume and mount when collectionCMNames is non-nil", func() {
 		collectionCMNames := []string{"test-evalhub-collection-healthcare-safety"}
-		deploymentSpec, err := reconciler.buildDeploymentSpec(ctx, evalHub, nil, collectionCMNames)
+		deploymentSpec, err := reconciler.buildDeploymentSpec(ctx, evalHub, nil, collectionCMNames, nil, nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		podSpec := deploymentSpec.Template.Spec
@@ -294,7 +294,7 @@ var _ = Describe("buildDeploymentSpec", func() {
 	It("adds both provider and collection volumes when both slices are non-nil", func() {
 		providerCMNames := []string{"test-evalhub-provider-lm-eval"}
 		collectionCMNames := []string{"test-evalhub-collection-healthcare-safety", "test-evalhub-collection-finance"}
-		deploymentSpec, err := reconciler.buildDeploymentSpec(ctx, evalHub, providerCMNames, collectionCMNames)
+		deploymentSpec, err := reconciler.buildDeploymentSpec(ctx, evalHub, providerCMNames, collectionCMNames, nil, nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		podSpec := deploymentSpec.Template.Spec
@@ -327,7 +327,7 @@ var _ = Describe("buildDeploymentSpec", func() {
 	})
 
 	It("does not include provider or collection volumes when both arguments are nil", func() {
-		deploymentSpec, err := reconciler.buildDeploymentSpec(ctx, evalHub, nil, nil)
+		deploymentSpec, err := reconciler.buildDeploymentSpec(ctx, evalHub, nil, nil, nil, nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		for _, v := range deploymentSpec.Template.Spec.Volumes {
@@ -352,7 +352,7 @@ var _ = Describe("buildDeploymentSpec", func() {
 			Spec: evalhubv1.EvalHubSpec{},
 		}
 
-		deploymentSpec, err := reconciler.buildDeploymentSpec(ctx, evalHubNoReplicas, nil, nil)
+		deploymentSpec, err := reconciler.buildDeploymentSpec(ctx, evalHubNoReplicas, nil, nil, nil, nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(*deploymentSpec.Replicas).To(Equal(int32(1)))
 	})

--- a/controllers/evalhub/configmap.go
+++ b/controllers/evalhub/configmap.go
@@ -473,35 +473,32 @@ func (r *EvalHubReconciler) validateImageConfiguration(ctx context.Context, imag
 	return nil
 }
 
-// reconcileProviderConfigMaps copies provider ConfigMaps from the operator namespace to the
-// EvalHub CR's namespace. Only providers listed in instance.Spec.Providers are copied.
-// Each source ConfigMap is discovered by the labels:
-//   - trustyai.opendatahub.io/evalhub-provider-type=system
-//   - trustyai.opendatahub.io/evalhub-provider-name=<name>
+// reconcileProviderConfigMaps copies system provider ConfigMaps from the operator namespace to
+// the EvalHub CR's namespace, and discovers tenant-scoped provider ConfigMaps (labeled
+// evalhub-provider-type=tenant) already present in the instance namespace.
 //
-// Returns the list of created ConfigMap names (for building projected volumes).
-func (r *EvalHubReconciler) reconcileProviderConfigMaps(ctx context.Context, instance *evalhubv1.EvalHub) ([]string, error) {
-	if len(instance.Spec.Providers) == 0 {
-		return nil, nil
-	}
-
+// System ConfigMaps are mounted at /etc/evalhub/config/providers/ (existing behaviour, unchanged).
+// Tenant ConfigMaps are used directly from the instance namespace and returned separately so
+// the deployment can mount them at /etc/evalhub/config/providers/tenant/.
+//
+// Returns (systemCMNames, tenantCMNames, error).
+func (r *EvalHubReconciler) reconcileProviderConfigMaps(ctx context.Context, instance *evalhubv1.EvalHub) ([]string, []string, error) {
 	log := log.FromContext(ctx)
-	log.Info("Reconciling Provider ConfigMaps", "instance", instance.Name, "providers", instance.Spec.Providers)
 
-	var cmNames []string
+	// --- System providers (existing behaviour) ---
+	var systemCMNames []string
 	for _, providerName := range instance.Spec.Providers {
-		// Look up the source ConfigMap by both labels
 		var sourceList corev1.ConfigMapList
 		if err := r.List(ctx, &sourceList,
 			client.InNamespace(r.Namespace),
 			client.MatchingLabels{
-				providerLabel:     "system",
+				providerLabel:     providerTypeSystem,
 				providerNameLabel: providerName,
 			}); err != nil {
-			return nil, fmt.Errorf("failed to list provider ConfigMaps for %q in namespace %s: %w", providerName, r.Namespace, err)
+			return nil, nil, fmt.Errorf("failed to list provider ConfigMaps for %q in namespace %s: %w", providerName, r.Namespace, err)
 		}
 		if len(sourceList.Items) == 0 {
-			return nil, fmt.Errorf("provider %q not found: no ConfigMap with label %s=%s in namespace %s",
+			return nil, nil, fmt.Errorf("provider %q not found: no ConfigMap with label %s=%s in namespace %s",
 				providerName, providerNameLabel, providerName, r.Namespace)
 		}
 
@@ -515,66 +512,79 @@ func (r *EvalHubReconciler) reconcileProviderConfigMaps(ctx context.Context, ins
 			},
 		}
 
-		// Check if ConfigMap already exists
 		getErr := r.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)
 		if getErr != nil && !errors.IsNotFound(getErr) {
-			return nil, getErr
+			return nil, nil, getErr
 		}
 
 		if errors.IsNotFound(getErr) {
 			configMap.Data = src.Data
 			if instance.UID != "" {
 				if err := controllerutil.SetControllerReference(instance, configMap, r.Scheme); err != nil {
-					return nil, err
+					return nil, nil, err
 				}
 			}
 			log.Info("Creating Provider ConfigMap", "name", targetName, "provider", providerName)
 			if err := r.Create(ctx, configMap); err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 		} else {
 			configMap.Data = src.Data
 			log.Info("Updating Provider ConfigMap", "name", targetName, "provider", providerName)
 			if err := r.Update(ctx, configMap); err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 		}
 
-		cmNames = append(cmNames, targetName)
+		systemCMNames = append(systemCMNames, targetName)
 	}
 
-	return cmNames, nil
+	// --- Tenant providers (new) ---
+	// Discover ConfigMaps labeled evalhub-provider-type=tenant in the instance namespace.
+	// These are used directly — no copy required. They mount at a separate path so they
+	// cannot shadow system providers.
+	var tenantList corev1.ConfigMapList
+	if err := r.List(ctx, &tenantList,
+		client.InNamespace(instance.Namespace),
+		client.MatchingLabels{providerLabel: providerTypeTenant}); err != nil {
+		return nil, nil, fmt.Errorf("failed to list tenant provider ConfigMaps in namespace %s: %w", instance.Namespace, err)
+	}
+
+	var tenantCMNames []string
+	for i := range tenantList.Items {
+		tenantCMNames = append(tenantCMNames, tenantList.Items[i].Name)
+		log.V(1).Info("Found tenant Provider ConfigMap", "name", tenantList.Items[i].Name)
+	}
+
+	return systemCMNames, tenantCMNames, nil
 }
 
-// reconcileCollectionConfigMaps copies collection ConfigMaps from the operator namespace to the
-// EvalHub CR's namespace. Only collections listed in instance.Spec.Collections are copied.
-// Each source ConfigMap is discovered by the labels:
-//   - trustyai.opendatahub.io/evalhub-collection-type=system
-//   - trustyai.opendatahub.io/evalhub-collection-name=<name>
+// reconcileCollectionConfigMaps copies system collection ConfigMaps from the operator namespace
+// to the EvalHub CR's namespace, and discovers tenant-scoped collection ConfigMaps (labeled
+// evalhub-collection-type=tenant) already present in the instance namespace.
 //
-// Returns the list of created ConfigMap names (for building projected volumes).
-func (r *EvalHubReconciler) reconcileCollectionConfigMaps(ctx context.Context, instance *evalhubv1.EvalHub) ([]string, error) {
-	if len(instance.Spec.Collections) == 0 {
-		return nil, nil
-	}
-
+// System ConfigMaps are mounted at /etc/evalhub/config/collections/ (existing behaviour).
+// Tenant ConfigMaps are used directly and returned separately so the deployment can mount them
+// at /etc/evalhub/config/collections/tenant/.
+//
+// Returns (systemCMNames, tenantCMNames, error).
+func (r *EvalHubReconciler) reconcileCollectionConfigMaps(ctx context.Context, instance *evalhubv1.EvalHub) ([]string, []string, error) {
 	log := log.FromContext(ctx)
-	log.Info("Reconciling Collection ConfigMaps", "instance", instance.Name, "collections", instance.Spec.Collections)
 
-	var cmNames []string
+	// --- System collections (existing behaviour) ---
+	var systemCMNames []string
 	for _, collectionName := range instance.Spec.Collections {
-		// Look up the source ConfigMap by both labels
 		var sourceList corev1.ConfigMapList
 		if err := r.List(ctx, &sourceList,
 			client.InNamespace(r.Namespace),
 			client.MatchingLabels{
-				collectionLabel:     "system",
+				collectionLabel:     collectionTypeSystem,
 				collectionNameLabel: collectionName,
 			}); err != nil {
-			return nil, fmt.Errorf("failed to list collection ConfigMaps for %q in namespace %s: %w", collectionName, r.Namespace, err)
+			return nil, nil, fmt.Errorf("failed to list collection ConfigMaps for %q in namespace %s: %w", collectionName, r.Namespace, err)
 		}
 		if len(sourceList.Items) == 0 {
-			return nil, fmt.Errorf("collection %q not found: no ConfigMap with label %s=%s in namespace %s",
+			return nil, nil, fmt.Errorf("collection %q not found: no ConfigMap with label %s=%s in namespace %s",
 				collectionName, collectionNameLabel, collectionName, r.Namespace)
 		}
 
@@ -588,35 +598,49 @@ func (r *EvalHubReconciler) reconcileCollectionConfigMaps(ctx context.Context, i
 			},
 		}
 
-		// Check if ConfigMap already exists
 		getErr := r.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)
 		if getErr != nil && !errors.IsNotFound(getErr) {
-			return nil, getErr
+			return nil, nil, getErr
 		}
 
 		if errors.IsNotFound(getErr) {
 			configMap.Data = src.Data
 			if instance.UID != "" {
 				if err := controllerutil.SetControllerReference(instance, configMap, r.Scheme); err != nil {
-					return nil, err
+					return nil, nil, err
 				}
 			}
 			log.Info("Creating Collection ConfigMap", "name", targetName, "collection", collectionName)
 			if err := r.Create(ctx, configMap); err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 		} else {
 			configMap.Data = src.Data
 			log.Info("Updating Collection ConfigMap", "name", targetName, "collection", collectionName)
 			if err := r.Update(ctx, configMap); err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 		}
 
-		cmNames = append(cmNames, targetName)
+		systemCMNames = append(systemCMNames, targetName)
 	}
 
-	return cmNames, nil
+	// --- Tenant collections (new) ---
+	// Discover ConfigMaps labeled evalhub-collection-type=tenant in the instance namespace.
+	var tenantList corev1.ConfigMapList
+	if err := r.List(ctx, &tenantList,
+		client.InNamespace(instance.Namespace),
+		client.MatchingLabels{collectionLabel: collectionTypeTenant}); err != nil {
+		return nil, nil, fmt.Errorf("failed to list tenant collection ConfigMaps in namespace %s: %w", instance.Namespace, err)
+	}
+
+	var tenantCMNames []string
+	for i := range tenantList.Items {
+		tenantCMNames = append(tenantCMNames, tenantList.Items[i].Name)
+		log.V(1).Info("Found tenant Collection ConfigMap", "name", tenantList.Items[i].Name)
+	}
+
+	return systemCMNames, tenantCMNames, nil
 }
 
 // collectionVolumeProjections builds VolumeProjection entries for mounting collection ConfigMaps

--- a/controllers/evalhub/constants.go
+++ b/controllers/evalhub/constants.go
@@ -82,10 +82,13 @@ const (
 	configDirPath = "/etc/evalhub/config"
 
 	// Provider ConfigMap configuration
-	providerLabel       = "trustyai.opendatahub.io/evalhub-provider-type"
-	providerNameLabel   = "trustyai.opendatahub.io/evalhub-provider-name"
-	providersVolumeName = "evalhub-providers"
-	providersMountPath  = configDirPath + "/providers"
+	providerLabel            = "trustyai.opendatahub.io/evalhub-provider-type"
+	providerNameLabel        = "trustyai.opendatahub.io/evalhub-provider-name"
+	providersVolumeName      = "evalhub-providers"
+	providersMountPath       = configDirPath + "/providers"
+	providerTypeSystem       = "system"
+	providerTypeTenant       = "tenant"
+	tenantProvidersMountPath = providersMountPath + "/tenant"
 
 	// Sidecar configuration
 	sidecarBaseURL = "http://localhost:8080"
@@ -110,10 +113,13 @@ const (
 	discoveryConfigMapLabel = "evalhub.trustyai.opendatahub.io/discovery"
 
 	// Collection ConfigMap configuration
-	collectionLabel       = "trustyai.opendatahub.io/evalhub-collection-type"
-	collectionNameLabel   = "trustyai.opendatahub.io/evalhub-collection-name"
-	collectionsVolumeName = "evalhub-collections"
-	collectionsMountPath  = configDirPath + "/collections"
+	collectionLabel            = "trustyai.opendatahub.io/evalhub-collection-type"
+	collectionNameLabel        = "trustyai.opendatahub.io/evalhub-collection-name"
+	collectionsVolumeName      = "evalhub-collections"
+	collectionsMountPath       = configDirPath + "/collections"
+	collectionTypeSystem       = "system"
+	collectionTypeTenant       = "tenant"
+	tenantCollectionsMountPath = collectionsMountPath + "/tenant"
 )
 
 var (

--- a/controllers/evalhub/deployment.go
+++ b/controllers/evalhub/deployment.go
@@ -15,8 +15,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// reconcileDeployment creates or updates the Deployment for EvalHub
-func (r *EvalHubReconciler) reconcileDeployment(ctx context.Context, instance *evalhubv1.EvalHub, providerCMNames []string, collectionCMNames []string) error {
+// reconcileDeployment creates or updates the Deployment for EvalHub.
+// systemProviderCMNames and systemCollectionCMNames are ConfigMaps copied from the operator namespace.
+// tenantProviderCMNames and tenantCollectionCMNames are ConfigMaps discovered directly in the instance namespace.
+func (r *EvalHubReconciler) reconcileDeployment(ctx context.Context, instance *evalhubv1.EvalHub, systemProviderCMNames, systemCollectionCMNames, tenantProviderCMNames, tenantCollectionCMNames []string) error {
 	log := log.FromContext(ctx)
 	log.Info("Reconciling Deployment", "name", instance.Name)
 
@@ -34,7 +36,7 @@ func (r *EvalHubReconciler) reconcileDeployment(ctx context.Context, instance *e
 	}
 
 	// Define the desired deployment spec
-	desiredSpec, err := r.buildDeploymentSpec(ctx, instance, providerCMNames, collectionCMNames)
+	desiredSpec, err := r.buildDeploymentSpec(ctx, instance, systemProviderCMNames, systemCollectionCMNames, tenantProviderCMNames, tenantCollectionCMNames)
 	if err != nil {
 		return err
 	}
@@ -59,7 +61,7 @@ func (r *EvalHubReconciler) reconcileDeployment(ctx context.Context, instance *e
 }
 
 // buildDeploymentSpec builds the deployment specification for EvalHub
-func (r *EvalHubReconciler) buildDeploymentSpec(ctx context.Context, instance *evalhubv1.EvalHub, providerCMNames []string, collectionCMNames []string) (appsv1.DeploymentSpec, error) {
+func (r *EvalHubReconciler) buildDeploymentSpec(ctx context.Context, instance *evalhubv1.EvalHub, systemProviderCMNames, systemCollectionCMNames, tenantProviderCMNames, tenantCollectionCMNames []string) (appsv1.DeploymentSpec, error) {
 	labels := map[string]string{
 		"app":       "eval-hub",
 		"instance":  instance.Name,
@@ -164,17 +166,31 @@ func (r *EvalHubReconciler) buildDeploymentSpec(ctx context.Context, instance *e
 			ReadOnly:  true,
 		},
 	}
-	if len(providerCMNames) > 0 {
+	if len(systemProviderCMNames) > 0 {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      providersVolumeName,
 			MountPath: providersMountPath,
 			ReadOnly:  true,
 		})
 	}
-	if len(collectionCMNames) > 0 {
+	if len(systemCollectionCMNames) > 0 {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      collectionsVolumeName,
 			MountPath: collectionsMountPath,
+			ReadOnly:  true,
+		})
+	}
+	if len(tenantProviderCMNames) > 0 {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      providersVolumeName + "-tenant",
+			MountPath: tenantProvidersMountPath,
+			ReadOnly:  true,
+		})
+	}
+	if len(tenantCollectionCMNames) > 0 {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      collectionsVolumeName + "-tenant",
+			MountPath: tenantCollectionsMountPath,
 			ReadOnly:  true,
 		})
 	}
@@ -343,22 +359,42 @@ func (r *EvalHubReconciler) buildDeploymentSpec(ctx context.Context, instance *e
 			},
 		},
 	}
-	if len(providerCMNames) > 0 {
+	if len(systemProviderCMNames) > 0 {
 		volumes = append(volumes, corev1.Volume{
 			Name: providersVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				Projected: &corev1.ProjectedVolumeSource{
-					Sources: providerVolumeProjections(providerCMNames),
+					Sources: providerVolumeProjections(systemProviderCMNames),
 				},
 			},
 		})
 	}
-	if len(collectionCMNames) > 0 {
+	if len(systemCollectionCMNames) > 0 {
 		volumes = append(volumes, corev1.Volume{
 			Name: collectionsVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				Projected: &corev1.ProjectedVolumeSource{
-					Sources: collectionVolumeProjections(collectionCMNames),
+					Sources: collectionVolumeProjections(systemCollectionCMNames),
+				},
+			},
+		})
+	}
+	if len(tenantProviderCMNames) > 0 {
+		volumes = append(volumes, corev1.Volume{
+			Name: providersVolumeName + "-tenant",
+			VolumeSource: corev1.VolumeSource{
+				Projected: &corev1.ProjectedVolumeSource{
+					Sources: providerVolumeProjections(tenantProviderCMNames),
+				},
+			},
+		})
+	}
+	if len(tenantCollectionCMNames) > 0 {
+		volumes = append(volumes, corev1.Volume{
+			Name: collectionsVolumeName + "-tenant",
+			VolumeSource: corev1.VolumeSource{
+				Projected: &corev1.ProjectedVolumeSource{
+					Sources: collectionVolumeProjections(tenantCollectionCMNames),
 				},
 			},
 		})

--- a/controllers/evalhub/deployment_test.go
+++ b/controllers/evalhub/deployment_test.go
@@ -78,7 +78,7 @@ var _ = Describe("EvalHub Deployment", func() {
 
 		It("should create deployment with correct specifications", func() {
 			By("Reconciling deployment")
-			err := reconciler.reconcileDeployment(ctx, evalHub, nil, nil)
+			err := reconciler.reconcileDeployment(ctx, evalHub, nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying deployment exists")
@@ -108,7 +108,7 @@ var _ = Describe("EvalHub Deployment", func() {
 
 		It("should configure evalhub container correctly", func() {
 			By("Reconciling deployment")
-			err := reconciler.reconcileDeployment(ctx, evalHub, nil, nil)
+			err := reconciler.reconcileDeployment(ctx, evalHub, nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Getting deployment")
@@ -160,7 +160,7 @@ var _ = Describe("EvalHub Deployment", func() {
 
 		It("should set default environment variables", func() {
 			By("Reconciling deployment")
-			err := reconciler.reconcileDeployment(ctx, evalHub, nil, nil)
+			err := reconciler.reconcileDeployment(ctx, evalHub, nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Getting deployment")
@@ -197,7 +197,7 @@ var _ = Describe("EvalHub Deployment", func() {
 
 		It("should include custom environment variables", func() {
 			By("Reconciling deployment")
-			err := reconciler.reconcileDeployment(ctx, evalHub, nil, nil)
+			err := reconciler.reconcileDeployment(ctx, evalHub, nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Getting deployment")
@@ -226,7 +226,7 @@ var _ = Describe("EvalHub Deployment", func() {
 
 		It("should configure resource requirements", func() {
 			By("Reconciling deployment")
-			err := reconciler.reconcileDeployment(ctx, evalHub, nil, nil)
+			err := reconciler.reconcileDeployment(ctx, evalHub, nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Getting deployment")
@@ -260,7 +260,7 @@ var _ = Describe("EvalHub Deployment", func() {
 
 		It("should configure security contexts", func() {
 			By("Reconciling deployment")
-			err := reconciler.reconcileDeployment(ctx, evalHub, nil, nil)
+			err := reconciler.reconcileDeployment(ctx, evalHub, nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Getting deployment")
@@ -289,7 +289,7 @@ var _ = Describe("EvalHub Deployment", func() {
 
 		It("should update existing deployment", func() {
 			By("Creating initial deployment")
-			err := reconciler.reconcileDeployment(ctx, evalHub, nil, nil)
+			err := reconciler.reconcileDeployment(ctx, evalHub, nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Modifying EvalHub replicas")
@@ -299,7 +299,7 @@ var _ = Describe("EvalHub Deployment", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Reconciling deployment again")
-			err = reconciler.reconcileDeployment(ctx, evalHub, nil, nil)
+			err = reconciler.reconcileDeployment(ctx, evalHub, nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying deployment is updated")
@@ -317,14 +317,14 @@ var _ = Describe("EvalHub Deployment", func() {
 			err := k8sClient.Delete(ctx, configMap)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = reconciler.reconcileDeployment(ctx, evalHub, nil, nil)
+			err = reconciler.reconcileDeployment(ctx, evalHub, nil, nil, nil, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("getting kube-rbac-proxy image"))
 		})
 
 		It("should configure rolling update strategy", func() {
 			By("Reconciling deployment")
-			err := reconciler.reconcileDeployment(ctx, evalHub, nil, nil)
+			err := reconciler.reconcileDeployment(ctx, evalHub, nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Getting deployment")
@@ -346,7 +346,7 @@ var _ = Describe("EvalHub Deployment", func() {
 			defer k8sClient.Delete(ctx, dbEvalHub)
 
 			By("Reconciling deployment")
-			err := reconciler.reconcileDeployment(ctx, dbEvalHub, nil, nil)
+			err := reconciler.reconcileDeployment(ctx, dbEvalHub, nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Getting deployment")
@@ -406,7 +406,7 @@ var _ = Describe("EvalHub Deployment", func() {
 			Expect(k8sClient.Create(ctx, evalHub)).Should(Succeed())
 
 			By("Reconciling deployment")
-			err := reconciler.reconcileDeployment(ctx, evalHub, nil, nil)
+			err := reconciler.reconcileDeployment(ctx, evalHub, nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Getting deployment")
@@ -442,7 +442,7 @@ var _ = Describe("EvalHub Deployment", func() {
 			}
 
 			By("Attempting to reconcile deployment")
-			err := reconciler.reconcileDeployment(ctx, nonExistentEvalHub, nil, nil)
+			err := reconciler.reconcileDeployment(ctx, nonExistentEvalHub, nil, nil, nil, nil)
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -456,7 +456,7 @@ var _ = Describe("EvalHub Deployment", func() {
 
 		It("should mount TLS secret on kube-rbac-proxy container", func() {
 			By("Reconciling deployment")
-			err := reconciler.reconcileDeployment(ctx, evalHub, nil, nil)
+			err := reconciler.reconcileDeployment(ctx, evalHub, nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Getting deployment")
@@ -486,7 +486,7 @@ var _ = Describe("EvalHub Deployment", func() {
 
 		It("should configure deployment volumes", func() {
 			By("Reconciling deployment")
-			err := reconciler.reconcileDeployment(ctx, evalHub, nil, nil)
+			err := reconciler.reconcileDeployment(ctx, evalHub, nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Getting deployment")
@@ -518,7 +518,7 @@ var _ = Describe("EvalHub Deployment", func() {
 
 		It("should configure service account for API", func() {
 			By("Reconciling deployment")
-			err := reconciler.reconcileDeployment(ctx, evalHub, nil, nil)
+			err := reconciler.reconcileDeployment(ctx, evalHub, nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Getting deployment")
@@ -599,7 +599,7 @@ var _ = Describe("EvalHubReconciler reconcileDeployment", func() {
 	})
 
 	It("creates the Deployment with expected pod spec from reconcileDeployment", func() {
-		Expect(reconciler.reconcileDeployment(ctx, evalHubInst, nil, nil)).To(Succeed())
+		Expect(reconciler.reconcileDeployment(ctx, evalHubInst, nil, nil, nil, nil)).To(Succeed())
 
 		deployment := waitForDeployment(parityEvalHubName, testNamespace)
 		Expect(deployment.Name).To(Equal(parityEvalHubName))
@@ -694,7 +694,7 @@ var _ = Describe("EvalHubReconciler reconcileDeployment", func() {
 			OperatorConfigMapName: configMapName,
 			EventRecorder:         record.NewFakeRecorder(100),
 		}
-		err := r.reconcileDeployment(ctx, fh, nil, nil)
+		err := r.reconcileDeployment(ctx, fh, nil, nil, nil, nil)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("getting kube-rbac-proxy image"))
 	})

--- a/controllers/evalhub/evalhub_controller.go
+++ b/controllers/evalhub/evalhub_controller.go
@@ -143,6 +143,26 @@ func (r *EvalHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return RequeueWithError(fmt.Errorf("spec.database.secret is required for postgresql"))
 	}
 
+	// Security invariant: a multi-tenant EvalHub instance must never be deployed in a tenant
+	// namespace. Multi-tenant EH is control-plane; eval jobs are data-plane.
+	if !instance.Spec.IsSingleTenancy() {
+		ns := &corev1.Namespace{}
+		if err := r.Get(ctx, types.NamespacedName{Name: instance.Namespace}, ns); err == nil {
+			if _, isTenant := ns.Labels[tenantLabel]; isTenant {
+				log.Error(nil, "Multi-tenant EvalHub must not be deployed in a tenant namespace",
+					"namespace", instance.Namespace)
+				instance.SetStatus("Ready", "InvalidPlacement",
+					"A multi-tenant EvalHub instance must not be deployed in a tenant namespace. "+
+						"Remove the evalhub.trustyai.opendatahub.io/tenant label from this namespace "+
+						"or set spec.tenancy: single.",
+					corev1.ConditionFalse)
+				instance.Status.Phase = "Error"
+				r.Status().Update(ctx, instance)
+				return DoNotRequeue()
+			}
+		}
+	}
+
 	// Create ServiceAccount for EvalHub
 	err = r.createServiceAccount(ctx, instance)
 	if err != nil {
@@ -186,8 +206,8 @@ func (r *EvalHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return RequeueWithError(err)
 	}
 
-	// Reconcile Provider ConfigMaps (copy from operator namespace to instance namespace)
-	providerCMNames, err := r.reconcileProviderConfigMaps(ctx, instance)
+	// Reconcile Provider ConfigMaps (system from operator namespace + tenant from instance namespace)
+	systemProviderCMNames, tenantProviderCMNames, err := r.reconcileProviderConfigMaps(ctx, instance)
 	if err != nil {
 		log.Error(err, "Failed to reconcile Provider ConfigMaps")
 		instance.SetStatus("Ready", "Error", fmt.Sprintf("Failed to reconcile Provider ConfigMaps: %v", err), corev1.ConditionFalse)
@@ -196,8 +216,8 @@ func (r *EvalHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 	instance.Status.ActiveProviders = instance.Spec.Providers
 
-	// Reconcile Collection ConfigMaps (copy from operator namespace to instance namespace)
-	collectionCMNames, err := r.reconcileCollectionConfigMaps(ctx, instance)
+	// Reconcile Collection ConfigMaps (system from operator namespace + tenant from instance namespace)
+	systemCollectionCMNames, tenantCollectionCMNames, err := r.reconcileCollectionConfigMaps(ctx, instance)
 	if err != nil {
 		log.Error(err, "Failed to reconcile Collection ConfigMaps")
 		instance.SetStatus("Ready", "Error", fmt.Sprintf("Failed to reconcile Collection ConfigMaps: %v", err), corev1.ConditionFalse)
@@ -207,7 +227,7 @@ func (r *EvalHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	instance.Status.ActiveCollections = instance.Spec.Collections
 
 	// Reconcile Deployment
-	if err := r.reconcileDeployment(ctx, instance, providerCMNames, collectionCMNames); err != nil {
+	if err := r.reconcileDeployment(ctx, instance, systemProviderCMNames, systemCollectionCMNames, tenantProviderCMNames, tenantCollectionCMNames); err != nil {
 		log.Error(err, "Failed to reconcile Deployment")
 		instance.SetStatus("Ready", "Error", fmt.Sprintf("Failed to reconcile Deployment: %v", err), corev1.ConditionFalse)
 		r.Status().Update(ctx, instance)
@@ -287,7 +307,8 @@ func (r *EvalHubReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}, builder.OnlyMetadata).
 		Owns(&corev1.ConfigMap{}, builder.OnlyMetadata).
-		Watches(&corev1.Namespace{}, handler.EnqueueRequestsFromMapFunc(r.mapNamespaceToEvalHubs), builder.OnlyMetadata, builder.WithPredicates(tenantLabelPredicate()))
+		Watches(&corev1.Namespace{}, handler.EnqueueRequestsFromMapFunc(r.mapNamespaceToEvalHubs), builder.OnlyMetadata, builder.WithPredicates(tenantLabelPredicate())).
+		Watches(&corev1.ConfigMap{}, handler.EnqueueRequestsFromMapFunc(r.mapTenantConfigMapToEvalHub), builder.WithPredicates(tenantConfigMapPredicate()))
 
 	if r.isServiceMonitorSupported() {
 		b = b.Owns(&monitoringv1.ServiceMonitor{}, builder.OnlyMetadata)
@@ -356,6 +377,39 @@ func (r *EvalHubReconciler) mapNamespaceToEvalHubs(ctx context.Context, _ client
 				Name:      eh.Name,
 				Namespace: eh.Namespace,
 			},
+		}
+	}
+	return requests
+}
+
+// tenantConfigMapPredicate returns a predicate that fires only for ConfigMaps
+// labeled as tenant providers or tenant collections. This avoids reconciling on
+// every ConfigMap change cluster-wide.
+func tenantConfigMapPredicate() predicate.Predicate {
+	hasTenantLabel := func(obj client.Object) bool {
+		labels := obj.GetLabels()
+		return labels[providerLabel] == providerTypeTenant || labels[collectionLabel] == collectionTypeTenant
+	}
+	return predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return hasTenantLabel(e.Object) },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return hasTenantLabel(e.ObjectNew) || hasTenantLabel(e.ObjectOld) },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return hasTenantLabel(e.Object) },
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+	}
+}
+
+// mapTenantConfigMapToEvalHub maps a tenant ConfigMap event to reconcile requests
+// for all EvalHub instances in the same namespace.
+func (r *EvalHubReconciler) mapTenantConfigMapToEvalHub(ctx context.Context, obj client.Object) []ctrl.Request {
+	evalHubList := &evalhubv1.EvalHubList{}
+	if err := r.List(ctx, evalHubList, client.InNamespace(obj.GetNamespace())); err != nil {
+		log.FromContext(ctx).Error(err, "Failed to list EvalHub instances for ConfigMap watch")
+		return nil
+	}
+	requests := make([]ctrl.Request, len(evalHubList.Items))
+	for i, eh := range evalHubList.Items {
+		requests[i] = ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: eh.Name, Namespace: eh.Namespace},
 		}
 	}
 	return requests

--- a/controllers/evalhub/evalhub_controller.go
+++ b/controllers/evalhub/evalhub_controller.go
@@ -147,19 +147,22 @@ func (r *EvalHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// namespace. Multi-tenant EH is control-plane; eval jobs are data-plane.
 	if !instance.Spec.IsSingleTenancy() {
 		ns := &corev1.Namespace{}
-		if err := r.Get(ctx, types.NamespacedName{Name: instance.Namespace}, ns); err == nil {
-			if _, isTenant := ns.Labels[tenantLabel]; isTenant {
-				log.Error(nil, "Multi-tenant EvalHub must not be deployed in a tenant namespace",
-					"namespace", instance.Namespace)
-				instance.SetStatus("Ready", "InvalidPlacement",
-					"A multi-tenant EvalHub instance must not be deployed in a tenant namespace. "+
-						"Remove the evalhub.trustyai.opendatahub.io/tenant label from this namespace "+
-						"or set spec.tenancy: single.",
-					corev1.ConditionFalse)
-				instance.Status.Phase = "Error"
-				r.Status().Update(ctx, instance)
-				return DoNotRequeue()
-			}
+		if err := r.Get(ctx, types.NamespacedName{Name: instance.Namespace}, ns); err != nil {
+			return RequeueWithError(fmt.Errorf("cannot verify namespace labels for placement guard: %w", err))
+		}
+		if _, isTenant := ns.Labels[tenantLabel]; isTenant {
+			log.Error(nil, "Multi-tenant EvalHub must not be deployed in a tenant namespace",
+				"namespace", instance.Namespace)
+			instance.SetStatus("Ready", "InvalidPlacement",
+				"A multi-tenant EvalHub instance must not be deployed in a tenant namespace. "+
+					"Remove the evalhub.trustyai.opendatahub.io/tenant label from this namespace "+
+					"or set spec.tenancy: single.",
+				corev1.ConditionFalse)
+			instance.Status.Phase = "Error"
+			r.Status().Update(ctx, instance)
+			r.EventRecorder.Event(instance, corev1.EventTypeWarning, "InvalidPlacement",
+				"Multi-tenant EvalHub must not be deployed in a tenant namespace")
+			return DoNotRequeue()
 		}
 	}
 

--- a/controllers/evalhub/evalhub_controller.go
+++ b/controllers/evalhub/evalhub_controller.go
@@ -65,7 +65,7 @@ type EvalHubReconciler struct {
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch;update
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,resourceNames=trustyai-service-operator-evalhub-model-secret,verbs=bind
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,resourceNames=trustyai-service-operator-evalhub-auth-reviewer-role;trustyai-service-operator-evalhub-jobs-writer;trustyai-service-operator-evalhub-job-config;trustyai-service-operator-evalhub-hardware-profiles-reader;trustyai-service-operator-evalhub-providers-access;trustyai-service-operator-evalhub-collections-access;trustyai-service-operator-evalhub-model-secret;trustyai-service-operator-evalhub-mlflow-access;trustyai-service-operator-evalhub-mlflow-jobs-access,verbs=bind
 //+kubebuilder:rbac:groups=infrastructure.opendatahub.io,resources=hardwareprofiles,verbs=get;list
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
@@ -189,6 +189,14 @@ func (r *EvalHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if err := r.reconcileTenantNamespaces(ctx, instance); err != nil {
 		log.Error(err, "Failed to reconcile tenant namespaces")
 		instance.SetStatus("Ready", "Error", fmt.Sprintf("Failed to reconcile tenant namespaces: %v", err), corev1.ConditionFalse)
+		r.Status().Update(ctx, instance)
+		return RequeueWithError(err)
+	}
+
+	// Reconcile single-tenancy Roles (tenant-admin, user) or clean them up in multi mode.
+	if err := r.reconcileSingleTenancyRoles(ctx, instance); err != nil {
+		log.Error(err, "Failed to reconcile single-tenancy roles")
+		instance.SetStatus("Ready", "Error", fmt.Sprintf("Failed to reconcile single-tenancy roles: %v", err), corev1.ConditionFalse)
 		r.Status().Update(ctx, instance)
 		return RequeueWithError(err)
 	}

--- a/controllers/evalhub/tenant_namespaces.go
+++ b/controllers/evalhub/tenant_namespaces.go
@@ -25,8 +25,15 @@ const (
 // removes stale resources from namespaces that no longer carry the tenant label.
 func (r *EvalHubReconciler) reconcileTenantNamespaces(ctx context.Context, instance *evalhubv1.EvalHub) error {
 	if instance.Spec.IsSingleTenancy() {
-		// Single-tenant mode: the EvalHub instance serves only its own namespace.
-		// No cross-namespace tenant label discovery is performed.
+		// Single-tenant mode: no cross-namespace provisioning. Clean up any
+		// tenant resources that may remain from a previous multi-tenant config.
+		noTenants := map[string]bool{}
+		if err := r.cleanupStaleTenantResources(ctx, instance, noTenants); err != nil {
+			return err
+		}
+		if err := r.cleanupDiscoveryConfigMaps(ctx, instance, noTenants); err != nil {
+			return err
+		}
 		return nil
 	}
 

--- a/controllers/evalhub/tenant_namespaces.go
+++ b/controllers/evalhub/tenant_namespaces.go
@@ -24,6 +24,12 @@ const (
 // the job ServiceAccount and API SA RoleBindings exist in each one. It also
 // removes stale resources from namespaces that no longer carry the tenant label.
 func (r *EvalHubReconciler) reconcileTenantNamespaces(ctx context.Context, instance *evalhubv1.EvalHub) error {
+	if instance.Spec.IsSingleTenancy() {
+		// Single-tenant mode: the EvalHub instance serves only its own namespace.
+		// No cross-namespace tenant label discovery is performed.
+		return nil
+	}
+
 	log := log.FromContext(ctx)
 
 	// List namespaces with the tenant label

--- a/controllers/evalhub/tenant_roles.go
+++ b/controllers/evalhub/tenant_roles.go
@@ -1,0 +1,232 @@
+package evalhub
+
+import (
+	"context"
+
+	evalhubv1 "github.com/trustyai-explainability/trustyai-service-operator/api/evalhub/v1"
+	"github.com/trustyai-explainability/trustyai-service-operator/controllers/constants"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	tenantAdminRoleName    = "evalhub-tenant-admin"
+	tenantUserRoleName     = "evalhub-user"
+	tenantAdminBindingName = "evalhub-tenant-admin-binding"
+)
+
+func tenantAdminRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{"trustyai.opendatahub.io"},
+			Resources: []string{"evalhubs"},
+			Verbs:     []string{"get"},
+		},
+		{
+			APIGroups: []string{"trustyai.opendatahub.io"},
+			Resources: []string{"evalhubs/proxy"},
+			Verbs:     []string{"get", "create"},
+		},
+		{
+			APIGroups: []string{"trustyai.opendatahub.io"},
+			Resources: []string{"providers"},
+			Verbs:     []string{"get", "list"},
+		},
+		{
+			APIGroups: []string{"trustyai.opendatahub.io"},
+			Resources: []string{"collections"},
+			Verbs:     []string{"get", "list", "create", "update", "patch", "delete"},
+		},
+		{
+			APIGroups: []string{"trustyai.opendatahub.io"},
+			Resources: []string{"status-events"},
+			Verbs:     []string{"create"},
+		},
+		{
+			APIGroups: []string{"mlflow.kubeflow.org"},
+			Resources: []string{"experiments"},
+			Verbs:     []string{"get", "list"},
+		},
+	}
+}
+
+func tenantUserRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{"trustyai.opendatahub.io"},
+			Resources: []string{"evalhubs"},
+			Verbs:     []string{"get"},
+		},
+		{
+			APIGroups: []string{"trustyai.opendatahub.io"},
+			Resources: []string{"evalhubs/proxy"},
+			Verbs:     []string{"get", "create"},
+		},
+		{
+			APIGroups: []string{"trustyai.opendatahub.io"},
+			Resources: []string{"providers"},
+			Verbs:     []string{"get", "list"},
+		},
+		{
+			APIGroups: []string{"trustyai.opendatahub.io"},
+			Resources: []string{"collections"},
+			Verbs:     []string{"get", "list"},
+		},
+		{
+			APIGroups: []string{"trustyai.opendatahub.io"},
+			Resources: []string{"status-events"},
+			Verbs:     []string{"create"},
+		},
+		{
+			APIGroups: []string{"mlflow.kubeflow.org"},
+			Resources: []string{"experiments"},
+			Verbs:     []string{"get", "list", "create"},
+		},
+	}
+}
+
+func tenantRoleLabels(instance *evalhubv1.EvalHub, name string) map[string]string {
+	return map[string]string{
+		"app":                          "eval-hub",
+		"app.kubernetes.io/name":       name,
+		"app.kubernetes.io/instance":   instance.Name,
+		"app.kubernetes.io/part-of":    "eval-hub",
+		"app.kubernetes.io/version":    constants.Version,
+		"app.kubernetes.io/component":  "tenancy",
+		"app.kubernetes.io/managed-by": "trustyai-service-operator",
+	}
+}
+
+// reconcileSingleTenancyRoles creates or cleans up namespace-scoped Roles and
+// RoleBindings for self-service single-tenant EvalHub deployments.
+// In single mode it provisions evalhub-tenant-admin and evalhub-user Roles.
+// In multi mode it removes any leftover tenant Roles from a previous config.
+func (r *EvalHubReconciler) reconcileSingleTenancyRoles(ctx context.Context, instance *evalhubv1.EvalHub) error {
+	if !instance.Spec.IsSingleTenancy() {
+		return r.cleanupSingleTenancyRoles(ctx, instance)
+	}
+
+	if err := r.createTenantRole(ctx, instance, tenantAdminRoleName, tenantAdminRules()); err != nil {
+		return err
+	}
+	if err := r.createTenantRole(ctx, instance, tenantUserRoleName, tenantUserRules()); err != nil {
+		return err
+	}
+	return r.createTenantAdminBinding(ctx, instance)
+}
+
+func (r *EvalHubReconciler) createTenantRole(ctx context.Context, instance *evalhubv1.EvalHub, name string, rules []rbacv1.PolicyRule) error {
+	log := log.FromContext(ctx)
+
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: instance.Namespace,
+			Labels:    tenantRoleLabels(instance, name),
+		},
+		Rules: rules,
+	}
+
+	if err := ctrl.SetControllerReference(instance, role, r.Scheme); err != nil {
+		return err
+	}
+
+	found := &rbacv1.Role{}
+	err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: instance.Namespace}, found)
+	if err != nil && errors.IsNotFound(err) {
+		log.Info("Creating tenant Role", "Name", name)
+		return r.Create(ctx, role)
+	} else if err != nil {
+		return err
+	}
+
+	if !equalPolicyRules(found.Rules, role.Rules) {
+		found.Rules = role.Rules
+		log.Info("Updating tenant Role rules", "Name", name)
+		return r.Update(ctx, found)
+	}
+	return nil
+}
+
+func (r *EvalHubReconciler) createTenantAdminBinding(ctx context.Context, instance *evalhubv1.EvalHub) error {
+	log := log.FromContext(ctx)
+
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      tenantAdminBindingName,
+			Namespace: instance.Namespace,
+			Labels:    tenantRoleLabels(instance, tenantAdminBindingName),
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:     "Group",
+				Name:     "system:serviceaccounts:" + instance.Namespace,
+				APIGroup: rbacv1.GroupName,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "Role",
+			Name:     tenantAdminRoleName,
+			APIGroup: rbacv1.GroupName,
+		},
+	}
+
+	if err := ctrl.SetControllerReference(instance, rb, r.Scheme); err != nil {
+		return err
+	}
+
+	found := &rbacv1.RoleBinding{}
+	err := r.Get(ctx, types.NamespacedName{Name: rb.Name, Namespace: rb.Namespace}, found)
+	if err != nil && errors.IsNotFound(err) {
+		log.Info("Creating tenant admin RoleBinding", "Name", rb.Name)
+		return r.Create(ctx, rb)
+	} else if err != nil {
+		return err
+	}
+
+	if !equalRoleBindingRoleRef(found.RoleRef, rb.RoleRef) {
+		log.Info("RoleRef differs, deleting and recreating tenant admin RoleBinding", "Name", rb.Name)
+		if err := r.Delete(ctx, found); err != nil {
+			return err
+		}
+		return r.Create(ctx, rb)
+	}
+	if !equalRoleBindingSubjects(found.Subjects, rb.Subjects) {
+		found.Subjects = rb.Subjects
+		log.Info("Updating tenant admin RoleBinding subjects", "Name", rb.Name)
+		return r.Update(ctx, found)
+	}
+	return nil
+}
+
+func (r *EvalHubReconciler) cleanupSingleTenancyRoles(ctx context.Context, instance *evalhubv1.EvalHub) error {
+	log := log.FromContext(ctx)
+	ns := instance.Namespace
+
+	rb := &rbacv1.RoleBinding{}
+	if err := r.Get(ctx, types.NamespacedName{Name: tenantAdminBindingName, Namespace: ns}, rb); err == nil {
+		log.Info("Removing tenant admin RoleBinding", "Name", tenantAdminBindingName)
+		if err := r.Delete(ctx, rb); err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+	} else if !errors.IsNotFound(err) {
+		return err
+	}
+
+	for _, name := range []string{tenantAdminRoleName, tenantUserRoleName} {
+		role := &rbacv1.Role{}
+		if err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: ns}, role); err == nil {
+			log.Info("Removing tenant Role", "Name", name)
+			if err := r.Delete(ctx, role); err != nil && !errors.IsNotFound(err) {
+				return err
+			}
+		} else if !errors.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
+}

--- a/controllers/evalhub/tenant_roles_test.go
+++ b/controllers/evalhub/tenant_roles_test.go
@@ -1,0 +1,213 @@
+package evalhub
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	evalhubv1 "github.com/trustyai-explainability/trustyai-service-operator/api/evalhub/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newTenantRolesReconciler(t *testing.T, instance *evalhubv1.EvalHub) *EvalHubReconciler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, evalhubv1.AddToScheme(scheme))
+	require.NoError(t, rbacv1.AddToScheme(scheme))
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(instance).
+		Build()
+
+	return &EvalHubReconciler{
+		Client:        fakeClient,
+		Scheme:        scheme,
+		Namespace:     instance.Namespace,
+		EventRecorder: record.NewFakeRecorder(10),
+	}
+}
+
+func singleTenantInstance(name, namespace string) *evalhubv1.EvalHub {
+	return &evalhubv1.EvalHub{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: evalhubv1.EvalHubSpec{
+			Tenancy: evalhubv1.TenancySingle,
+		},
+	}
+}
+
+func multiTenantInstance(name, namespace string) *evalhubv1.EvalHub {
+	return &evalhubv1.EvalHub{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: evalhubv1.EvalHubSpec{
+			Tenancy: evalhubv1.TenancyMulti,
+		},
+	}
+}
+
+func TestReconcileSingleTenancyRolesCreatesRolesInSingleMode(t *testing.T) {
+	ctx := context.Background()
+	instance := singleTenantInstance("my-evalhub", "team-a")
+	r := newTenantRolesReconciler(t, instance)
+
+	err := r.reconcileSingleTenancyRoles(ctx, instance)
+	require.NoError(t, err)
+
+	// Verify tenant-admin Role
+	adminRole := &rbacv1.Role{}
+	err = r.Get(ctx, types.NamespacedName{Name: tenantAdminRoleName, Namespace: "team-a"}, adminRole)
+	require.NoError(t, err)
+	assert.Equal(t, tenantAdminRoleName, adminRole.Name)
+	assert.True(t, len(adminRole.Rules) > 0, "tenant-admin Role should have rules")
+
+	// Verify tenant-user Role
+	userRole := &rbacv1.Role{}
+	err = r.Get(ctx, types.NamespacedName{Name: tenantUserRoleName, Namespace: "team-a"}, userRole)
+	require.NoError(t, err)
+	assert.Equal(t, tenantUserRoleName, userRole.Name)
+	assert.True(t, len(userRole.Rules) > 0, "tenant-user Role should have rules")
+
+	// Verify tenant-admin-binding RoleBinding
+	rb := &rbacv1.RoleBinding{}
+	err = r.Get(ctx, types.NamespacedName{Name: tenantAdminBindingName, Namespace: "team-a"}, rb)
+	require.NoError(t, err)
+	assert.Equal(t, tenantAdminRoleName, rb.RoleRef.Name)
+	assert.Equal(t, "Role", rb.RoleRef.Kind)
+	require.Len(t, rb.Subjects, 1)
+	assert.Equal(t, "Group", rb.Subjects[0].Kind)
+	assert.Equal(t, "system:serviceaccounts:team-a", rb.Subjects[0].Name)
+}
+
+func TestReconcileSingleTenancyRolesSkipsInMultiMode(t *testing.T) {
+	ctx := context.Background()
+	instance := multiTenantInstance("my-evalhub", "team-b")
+	r := newTenantRolesReconciler(t, instance)
+
+	err := r.reconcileSingleTenancyRoles(ctx, instance)
+	require.NoError(t, err)
+
+	// Verify no Roles or RoleBindings were created
+	adminRole := &rbacv1.Role{}
+	err = r.Get(ctx, types.NamespacedName{Name: tenantAdminRoleName, Namespace: "team-b"}, adminRole)
+	assert.True(t, err != nil, "tenant-admin Role should not exist in multi mode")
+
+	userRole := &rbacv1.Role{}
+	err = r.Get(ctx, types.NamespacedName{Name: tenantUserRoleName, Namespace: "team-b"}, userRole)
+	assert.True(t, err != nil, "tenant-user Role should not exist in multi mode")
+
+	rb := &rbacv1.RoleBinding{}
+	err = r.Get(ctx, types.NamespacedName{Name: tenantAdminBindingName, Namespace: "team-b"}, rb)
+	assert.True(t, err != nil, "tenant-admin-binding should not exist in multi mode")
+}
+
+func TestReconcileSingleTenancyRolesCleanupOnModeSwitch(t *testing.T) {
+	ctx := context.Background()
+	instance := singleTenantInstance("my-evalhub", "team-c")
+	r := newTenantRolesReconciler(t, instance)
+
+	// First: create Roles in single mode
+	err := r.reconcileSingleTenancyRoles(ctx, instance)
+	require.NoError(t, err)
+
+	// Verify they exist
+	adminRole := &rbacv1.Role{}
+	require.NoError(t, r.Get(ctx, types.NamespacedName{Name: tenantAdminRoleName, Namespace: "team-c"}, adminRole))
+
+	// Switch to multi mode
+	instance.Spec.Tenancy = evalhubv1.TenancyMulti
+	err = r.reconcileSingleTenancyRoles(ctx, instance)
+	require.NoError(t, err)
+
+	// Verify cleanup
+	err = r.Get(ctx, types.NamespacedName{Name: tenantAdminRoleName, Namespace: "team-c"}, adminRole)
+	assert.True(t, err != nil, "tenant-admin Role should be deleted after switch to multi")
+
+	userRole := &rbacv1.Role{}
+	err = r.Get(ctx, types.NamespacedName{Name: tenantUserRoleName, Namespace: "team-c"}, userRole)
+	assert.True(t, err != nil, "tenant-user Role should be deleted after switch to multi")
+
+	rb := &rbacv1.RoleBinding{}
+	err = r.Get(ctx, types.NamespacedName{Name: tenantAdminBindingName, Namespace: "team-c"}, rb)
+	assert.True(t, err != nil, "tenant-admin-binding should be deleted after switch to multi")
+}
+
+func TestTenantAdminRoleRulesAreMinimalAndSufficient(t *testing.T) {
+	rules := tenantAdminRules()
+
+	ruleMap := make(map[string][]string)
+	for _, rule := range rules {
+		for _, res := range rule.Resources {
+			key := rule.APIGroups[0] + "/" + res
+			ruleMap[key] = rule.Verbs
+		}
+	}
+
+	// Verify expected resources are present
+	assert.Contains(t, ruleMap, "trustyai.opendatahub.io/evalhubs")
+	assert.Contains(t, ruleMap, "trustyai.opendatahub.io/evalhubs/proxy")
+	assert.Contains(t, ruleMap, "trustyai.opendatahub.io/providers")
+	assert.Contains(t, ruleMap, "trustyai.opendatahub.io/collections")
+	assert.Contains(t, ruleMap, "trustyai.opendatahub.io/status-events")
+	assert.Contains(t, ruleMap, "mlflow.kubeflow.org/experiments")
+
+	// Verify collections has full CRUD
+	assert.ElementsMatch(t, []string{"get", "list", "create", "update", "patch", "delete"}, ruleMap["trustyai.opendatahub.io/collections"])
+
+	// Verify providers is read-only
+	assert.ElementsMatch(t, []string{"get", "list"}, ruleMap["trustyai.opendatahub.io/providers"])
+
+	// Verify no unexpected resources
+	assert.Len(t, ruleMap, 6, "tenant-admin should have exactly 6 resource rules")
+}
+
+func TestTenantUserRoleRulesAreMinimalAndSufficient(t *testing.T) {
+	rules := tenantUserRules()
+
+	ruleMap := make(map[string][]string)
+	for _, rule := range rules {
+		for _, res := range rule.Resources {
+			key := rule.APIGroups[0] + "/" + res
+			ruleMap[key] = rule.Verbs
+		}
+	}
+
+	// Verify collections is read-only (no create/update/patch/delete)
+	assert.ElementsMatch(t, []string{"get", "list"}, ruleMap["trustyai.opendatahub.io/collections"])
+
+	// Verify proxy includes create (for submitting evaluations)
+	assert.ElementsMatch(t, []string{"get", "create"}, ruleMap["trustyai.opendatahub.io/evalhubs/proxy"])
+
+	// Verify MLflow includes create
+	assert.ElementsMatch(t, []string{"get", "list", "create"}, ruleMap["mlflow.kubeflow.org/experiments"])
+
+	// Verify no unexpected resources
+	assert.Len(t, ruleMap, 6, "tenant-user should have exactly 6 resource rules")
+}
+
+func TestReconcileSingleTenancyRolesIdempotent(t *testing.T) {
+	ctx := context.Background()
+	instance := singleTenantInstance("my-evalhub", "team-d")
+	r := newTenantRolesReconciler(t, instance)
+
+	// Run twice — second call should be a no-op
+	require.NoError(t, r.reconcileSingleTenancyRoles(ctx, instance))
+	require.NoError(t, r.reconcileSingleTenancyRoles(ctx, instance))
+
+	// Verify resources still exist and are correct
+	adminRole := &rbacv1.Role{}
+	require.NoError(t, r.Get(ctx, types.NamespacedName{Name: tenantAdminRoleName, Namespace: "team-d"}, adminRole))
+	assert.True(t, equalPolicyRules(adminRole.Rules, tenantAdminRules()))
+}

--- a/controllers/evalhub/unit_test.go
+++ b/controllers/evalhub/unit_test.go
@@ -1342,7 +1342,7 @@ func TestEvalHubReconciler_reconcileDeployment_WithDB(t *testing.T) {
 	}
 
 	t.Run("should add DB secret volume and mount when database configured", func(t *testing.T) {
-		err := reconciler.reconcileDeployment(ctx, evalHub, nil, nil)
+		err := reconciler.reconcileDeployment(ctx, evalHub, nil, nil, nil, nil)
 		require.NoError(t, err)
 
 		deployment := &appsv1.Deployment{}
@@ -1480,7 +1480,7 @@ func TestEvalHubReconciler_reconcileProviderConfigMaps(t *testing.T) {
 			EventRecorder: record.NewFakeRecorder(10),
 		}
 
-		cmNames, err := reconciler.reconcileProviderConfigMaps(ctx, evalHub)
+		cmNames, _, err := reconciler.reconcileProviderConfigMaps(ctx, evalHub)
 		require.NoError(t, err)
 
 		// Should return the target ConfigMap name
@@ -1518,7 +1518,7 @@ func TestEvalHubReconciler_reconcileProviderConfigMaps(t *testing.T) {
 			EventRecorder: record.NewFakeRecorder(10),
 		}
 
-		cmNames, err := reconciler.reconcileProviderConfigMaps(ctx, evalHub)
+		cmNames, _, err := reconciler.reconcileProviderConfigMaps(ctx, evalHub)
 		require.NoError(t, err)
 		assert.Nil(t, cmNames)
 	})
@@ -1546,7 +1546,7 @@ func TestEvalHubReconciler_reconcileProviderConfigMaps(t *testing.T) {
 			EventRecorder: record.NewFakeRecorder(10),
 		}
 
-		cmNames, err := reconciler.reconcileProviderConfigMaps(ctx, evalHub)
+		cmNames, _, err := reconciler.reconcileProviderConfigMaps(ctx, evalHub)
 		require.Error(t, err)
 		assert.Nil(t, cmNames)
 		assert.Contains(t, err.Error(), "not found")
@@ -1587,12 +1587,12 @@ func TestEvalHubReconciler_reconcileProviderConfigMaps(t *testing.T) {
 		}
 
 		// First reconcile provider ConfigMaps
-		cmNames, err := reconciler.reconcileProviderConfigMaps(ctx, evalHub)
+		cmNames, _, err := reconciler.reconcileProviderConfigMaps(ctx, evalHub)
 		require.NoError(t, err)
 		require.Len(t, cmNames, 1)
 
 		// Then reconcile deployment with the provider ConfigMap names
-		err = reconciler.reconcileDeployment(ctx, evalHub, cmNames, nil)
+		err = reconciler.reconcileDeployment(ctx, evalHub, cmNames, nil, nil, nil)
 		require.NoError(t, err)
 
 		// Verify the deployment has the projected volume


### PR DESCRIPTION
## What and why

Adds a `spec.tenancy` field to the EvalHub CRD to express whether an instance runs in shared control-plane mode (`multi`, default) or self-service per-namespace mode (`single`).

This unblocks the single-tenant deployment path where an EvalHub instance lives in the same namespace as its users, without needing cross-namespace tenant label discovery.

Alongside the tenancy mode, this PR adds support for tenant-scoped providers and collections: ConfigMaps labeled `evalhub-provider-type=tenant` or `evalhub-collection-type=tenant` in the instance namespace are now discovered and mounted at a separate path (`/etc/evalhub/config/providers/tenant/` and `/etc/evalhub/config/collections/tenant/`), isolating them from system providers to prevent shadowing.

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [ ] Tested manually

## Breaking changes

`reconcileProviderConfigMaps` and `reconcileCollectionConfigMaps` now return `([]string, []string, error)` instead of `([]string, error)`. This is an internal controller change and does not affect the CRD API or any external callers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable tenancy mode (single or multi-tenant) for EvalHub deployments, with multi-tenant as default.
  * Added validation to prevent multi-tenant deployments in tenant-labeled namespaces.

* **Improvements**
  * Enhanced support for both system-scoped and tenant-scoped provider and collection resources.
  * Updated RBAC permissions for cluster role binding flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->