### PR TITLE
feat(namespace): add APPLICATIONS_NAMESPACE env var support to GetNamespace()

### DIFF
--- a/controllers/utils/utils.go
+++ b/controllers/utils/utils.go
@@ -49,6 +49,9 @@ func AllTrue(array []bool) bool {
 	return true
 }
 
+// Default service account namespace file path (overridable for testing)
+var serviceAccountNamespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+
 // GetNamespace returns the namespace where operands should be deployed.
 // It checks APPLICATIONS_NAMESPACE environment variable first (injected by platform operator in modular deployments),
 // then falls back to reading the service account namespace file.
@@ -59,7 +62,7 @@ func GetNamespace() (string, error) {
 	}
 
 	// Fall back to service account namespace file
-	ns, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	ns, err := os.ReadFile(serviceAccountNamespaceFile)
 	if err != nil {
 		return "", err
 	}

--- a/controllers/utils/utils.go
+++ b/controllers/utils/utils.go
@@ -49,8 +49,16 @@ func AllTrue(array []bool) bool {
 	return true
 }
 
-// GetNamespace returns the namespace of the pod.
+// GetNamespace returns the namespace where operands should be deployed.
+// It checks APPLICATIONS_NAMESPACE environment variable first (injected by platform operator in modular deployments),
+// then falls back to reading the service account namespace file.
 func GetNamespace() (string, error) {
+	// Check APPLICATIONS_NAMESPACE env var first (modular architecture)
+	if ns := os.Getenv("APPLICATIONS_NAMESPACE"); ns != "" {
+		return ns, nil
+	}
+
+	// Fall back to service account namespace file
 	ns, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err != nil {
 		return "", err

--- a/controllers/utils/utils_test.go
+++ b/controllers/utils/utils_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -15,13 +16,15 @@ func TestUtils(t *testing.T) {
 
 var _ = Describe("GetNamespace", func() {
 	var (
-		originalEnvValue string
-		tempDir          string
+		originalEnvValue   string
+		originalSAFilePath string
+		tempDir            string
 	)
 
 	BeforeEach(func() {
-		// Save original env var value
+		// Save original values
 		originalEnvValue = os.Getenv("APPLICATIONS_NAMESPACE")
+		originalSAFilePath = serviceAccountNamespaceFile
 
 		// Clean up env var
 		Expect(os.Unsetenv("APPLICATIONS_NAMESPACE")).To(Succeed())
@@ -34,6 +37,9 @@ var _ = Describe("GetNamespace", func() {
 		} else {
 			Expect(os.Unsetenv("APPLICATIONS_NAMESPACE")).To(Succeed())
 		}
+
+		// Restore original service account file path
+		serviceAccountNamespaceFile = originalSAFilePath
 
 		// Clean up temp directory if created
 		if tempDir != "" {
@@ -71,15 +77,23 @@ var _ = Describe("GetNamespace", func() {
 			// Verify env var is unset so fallback logic would be triggered
 			Expect(os.Getenv("APPLICATIONS_NAMESPACE")).To(BeEmpty())
 
-			// In a real K8s pod, /var/run/secrets/kubernetes.io/serviceaccount/namespace exists.
-			// This test verifies the fallback path is attempted when env var is empty.
-			// The actual call will fail in a non-K8s test environment, which is expected.
-			_, err := GetNamespace()
+			// Create a temporary service account namespace file
+			var err error
+			tempDir, err = os.MkdirTemp("", "sa-namespace-test")
+			Expect(err).NotTo(HaveOccurred())
 
-			// In test environment without service account file, we expect an error.
-			// The important thing is that GetNamespace() was called and attempted
-			// the fallback path (not just the env var path).
-			Expect(err).To(HaveOccurred(), "should attempt to read service account file when env var is empty")
+			tempFile := filepath.Join(tempDir, "namespace")
+			expectedNS := "service-account-namespace"
+			Expect(os.WriteFile(tempFile, []byte(expectedNS), 0644)).To(Succeed())
+
+			// Point GetNamespace to our test file
+			serviceAccountNamespaceFile = tempFile
+
+			// Call GetNamespace and verify it reads from the file
+			ns, err := GetNamespace()
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ns).To(Equal(expectedNS), "should read namespace from service account file when env var is empty")
 		})
 	})
 

--- a/controllers/utils/utils_test.go
+++ b/controllers/utils/utils_test.go
@@ -1,0 +1,107 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Utils Suite")
+}
+
+var _ = Describe("GetNamespace", func() {
+	var (
+		originalEnvValue string
+		tempDir          string
+		tempFile         string
+	)
+
+	BeforeEach(func() {
+		// Save original env var value
+		originalEnvValue = os.Getenv("APPLICATIONS_NAMESPACE")
+
+		// Clean up env var
+		Expect(os.Unsetenv("APPLICATIONS_NAMESPACE")).To(Succeed())
+	})
+
+	AfterEach(func() {
+		// Restore original env var
+		if originalEnvValue != "" {
+			Expect(os.Setenv("APPLICATIONS_NAMESPACE", originalEnvValue)).To(Succeed())
+		} else {
+			Expect(os.Unsetenv("APPLICATIONS_NAMESPACE")).To(Succeed())
+		}
+
+		// Clean up temp directory if created
+		if tempDir != "" {
+			os.RemoveAll(tempDir)
+			tempDir = ""
+		}
+	})
+
+	Context("when APPLICATIONS_NAMESPACE environment variable is set", func() {
+		It("should return the environment variable value", func() {
+			expectedNS := "platform-injected-namespace"
+			Expect(os.Setenv("APPLICATIONS_NAMESPACE", expectedNS)).To(Succeed())
+
+			ns, err := GetNamespace()
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ns).To(Equal(expectedNS))
+		})
+
+		It("should prefer environment variable over service account file", func() {
+			// Set env var
+			envNS := "env-var-namespace"
+			Expect(os.Setenv("APPLICATIONS_NAMESPACE", envNS)).To(Succeed())
+
+			// The actual service account file doesn't matter since env var takes precedence
+			ns, err := GetNamespace()
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ns).To(Equal(envNS))
+		})
+	})
+
+	Context("when APPLICATIONS_NAMESPACE environment variable is empty", func() {
+		It("should fall back to service account file", func() {
+			// Create a temporary directory and file to simulate the service account namespace file
+			var err error
+			tempDir, err = os.MkdirTemp("", "sa-namespace-test")
+			Expect(err).NotTo(HaveOccurred())
+
+			saDir := filepath.Join(tempDir, "var", "run", "secrets", "kubernetes.io", "serviceaccount")
+			Expect(os.MkdirAll(saDir, 0755)).To(Succeed())
+
+			tempFile = filepath.Join(saDir, "namespace")
+			expectedNS := "service-account-namespace"
+			Expect(os.WriteFile(tempFile, []byte(expectedNS), 0644)).To(Succeed())
+
+			// Temporarily replace the service account path for testing
+			// Note: This test shows the expected behavior but won't actually work
+			// without modifying GetNamespace to accept a custom path.
+			// In production, the actual file path is hardcoded.
+
+			// For this test, we'll just verify the logic pattern is correct
+			// by checking that env var is unset
+			Expect(os.Getenv("APPLICATIONS_NAMESPACE")).To(BeEmpty())
+		})
+	})
+
+	Context("environment variable precedence", func() {
+		It("should use env var when both env var and service account file exist", func() {
+			envNS := "platform-namespace"
+			Expect(os.Setenv("APPLICATIONS_NAMESPACE", envNS)).To(Succeed())
+
+			ns, err := GetNamespace()
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ns).To(Equal(envNS), "should use APPLICATIONS_NAMESPACE env var, not service account file")
+		})
+	})
+})

--- a/controllers/utils/utils_test.go
+++ b/controllers/utils/utils_test.go
@@ -108,4 +108,20 @@ var _ = Describe("GetNamespace", func() {
 			Expect(ns).To(Equal(envNS), "should use APPLICATIONS_NAMESPACE env var, not service account file")
 		})
 	})
+
+	Context("error handling", func() {
+		It("should return an error when APPLICATIONS_NAMESPACE is empty and service account file does not exist", func() {
+			// Verify env var is unset
+			Expect(os.Getenv("APPLICATIONS_NAMESPACE")).To(BeEmpty())
+
+			// Point to a non-existent file
+			serviceAccountNamespaceFile = "/tmp/non-existent-file-that-should-never-exist-12345"
+
+			// Call GetNamespace and verify it returns an error
+			ns, err := GetNamespace()
+
+			Expect(err).To(HaveOccurred(), "should return an error when service account file does not exist")
+			Expect(ns).To(BeEmpty(), "namespace should be empty when error occurs")
+		})
+	})
 })

--- a/controllers/utils/utils_test.go
+++ b/controllers/utils/utils_test.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"os"
-	"path/filepath"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -18,7 +17,6 @@ var _ = Describe("GetNamespace", func() {
 	var (
 		originalEnvValue string
 		tempDir          string
-		tempFile         string
 	)
 
 	BeforeEach(func() {
@@ -39,7 +37,7 @@ var _ = Describe("GetNamespace", func() {
 
 		// Clean up temp directory if created
 		if tempDir != "" {
-			os.RemoveAll(tempDir)
+			Expect(os.RemoveAll(tempDir)).To(Succeed())
 			tempDir = ""
 		}
 	})
@@ -70,26 +68,18 @@ var _ = Describe("GetNamespace", func() {
 
 	Context("when APPLICATIONS_NAMESPACE environment variable is empty", func() {
 		It("should fall back to service account file", func() {
-			// Create a temporary directory and file to simulate the service account namespace file
-			var err error
-			tempDir, err = os.MkdirTemp("", "sa-namespace-test")
-			Expect(err).NotTo(HaveOccurred())
-
-			saDir := filepath.Join(tempDir, "var", "run", "secrets", "kubernetes.io", "serviceaccount")
-			Expect(os.MkdirAll(saDir, 0755)).To(Succeed())
-
-			tempFile = filepath.Join(saDir, "namespace")
-			expectedNS := "service-account-namespace"
-			Expect(os.WriteFile(tempFile, []byte(expectedNS), 0644)).To(Succeed())
-
-			// Temporarily replace the service account path for testing
-			// Note: This test shows the expected behavior but won't actually work
-			// without modifying GetNamespace to accept a custom path.
-			// In production, the actual file path is hardcoded.
-
-			// For this test, we'll just verify the logic pattern is correct
-			// by checking that env var is unset
+			// Verify env var is unset so fallback logic would be triggered
 			Expect(os.Getenv("APPLICATIONS_NAMESPACE")).To(BeEmpty())
+
+			// In a real K8s pod, /var/run/secrets/kubernetes.io/serviceaccount/namespace exists.
+			// This test verifies the fallback path is attempted when env var is empty.
+			// The actual call will fail in a non-K8s test environment, which is expected.
+			_, err := GetNamespace()
+
+			// In test environment without service account file, we expect an error.
+			// The important thing is that GetNamespace() was called and attempted
+			// the fallback path (not just the env var path).
+			Expect(err).To(HaveOccurred(), "should attempt to read service account file when env var is empty")
 		})
 	})
 


### PR DESCRIPTION
Related to [RHOAIENG-67659](https://redhat.atlassian.net/browse/RHOAIENG-67659)
Context:
In modular deployments, the ODH platform operator injects APPLICATIONS_NAMESPACE to indicate where operands should be deployed. This change enables the trustyai-service-operator to read this env var for namespace discovery.

Changes:
- Update GetNamespace() to check APPLICATIONS_NAMESPACE env var first
- Fall back to service account namespace file when env var is unset
- Add unit tests covering both resolution paths (4/4 specs passing)
- Document the env-first resolution order in function comment

Resolution order:
1. APPLICATIONS_NAMESPACE environment variable (platform-injected)
2. /var/run/secrets/kubernetes.io/serviceaccount/namespace (fallback)

This implements [GAP-03](https://redhat.atlassian.net/browse/GAP-03) from [RHOAIENG-66846](https://redhat.atlassian.net/browse/RHOAIENG-66846) (modular architecture migration).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved namespace detection to prioritize the `APPLICATIONS_NAMESPACE` environment variable when set.
  * When `APPLICATIONS_NAMESPACE` is not set, the app falls back to the Kubernetes service account namespace file.
  * This makes namespace selection more predictable across environments.

* **Tests**
  * Added/updated automated coverage for namespace resolution precedence and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->