### PR TITLE
refactor: extract ConfigMap helpers to shared pkg/configmap package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN go mod download
 COPY cmd/ cmd/
 COPY api/ api/
 COPY controllers/ controllers/
+COPY pkg/ pkg/
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command

--- a/controllers/images/resolver.go
+++ b/controllers/images/resolver.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
+	"github.com/trustyai-explainability/trustyai-service-operator/pkg/configmap"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -113,20 +111,12 @@ func ResolveImage(ctx context.Context, c client.Client, configMapKey, configMapN
 // getImageFromConfigMapDirect is an internal helper that directly reads from ConfigMap without env var check.
 // This is used internally by ResolveImage to avoid circular logic.
 func getImageFromConfigMapDirect(ctx context.Context, c client.Client, configMapKey, configMapName, namespace string) (string, error) {
-	// Inline implementation to avoid circular import with controllers/utils.
-	// TODO: Refactor to shared pkg/configmap package to eliminate duplication.
-	// See https://github.com/trustyai-explainability/trustyai-service-operator/issues/783
-
-	configMap := &corev1.ConfigMap{}
-	err := c.Get(ctx, types.NamespacedName{Name: configMapName, Namespace: namespace}, configMap)
+	cm, err := configmap.Get(ctx, c, configMapName, namespace)
 	if err != nil {
-		if errors.IsNotFound(err) {
-			return "", fmt.Errorf("configmap %s not found in namespace %s", configMapName, namespace)
-		}
-		return "", fmt.Errorf("error reading configmap %s in namespace %s: %w", configMapName, namespace, err)
+		return "", err
 	}
 
-	value, ok := configMap.Data[configMapKey]
+	value, ok := cm.Data[configMapKey]
 	if !ok {
 		return "", fmt.Errorf("configmap %s in namespace %s does not contain key %s", configMapName, namespace, configMapKey)
 	}

--- a/controllers/utils/configmap.go
+++ b/controllers/utils/configmap.go
@@ -8,9 +8,8 @@ import (
 	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/trustyai-explainability/trustyai-service-operator/pkg/configmap"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -48,17 +47,10 @@ func ReconcileConfigMap(ctx context.Context, c client.Client, owner metav1.Objec
 }
 
 // === SPECIFIC CONFIGMAP FUNCTIONS ====================================================================================
-// GetConfigMapByName retrieves a configmap by name in the given namespace
+// GetConfigMapByName retrieves a configmap by name in the given namespace.
+// Deprecated: Use pkg/configmap.Get() directly for new code.
 func GetConfigMapByName(ctx context.Context, c client.Client, configMapName string, namespace string) (*corev1.ConfigMap, error) {
-	configMap := &corev1.ConfigMap{}
-	err := c.Get(ctx, types.NamespacedName{Name: configMapName, Namespace: namespace}, configMap)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil, fmt.Errorf("configmap %s not found in namespace %s", configMapName, namespace)
-		}
-		return nil, fmt.Errorf("error reading configmap %s in namespace %s: %w", configMapName, namespace, err)
-	}
-	return configMap, nil
+	return configmap.Get(ctx, c, configMapName, namespace)
 }
 
 // GetImageFromConfigMapWithFallback retrieves a value from a ConfigMap by key, with a fallback value if no configmap is found or the key does not exist

--- a/pkg/configmap/configmap.go
+++ b/pkg/configmap/configmap.go
@@ -1,0 +1,25 @@
+package configmap
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Get retrieves a ConfigMap by name in the given namespace.
+// Returns an error if the ConfigMap is not found or cannot be read.
+func Get(ctx context.Context, c client.Client, name, namespace string) (*corev1.ConfigMap, error) {
+	configMap := &corev1.ConfigMap{}
+	err := c.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, configMap)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, fmt.Errorf("configmap %s not found in namespace %s", name, namespace)
+		}
+		return nil, fmt.Errorf("error reading configmap %s in namespace %s: %w", name, namespace, err)
+	}
+	return configMap, nil
+}

--- a/pkg/configmap/configmap_test.go
+++ b/pkg/configmap/configmap_test.go
@@ -1,0 +1,152 @@
+package configmap_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/trustyai-explainability/trustyai-service-operator/pkg/configmap"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestGet_Success(t *testing.T) {
+	// Create a fake ConfigMap
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cm",
+			Namespace: "test-ns",
+		},
+		Data: map[string]string{
+			"key1": "value1",
+		},
+	}
+
+	// Create a fake client with the ConfigMap
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+
+	// Test Get
+	ctx := context.Background()
+	result, err := configmap.Get(ctx, fakeClient, "test-cm", "test-ns")
+
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if result.Name != "test-cm" {
+		t.Errorf("expected name 'test-cm', got: %s", result.Name)
+	}
+
+	if result.Data["key1"] != "value1" {
+		t.Errorf("expected data key1='value1', got: %s", result.Data["key1"])
+	}
+}
+
+func TestGet_NotFound(t *testing.T) {
+	// Create a fake client with no ConfigMaps
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	// Test Get for non-existent ConfigMap
+	ctx := context.Background()
+	result, err := configmap.Get(ctx, fakeClient, "nonexistent", "test-ns")
+
+	if err == nil {
+		t.Fatal("expected error for non-existent ConfigMap, got nil")
+	}
+
+	if result != nil {
+		t.Error("expected nil result for non-existent ConfigMap")
+	}
+
+	// Verify the error message contains expected text
+	expectedMsg := "configmap nonexistent not found in namespace test-ns"
+	if err.Error() != expectedMsg {
+		t.Errorf("expected error message '%s', got: %s", expectedMsg, err.Error())
+	}
+}
+
+func TestGet_DifferentNamespace(t *testing.T) {
+	// Create ConfigMaps in different namespaces
+	cm1 := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "shared-name",
+			Namespace: "ns1",
+		},
+		Data: map[string]string{
+			"source": "ns1",
+		},
+	}
+	cm2 := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "shared-name",
+			Namespace: "ns2",
+		},
+		Data: map[string]string{
+			"source": "ns2",
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm1, cm2).Build()
+
+	ctx := context.Background()
+
+	// Get from ns1
+	result1, err := configmap.Get(ctx, fakeClient, "shared-name", "ns1")
+	if err != nil {
+		t.Fatalf("ns1: unexpected error: %v", err)
+	}
+	if result1.Data["source"] != "ns1" {
+		t.Errorf("ns1: expected source='ns1', got: %s", result1.Data["source"])
+	}
+
+	// Get from ns2
+	result2, err := configmap.Get(ctx, fakeClient, "shared-name", "ns2")
+	if err != nil {
+		t.Fatalf("ns2: unexpected error: %v", err)
+	}
+	if result2.Data["source"] != "ns2" {
+		t.Errorf("ns2: expected source='ns2', got: %s", result2.Data["source"])
+	}
+}
+
+func TestGet_ErrorType(t *testing.T) {
+	// Create a fake client with a ConfigMap
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "exists",
+			Namespace: "test-ns",
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+
+	ctx := context.Background()
+
+	// Test with wrong namespace - should get NotFound error
+	_, err := configmap.Get(ctx, fakeClient, "exists", "wrong-ns")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	// The error should wrap a NotFound error
+	if !errors.IsNotFound(err) {
+		// Our wrapper doesn't preserve the original error type, which is acceptable
+		// Just verify it's an error with the right message
+		if err.Error() != "configmap exists not found in namespace wrong-ns" {
+			t.Errorf("unexpected error message: %s", err.Error())
+		}
+	}
+}
+
+// TestGet_WithRealClient would require a real Kubernetes client and is beyond the scope
+// of a unit test. The fake client tests above cover the core logic.


### PR DESCRIPTION
Resolves the issue https://github.com/trustyai-explainability/trustyai-service-operator/issues/783 
Eliminates code duplication and circular dependency between controllers/images and controllers/utils by moving ConfigMap lookup logic to a new shared package.

Changes:
- Create pkg/configmap.Get() for shared ConfigMap retrieval
- Update controllers/utils.GetConfigMapByName() to delegate to pkg/configmap.Get()
- Update controllers/images/resolver.go to use pkg/configmap instead of inline duplication
- Add comprehensive unit tests for pkg/configmap (85.7% coverage)

All tests pass:
✅ pkg/configmap: 4/4 tests pass
✅ controllers/images: 10/10 tests pass (resolver functionality unchanged) ✅ No circular dependencies

Fixes #783