### PR TITLE
fix(evalhub): rename ClusterRole and add secret update verb for ownerref

### DIFF
--- a/config/components/evalhub/rbac/evalhub_model_secret_role.yaml
+++ b/config/components/evalhub/rbac/evalhub_model_secret_role.yaml
@@ -4,16 +4,17 @@
 #   - get the user-provided model credential secret to build the internalModelRef secret
 #   - list secrets by label for explicit cleanup in DeleteEvaluationJobResources
 #   - create the ephemeral internalModelRef secret before job submission
-#   - delete the internalModelRef secret on job creation failure (normal GC is via owner reference)
+#   - update the internalModelRef secret to set its owner reference (so GC cleans it up with the job)
+#   - delete the internalModelRef secret on job creation failure (fallback cleanup if owner ref fails)
 # Bound per-tenant-namespace via a namespace-scoped RoleBinding created in createJobsServiceAccount.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: trustyai-service-operator-evalhub-model-secret
+  name: evalhub-model-secret
   labels:
     app.kubernetes.io/name: trustyai-service-operator
     app.kubernetes.io/component: evalhub
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list", "create", "delete"]
+    verbs: ["get", "list", "create", "update", "delete"]


### PR DESCRIPTION
## What and why

The `evalhub-model-secret` ClusterRole had two issues:

1. **Wrong name**: the role was named `trustyai-service-operator-evalhub-model-secret`, which doesn't follow the shorter naming convention used by other EvalHub roles (leading to double-prefixing). Renamed to `evalhub-model-secret`.

2. **Missing `update` verb**: the controller sets an owner reference on the ephemeral `internalModelRef` secret after creation (so Kubernetes GC cleans it up when the job is deleted), but `update` was not in the allowed verbs. Without it, the owner-reference patch would fail at runtime, leaving orphaned secrets if the fallback `delete` path was also not reached.

The comment is also updated to clarify the primary GC path (owner ref) versus the fallback (explicit delete on creation failure).

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

## Breaking changes

The ClusterRole is renamed from `trustyai-service-operator-evalhub-model-secret` to `evalhub-model-secret`. Any RoleBinding or ClusterRoleBinding that references the old name by string (outside of Kustomize-managed resources) will need to be updated. Kustomize-managed bindings will pick up the new name automatically on re-apply.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated EvalHub model credential permissions to support updating and deleting secrets, alongside existing access.
  * Adjusted the related access rule name and labels for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->