### PR TITLE
fix(kustomize): replace install script with direct binary download

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,6 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 KUSTOMIZE_VERSION ?= v5.7.0
 CONTROLLER_TOOLS_VERSION ?= v0.20.0
 
-KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.
 $(KUSTOMIZE): $(LOCALBIN)
@@ -252,7 +251,12 @@ $(KUSTOMIZE): $(LOCALBIN)
 		echo "$(LOCALBIN)/kustomize version is not expected $(KUSTOMIZE_VERSION). Removing it before installing."; \
 		rm -rf $(LOCALBIN)/kustomize; \
 	fi
-	test -s $(LOCALBIN)/kustomize || { curl -Ss $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN); }
+	@test -s $(LOCALBIN)/kustomize || { \
+		OPSYS=$$(uname -s | tr '[:upper:]' '[:lower:]') && \
+		ARCH=$$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') && \
+		curl -sL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F$(KUSTOMIZE_VERSION)/kustomize_$(KUSTOMIZE_VERSION)_$${OPSYS}_$${ARCH}.tar.gz" | \
+		tar xz -C $(LOCALBIN); \
+	}
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary. If wrong version is installed, it will be overwritten.

--- a/Makefile
+++ b/Makefile
@@ -254,7 +254,7 @@ $(KUSTOMIZE): $(LOCALBIN)
 	@test -s $(LOCALBIN)/kustomize || { \
 		OPSYS=$$(uname -s | tr '[:upper:]' '[:lower:]') && \
 		ARCH=$$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') && \
-		curl -sL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F$(KUSTOMIZE_VERSION)/kustomize_$(KUSTOMIZE_VERSION)_$${OPSYS}_$${ARCH}.tar.gz" | \
+		curl -sfL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F$(KUSTOMIZE_VERSION)/kustomize_$(KUSTOMIZE_VERSION)_$${OPSYS}_$${ARCH}.tar.gz" | \
 		tar xz -C $(LOCALBIN); \
 	}
 


### PR DESCRIPTION
## Summary
- Replace `install_kustomize.sh` script with direct binary download from GitHub releases
- The script hits `api.github.com` unauthenticated to resolve release URLs, which gets rate-limited (60 req/hr per shared runner IP) — root cause of frequent CI failures
- Direct download URL is deterministic and bypasses the API entirely

**Depends on:** #797

## Test plan
- [x] Verified `rm -f bin/kustomize && make kustomize && bin/kustomize version` succeeds locally
- [ ] CI workflows that use `make kustomize` pass without rate-limit errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the local tooling setup to fetch the required `kustomize` binary directly from the official release package.
  * Improved platform detection so the correct download is used for common CPU architectures.
  * Existing installs still verify the expected version and are refreshed when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->