### PR TITLE
fix(ci): add SAN to webhook certificate in smoke test workflow

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -67,20 +67,14 @@ jobs:
 
       - name: Inject CA bundle into webhook configurations
         run: |
-          # Encode the CA bundle (the cert itself for self-signed)
-          CA_BUNDLE=$(cat /tmp/tls.crt | base64 -w 0)
-
-          # Patch TrustyAIService CRD if it has a conversion webhook
-          if kubectl get crd trustyaiservices.trustyai.opendatahub.io -o jsonpath='{.spec.conversion.strategy}' | grep -q "Webhook"; then
-            kubectl patch crd trustyaiservices.trustyai.opendatahub.io --type='json' -p="[{\"op\": \"add\", \"path\": \"/spec/conversion/webhook/clientConfig/caBundle\", \"value\":\"${CA_BUNDLE}\"}]"
-            echo "Patched TrustyAIService CRD with CA bundle"
-          fi
-
-          # Patch EvalHub CRD if it has a conversion webhook
-          if kubectl get crd evalhubs.trustyai.opendatahub.io -o jsonpath='{.spec.conversion.strategy}' 2>/dev/null | grep -q "Webhook"; then
-            kubectl patch crd evalhubs.trustyai.opendatahub.io --type='json' -p="[{\"op\": \"add\", \"path\": \"/spec/conversion/webhook/clientConfig/caBundle\", \"value\":\"${CA_BUNDLE}\"}]"
-            echo "Patched EvalHub CRD with CA bundle"
-          fi
+          CA_BUNDLE=$(base64 -w 0 /tmp/tls.crt)
+          for CRD in trustyaiservices.trustyai.opendatahub.io evalhubs.trustyai.opendatahub.io; do
+            if kubectl get crd "$CRD" -o jsonpath='{.spec.conversion.strategy}' 2>/dev/null | grep -q "Webhook"; then
+              kubectl patch crd "$CRD" --type='json' \
+                -p="[{\"op\":\"add\",\"path\":\"/spec/conversion/webhook/clientConfig/caBundle\",\"value\":\"${CA_BUNDLE}\"}]"
+              echo "Patched $CRD with CA bundle"
+            fi
+          done
 
       - name: Wait for operator to be ready
         run: |

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -65,6 +65,23 @@ jobs:
             --cert=/tmp/tls.crt --key=/tmp/tls.key -n system
           kustomize build config/overlays/testing | sed 's/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g' | kubectl apply -n system -f -
 
+      - name: Inject CA bundle into webhook configurations
+        run: |
+          # Encode the CA bundle (the cert itself for self-signed)
+          CA_BUNDLE=$(cat /tmp/tls.crt | base64 -w 0)
+
+          # Patch TrustyAIService CRD if it has a conversion webhook
+          if kubectl get crd trustyaiservices.trustyai.opendatahub.io -o jsonpath='{.spec.conversion.strategy}' | grep -q "Webhook"; then
+            kubectl patch crd trustyaiservices.trustyai.opendatahub.io --type='json' -p="[{\"op\": \"add\", \"path\": \"/spec/conversion/webhook/clientConfig/caBundle\", \"value\":\"${CA_BUNDLE}\"}]"
+            echo "Patched TrustyAIService CRD with CA bundle"
+          fi
+
+          # Patch EvalHub CRD if it has a conversion webhook
+          if kubectl get crd evalhubs.trustyai.opendatahub.io -o jsonpath='{.spec.conversion.strategy}' 2>/dev/null | grep -q "Webhook"; then
+            kubectl patch crd evalhubs.trustyai.opendatahub.io --type='json' -p="[{\"op\": \"add\", \"path\": \"/spec/conversion/webhook/clientConfig/caBundle\", \"value\":\"${CA_BUNDLE}\"}]"
+            echo "Patched EvalHub CRD with CA bundle"
+          fi
+
       - name: Wait for operator to be ready
         run: |
           kubectl wait --for=condition=available --timeout=120s \


### PR DESCRIPTION
Modern Kubernetes (1.19+) rejects certificates that rely solely on the legacy Common Name (CN) field for identity verification. The webhook certificate must include Subject Alternative Names (SANs).

Add the -addext flag to the openssl command to include both short and FQDN forms of the webhook service DNS name as SANs. This prevents the error:

  x509: certificate relies on legacy Common Name field, use SANs instead

This fix ensures the smoke tests work correctly with the conversion webhook for both EvalHub (v1alpha1→v1) and TrustyAIService (v1alpha1→v1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS certificate generation for the webhook service to include the correct DNS names (short service name and in-cluster FQDN).
  * Ensures smoother certificate validation during deployment.
* **New Features**
  * Automatically injects the webhook server certificate into the CA bundle for webhook-based conversion specifications of the affected CRDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->