### PR TITLE
ci: add disconnected readiness scanner GHA workflow

### DIFF
--- a/.github/workflows/disconnected-readiness.yaml
+++ b/.github/workflows/disconnected-readiness.yaml
@@ -1,0 +1,33 @@
+name: Tier 1 - Disconnected readiness
+
+on: [push, pull_request]
+
+jobs:
+  disconnected-score:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install kustomize
+        uses: imranismail/setup-kustomize@2ba527d4d055ab63514ba50a99456fc35684947f # v2
+        with:
+          kustomize-version: "5.7.0"
+
+      - name: Clone disconnected-readiness-scorer
+        run: git clone --depth 1 https://github.com/opendatahub-io/disconnected-readiness-scorer.git /tmp/scorer
+
+      - name: Install scorer dependencies
+        run: |
+          pip install pyyaml jinja2
+          make -C /tmp/scorer install-arch-analyzer
+
+      - name: Run disconnected readiness check
+        run: python3 /tmp/scorer/main.py . --arch-analyzer /tmp/scorer/bin/arch-analyzer

--- a/.github/workflows/disconnected-readiness.yaml
+++ b/.github/workflows/disconnected-readiness.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install scorer dependencies
         run: |
-          pip install /tmp/scorer[report]
+          pip install pyyaml jsonschema jinja2
           make -C /tmp/scorer install-arch-analyzer
 
       - name: Run disconnected readiness check

--- a/.github/workflows/disconnected-readiness.yaml
+++ b/.github/workflows/disconnected-readiness.yaml
@@ -20,9 +20,9 @@ jobs:
           python-version: "3.12"
 
       - name: Install kustomize
-        uses: imranismail/setup-kustomize@2ba527d4d055ab63514ba50a99456fc35684947f # v2
-        with:
-          kustomize-version: "5.7.0"
+        run: |
+          make kustomize
+          echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
 
       - name: Clone disconnected-readiness-scorer
         run: |

--- a/.github/workflows/disconnected-readiness.yaml
+++ b/.github/workflows/disconnected-readiness.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install scorer dependencies
         run: |
-          pip install pyyaml jinja2
+          pip install /tmp/scorer[report]
           make -C /tmp/scorer install-arch-analyzer
 
       - name: Run disconnected readiness check

--- a/.github/workflows/disconnected-readiness.yaml
+++ b/.github/workflows/disconnected-readiness.yaml
@@ -2,6 +2,9 @@ name: Tier 1 - Disconnected readiness
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   disconnected-score:
     runs-on: ubuntu-latest
@@ -22,7 +25,9 @@ jobs:
           kustomize-version: "5.7.0"
 
       - name: Clone disconnected-readiness-scorer
-        run: git clone --depth 1 https://github.com/opendatahub-io/disconnected-readiness-scorer.git /tmp/scorer
+        run: |
+          git clone https://github.com/opendatahub-io/disconnected-readiness-scorer.git /tmp/scorer
+          git -C /tmp/scorer checkout 64e6c53e17c7528fb41146fce9342d24a831517b # main
 
       - name: Install scorer dependencies
         run: |


### PR DESCRIPTION
## What and why

Adds a GitHub Actions workflow that runs the disconnected readiness scanner on every push and PR. Catches disconnected-breaking patterns at PR time rather than later.

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci
- [x] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new automated readiness check that runs on pushes and pull requests.
  * Expanded continuous integration coverage to validate disconnected-readiness status for changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->