### PR TITLE
test(images): fix test failures from removed image defaults and extract image constants

### DIFF
--- a/controllers/evalhub/build_test.go
+++ b/controllers/evalhub/build_test.go
@@ -216,7 +216,7 @@ var _ = Describe("buildDeploymentSpec", func() {
 
 		_, err := r.buildDeploymentSpec(ctx, evalHub, nil, nil)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("resolving kube-rbac-proxy image"))
+		Expect(err.Error()).To(ContainSubstring("resolving EvalHub image"))
 	})
 
 	It("adds provider volume and mount when providerCMNames is non-nil", func() {

--- a/controllers/evalhub/build_test.go
+++ b/controllers/evalhub/build_test.go
@@ -68,8 +68,8 @@ var _ = Describe("buildDeploymentSpec", func() {
 				Namespace: testNamespace,
 			},
 			Data: map[string]string{
-				configMapEvalHubImageKey:       "quay.io/test/eval-hub:v1.2.3",
-				configMapKubeRBACProxyImageKey: "quay.io/test/kube-rbac-proxy:v1",
+				configMapEvalHubImageKey:       testBuildEvalHubImage,
+				configMapKubeRBACProxyImageKey: testBuildKubeRBACProxyImage,
 			},
 		}
 		Expect(k8sClient.Create(ctx, operatorCM)).To(Succeed())
@@ -111,7 +111,7 @@ var _ = Describe("buildDeploymentSpec", func() {
 		Expect(container).NotTo(BeNil(), "evalhub container should be present")
 
 		Expect(container.Name).To(Equal(containerName))
-		Expect(container.Image).To(Equal("quay.io/test/eval-hub:v1.2.3"))
+		Expect(container.Image).To(Equal(testBuildEvalHubImage))
 		Expect(container.ImagePullPolicy).To(Equal(corev1.PullAlways))
 
 		Expect(container.Ports).To(HaveLen(2))
@@ -154,7 +154,7 @@ var _ = Describe("buildDeploymentSpec", func() {
 
 		krp := findContainerByName(podSpec.Containers, kubeRBACProxyContainerName)
 		Expect(krp).NotTo(BeNil())
-		Expect(krp.Image).To(Equal("quay.io/test/kube-rbac-proxy:v1"))
+		Expect(krp.Image).To(Equal(testBuildKubeRBACProxyImage))
 		Expect(strings.Join(krp.Args, " ")).To(ContainSubstring(fmt.Sprintf("--upstream=http://127.0.0.1:%d/", evalHubAppPort)))
 		Expect(krp.ReadinessProbe).NotTo(BeNil())
 		Expect(krp.StartupProbe).NotTo(BeNil())
@@ -402,7 +402,7 @@ var _ = Describe("getImageFromConfigMap", func() {
 				Namespace: nsName,
 			},
 			Data: map[string]string{
-				configMapEvalHubImageKey: "quay.io/test/eval-hub:custom",
+				configMapEvalHubImageKey: testCustomEvalHubImage,
 			},
 		}
 		Expect(k8sClient.Create(ctx, cm)).To(Succeed())
@@ -413,7 +413,7 @@ var _ = Describe("getImageFromConfigMap", func() {
 		}
 		image, err := r.getImageFromConfigMap(ctx, configMapEvalHubImageKey)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(image).To(Equal("quay.io/test/eval-hub:custom"))
+		Expect(image).To(Equal(testCustomEvalHubImage))
 	})
 
 	It("returns an error when the ConfigMap is not found", func() {

--- a/controllers/evalhub/deployment_test.go
+++ b/controllers/evalhub/deployment_test.go
@@ -47,8 +47,8 @@ var _ = Describe("EvalHub Deployment", func() {
 				Namespace: testNamespace,
 			},
 			Data: map[string]string{
-				"evalHubImage":    "quay.io/ruimvieira/eval-hub:test",
-				"kube-rbac-proxy": "quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable",
+				"evalHubImage":    testEvalHubImage,
+				"kube-rbac-proxy": testKubeRBACProxyImage,
 			},
 		}
 		Expect(k8sClient.Create(ctx, configMap)).Should(Succeed())
@@ -126,7 +126,7 @@ var _ = Describe("EvalHub Deployment", func() {
 			Expect(evalHubContainer).NotTo(BeNil(), "evalhub container should be present")
 
 			By("Checking evalhub container configuration")
-			Expect(evalHubContainer.Image).To(Equal("quay.io/ruimvieira/eval-hub:test")) // From test configmap
+			Expect(evalHubContainer.Image).To(Equal(testEvalHubImage)) // From test configmap
 			Expect(evalHubContainer.ImagePullPolicy).To(Equal(corev1.PullAlways))
 
 			// Check ports (loopback app port + metrics port; Service targets kube-rbac-proxy on 8443)
@@ -146,7 +146,7 @@ var _ = Describe("EvalHub Deployment", func() {
 				}
 			}
 			Expect(krp).NotTo(BeNil())
-			Expect(krp.Image).To(Equal("quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable"))
+			Expect(krp.Image).To(Equal(testKubeRBACProxyImage))
 			Expect(krp.Args).To(ContainElement("--config-file=" + kubeRBACProxyConfigMountPath))
 			Expect(strings.Join(krp.Args, " ")).To(ContainSubstring(fmt.Sprintf("--upstream=http://127.0.0.1:%d/", evalHubAppPort)))
 			var hasAuthMount bool
@@ -319,7 +319,7 @@ var _ = Describe("EvalHub Deployment", func() {
 
 			err = reconciler.reconcileDeployment(ctx, evalHub, nil, nil)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("resolving kube-rbac-proxy image"))
+			Expect(err.Error()).To(ContainSubstring("resolving EvalHub image"))
 		})
 
 		It("should configure rolling update strategy", func() {
@@ -554,8 +554,8 @@ var _ = Describe("EvalHubReconciler reconcileDeployment", func() {
 				Namespace: testNamespace,
 			},
 			Data: map[string]string{
-				configMapEvalHubImageKey:       "quay.io/test/eval-hub:latest",
-				configMapKubeRBACProxyImageKey: "quay.io/test/kube-rbac-proxy:latest",
+				configMapEvalHubImageKey:       testEvalHubLatestImage,
+				configMapKubeRBACProxyImageKey: testKubeRBACProxyLatestImage,
 			},
 		}
 		Expect(k8sClient.Create(ctx, operatorCM)).To(Succeed())
@@ -620,7 +620,7 @@ var _ = Describe("EvalHubReconciler reconcileDeployment", func() {
 		Expect(evalHubC).NotTo(BeNil())
 		Expect(krp).NotTo(BeNil())
 
-		Expect(evalHubC.Image).To(Equal("quay.io/test/eval-hub:latest"))
+		Expect(evalHubC.Image).To(Equal(testEvalHubLatestImage))
 		Expect(evalHubC.ImagePullPolicy).To(Equal(corev1.PullAlways))
 		Expect(evalHubC.Ports).To(HaveLen(2))
 		Expect(evalHubC.Ports[0].Name).To(Equal("evalhub"))
@@ -644,7 +644,7 @@ var _ = Describe("EvalHubReconciler reconcileDeployment", func() {
 		Expect(evalHubC.ReadinessProbe).To(BeNil())
 		Expect(evalHubC.LivenessProbe).To(BeNil())
 
-		Expect(krp.Image).To(Equal("quay.io/test/kube-rbac-proxy:latest"))
+		Expect(krp.Image).To(Equal(testKubeRBACProxyLatestImage))
 		Expect(strings.Join(krp.Args, " ")).To(ContainSubstring(fmt.Sprintf("--upstream=http://127.0.0.1:%d/", evalHubAppPort)))
 		Expect(krp.Args).To(ContainElement("--config-file=" + kubeRBACProxyConfigMountPath))
 
@@ -696,6 +696,6 @@ var _ = Describe("EvalHubReconciler reconcileDeployment", func() {
 		}
 		err := r.reconcileDeployment(ctx, fh, nil, nil)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("resolving kube-rbac-proxy image"))
+		Expect(err.Error()).To(ContainSubstring("resolving EvalHub image"))
 	})
 })

--- a/controllers/evalhub/evalhub_controller_test.go
+++ b/controllers/evalhub/evalhub_controller_test.go
@@ -275,7 +275,7 @@ var _ = Describe("EvalHub Lifecycle Integration", func() {
 		}
 		Expect(container).NotTo(BeNil(), "evalhub container should be present")
 		Expect(container.Name).To(Equal("evalhub"))
-		Expect(container.Image).To(Equal("quay.io/ruimvieira/eval-hub:test"))
+		Expect(container.Image).To(Equal(testEvalHubImage))
 		Expect(container.Ports[0].ContainerPort).To(Equal(int32(evalHubAppPort)))
 
 		// Check custom environment variables are included

--- a/controllers/evalhub/mcp_deployment_test.go
+++ b/controllers/evalhub/mcp_deployment_test.go
@@ -39,7 +39,8 @@ func TestBuildMCPDeploymentSpec_envAndArgs(t *testing.T) {
 	operatorCM := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: configMapName, Namespace: "op-system"},
 		Data: map[string]string{
-			configMapKubeRBACProxyImageKey: "quay.io/test/kube-rbac-proxy:v1",
+			configMapEvalHubImageKey:       testMCPEvalHubImage,
+			configMapKubeRBACProxyImageKey: testBuildKubeRBACProxyImage,
 		},
 	}
 

--- a/controllers/evalhub/proxy_rbac_test.go
+++ b/controllers/evalhub/proxy_rbac_test.go
@@ -48,7 +48,7 @@ var _ = Describe("EvalHub API RBAC", func() {
 				Namespace: operatorNamespace,
 			},
 			Data: map[string]string{
-				"evalHubImage": "quay.io/ruimvieira/eval-hub:test",
+				"evalHubImage": testEvalHubImage,
 			},
 		}
 		Expect(k8sClient.Create(ctx, operatorCM)).Should(Succeed())
@@ -353,7 +353,7 @@ var _ = Describe("EvalHub API RBAC", func() {
 			By("Retrieving image from ConfigMap")
 			image, err := reconciler.getImageFromConfigMap(ctx, "evalHubImage")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(image).To(Equal("quay.io/ruimvieira/eval-hub:test"))
+			Expect(image).To(Equal(testEvalHubImage))
 		})
 
 		It("should fail when ConfigMap is not found", func() {

--- a/controllers/evalhub/suite_test.go
+++ b/controllers/evalhub/suite_test.go
@@ -130,8 +130,8 @@ func createConfigMap(name, namespace string) *corev1.ConfigMap {
 			Namespace: namespace,
 		},
 		Data: map[string]string{
-			"evalHubImage":    "quay.io/ruimvieira/eval-hub:test",
-			"kube-rbac-proxy": "quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable",
+			"evalHubImage":    testEvalHubImage,
+			"kube-rbac-proxy": testKubeRBACProxyImage,
 		},
 	}
 }
@@ -203,8 +203,8 @@ func setupReconciler(namespace string) (*EvalHubReconciler, context.Context) {
 			Namespace: namespace,
 		},
 		Data: map[string]string{
-			configMapEvalHubImageKey:       "quay.io/evalhub/evalhub:test",
-			configMapKubeRBACProxyImageKey: "quay.io/openshift/origin-kube-rbac-proxy:4.19",
+			configMapEvalHubImageKey:       testReconcilerEvalHubImage,
+			configMapKubeRBACProxyImageKey: testReconcilerKubeRBACProxyImage,
 		},
 	}
 	if err := k8sClient.Create(ctx, operatorCM); err != nil {

--- a/controllers/evalhub/test_images_test.go
+++ b/controllers/evalhub/test_images_test.go
@@ -1,0 +1,29 @@
+package evalhub
+
+const (
+	// testEvalHubImage and testKubeRBACProxyImage are the primary images used in the main
+	// Ginkgo integration test ConfigMap (createConfigMap in suite_test.go).
+	testEvalHubImage       = "quay.io/ruimvieira/eval-hub:test"
+	testKubeRBACProxyImage = "quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable"
+
+	// testReconcilerEvalHubImage and testReconcilerKubeRBACProxyImage are used by setupReconciler
+	// and the unit tests that build their own fake client.
+	testReconcilerEvalHubImage       = "quay.io/evalhub/evalhub:test"
+	testReconcilerKubeRBACProxyImage = "quay.io/openshift/origin-kube-rbac-proxy:4.19"
+
+	// testBuildEvalHubImage and testBuildKubeRBACProxyImage are placeholder images used in
+	// build_test.go and mcp_deployment_test.go to verify version-specific resolution.
+	testBuildEvalHubImage       = "quay.io/test/eval-hub:v1.2.3"
+	testBuildKubeRBACProxyImage = "quay.io/test/kube-rbac-proxy:v1"
+
+	// testCustomEvalHubImage is used in build_test.go to test spec.image override behaviour.
+	testCustomEvalHubImage = "quay.io/test/eval-hub:custom"
+
+	// testEvalHubLatestImage and testKubeRBACProxyLatestImage are used in deployment_test.go
+	// and unit_test.go for custom-image-override tests.
+	testEvalHubLatestImage       = "quay.io/test/eval-hub:latest"
+	testKubeRBACProxyLatestImage = "quay.io/test/kube-rbac-proxy:latest"
+
+	// testMCPEvalHubImage is used in mcp_deployment_test.go (note: repo is "evalhub", not "eval-hub").
+	testMCPEvalHubImage = "quay.io/test/evalhub:latest"
+)

--- a/controllers/evalhub/unit_test.go
+++ b/controllers/evalhub/unit_test.go
@@ -106,8 +106,8 @@ func TestEvalHubReconciler_reconcileConfigMap(t *testing.T) {
 			Namespace: testNamespace,
 		},
 		Data: map[string]string{
-			configMapEvalHubImageKey:       "quay.io/evalhub/evalhub:test",
-			configMapKubeRBACProxyImageKey: "quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable",
+			configMapEvalHubImageKey:       testReconcilerEvalHubImage,
+			configMapKubeRBACProxyImageKey: testKubeRBACProxyImage,
 		},
 	}
 
@@ -1324,8 +1324,8 @@ func TestEvalHubReconciler_reconcileDeployment_WithDB(t *testing.T) {
 			Namespace: testNamespace,
 		},
 		Data: map[string]string{
-			configMapEvalHubImageKey:       "quay.io/test/eval-hub:latest",
-			configMapKubeRBACProxyImageKey: "quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable",
+			configMapEvalHubImageKey:       testEvalHubLatestImage,
+			configMapKubeRBACProxyImageKey: testKubeRBACProxyImage,
 		},
 	}
 
@@ -1569,8 +1569,8 @@ func TestEvalHubReconciler_reconcileProviderConfigMaps(t *testing.T) {
 				Namespace: operatorNamespace,
 			},
 			Data: map[string]string{
-				configMapEvalHubImageKey:       "quay.io/test/eval-hub:latest",
-				configMapKubeRBACProxyImageKey: "quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable",
+				configMapEvalHubImageKey:       testEvalHubLatestImage,
+				configMapKubeRBACProxyImageKey: testKubeRBACProxyImage,
 			},
 		}
 

--- a/controllers/tas/config_maps_test.go
+++ b/controllers/tas/config_maps_test.go
@@ -64,13 +64,13 @@ var _ = Describe("ConfigMap tests", func() {
 
 			WaitFor(func() error {
 				var err error
-				actualKubeRBACProxyImage, err = utils.GetImageFromConfigMapWithFallback(ctx, k8sClient, configMapKubeRBACProxyImageKey, constants.ConfigMap, operatorNamespace, "quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable")
+				actualKubeRBACProxyImage, err = utils.GetImageFromConfigMapWithFallback(ctx, k8sClient, configMapKubeRBACProxyImageKey, constants.ConfigMap, operatorNamespace, testKubeRBACProxyImage)
 				return err
 			}, "failed to get kube-rbac-proxy image from ConfigMap")
 
 			WaitFor(func() error {
 				var err error
-				actualServiceImage, err = utils.GetImageFromConfigMapWithFallback(ctx, k8sClient, configMapServiceImageKey, constants.ConfigMap, operatorNamespace, "quay.io/trustyai/trustyai-service:latest")
+				actualServiceImage, err = utils.GetImageFromConfigMapWithFallback(ctx, k8sClient, configMapServiceImageKey, constants.ConfigMap, operatorNamespace, testTrustAIServiceImage)
 				return err
 			}, "failed to get service image from ConfigMap")
 
@@ -88,7 +88,7 @@ var _ = Describe("ConfigMap tests", func() {
 
 			WaitFor(func() error {
 				var err error
-				actualKubeRBACProxyImage, err = utils.GetImageFromConfigMapWithFallback(ctx, k8sClient, configMapKubeRBACProxyImageKey, constants.ConfigMap, operatorNamespace, "quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable")
+				actualKubeRBACProxyImage, err = utils.GetImageFromConfigMapWithFallback(ctx, k8sClient, configMapKubeRBACProxyImageKey, constants.ConfigMap, operatorNamespace, testKubeRBACProxyImage)
 				if err != nil {
 					Expect(err).To(MatchError(fmt.Sprintf("configmap %s not found in namespace %s", constants.ConfigMap, operatorNamespace)))
 					return nil
@@ -98,7 +98,7 @@ var _ = Describe("ConfigMap tests", func() {
 
 			WaitFor(func() error {
 				var err error
-				actualServiceImage, err = utils.GetImageFromConfigMapWithFallback(ctx, k8sClient, configMapServiceImageKey, constants.ConfigMap, operatorNamespace, "quay.io/trustyai/trustyai-service:latest")
+				actualServiceImage, err = utils.GetImageFromConfigMapWithFallback(ctx, k8sClient, configMapServiceImageKey, constants.ConfigMap, operatorNamespace, testTrustAIServiceImage)
 				if err != nil {
 					Expect(err).To(MatchError(fmt.Sprintf("configmap %s not found in namespace %s", constants.ConfigMap, operatorNamespace)))
 					return nil
@@ -106,8 +106,8 @@ var _ = Describe("ConfigMap tests", func() {
 				return nil
 			}, "failed to get service image from ConfigMap")
 
-			Expect(actualKubeRBACProxyImage).Should(Equal("quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable"))
-			Expect(actualServiceImage).Should(Equal("quay.io/trustyai/trustyai-service:latest"))
+			Expect(actualKubeRBACProxyImage).Should(Equal(testKubeRBACProxyImage))
+			Expect(actualServiceImage).Should(Equal(testTrustAIServiceImage))
 		})
 	})
 
@@ -137,18 +137,18 @@ var _ = Describe("ConfigMap tests", func() {
 
 			Eventually(func() error {
 				var err error
-				actualKubeRBACProxyImage, err = utils.GetImageFromConfigMapWithFallback(ctx, k8sClient, configMapKubeRBACProxyImageKey, constants.ConfigMap, operatorNamespace, "quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable")
+				actualKubeRBACProxyImage, err = utils.GetImageFromConfigMapWithFallback(ctx, k8sClient, configMapKubeRBACProxyImageKey, constants.ConfigMap, operatorNamespace, testKubeRBACProxyImage)
 				return err
 			}, defaultTimeout, defaultPolling).Should(MatchError(fmt.Sprintf("configmap %s in namespace %s does not contain key %s", constants.ConfigMap, operatorNamespace, configMapKubeRBACProxyImageKey)), "failed to get kube-rbac-proxy image from ConfigMap")
 
 			Eventually(func() error {
 				var err error
-				actualServiceImage, err = utils.GetImageFromConfigMapWithFallback(ctx, k8sClient, configMapServiceImageKey, constants.ConfigMap, operatorNamespace, "quay.io/trustyai/trustyai-service:latest")
+				actualServiceImage, err = utils.GetImageFromConfigMapWithFallback(ctx, k8sClient, configMapServiceImageKey, constants.ConfigMap, operatorNamespace, testTrustAIServiceImage)
 				return err
 			}, defaultTimeout, defaultPolling).Should(MatchError(fmt.Sprintf("configmap %s in namespace %s does not contain key %s", constants.ConfigMap, operatorNamespace, configMapServiceImageKey)), "failed to get service image from ConfigMap")
 
-			Expect(actualKubeRBACProxyImage).Should(Equal("quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable"))
-			Expect(actualServiceImage).Should(Equal("quay.io/trustyai/trustyai-service:latest"))
+			Expect(actualKubeRBACProxyImage).Should(Equal(testKubeRBACProxyImage))
+			Expect(actualServiceImage).Should(Equal(testTrustAIServiceImage))
 		})
 	})
 

--- a/controllers/tas/deployment_test.go
+++ b/controllers/tas/deployment_test.go
@@ -32,6 +32,7 @@ func printKubeObject(obj interface{}) {
 
 func setupAndTestDeploymentDefault(instance *trustyaiopendatahubiov1.TrustyAIService, namespace string) {
 	Expect(createNamespace(ctx, k8sClient, namespace)).To(Succeed())
+	Expect(k8sClient.Create(ctx, createConfigMap(operatorNamespace, testKubeRBACProxyImage, testTrustAIServiceImage))).To(Succeed())
 	caBundle := reconciler.GetCustomCertificatesBundle(ctx, instance)
 
 	Expect(createTestPVC(ctx, k8sClient, instance)).To(Succeed())
@@ -53,8 +54,8 @@ func setupAndTestDeploymentDefault(instance *trustyaiopendatahubiov1.TrustyAISer
 	Expect(deployment.Labels["app.kubernetes.io/version"]).Should(Equal(constants.Version))
 
 	Expect(len(deployment.Spec.Template.Spec.Containers)).Should(Equal(2))
-	Expect(deployment.Spec.Template.Spec.Containers[0].Image).Should(Equal("quay.io/trustyai/trustyai-service:latest"))
-	Expect(deployment.Spec.Template.Spec.Containers[1].Image).Should(Equal("quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable"))
+	Expect(deployment.Spec.Template.Spec.Containers[0].Image).Should(Equal(testTrustAIServiceImage))
+	Expect(deployment.Spec.Template.Spec.Containers[1].Image).Should(Equal(testKubeRBACProxyImage))
 
 	WaitFor(func() error {
 		internalServiceConfig := getServiceConfig(instance.Name, instance)
@@ -167,6 +168,7 @@ func setupAndTestDeploymentConfigMap(instance *trustyaiopendatahubiov1.TrustyAIS
 
 func setupAndTestDeploymentNoCustomCABundle(instance *trustyaiopendatahubiov1.TrustyAIService, namespace string) {
 	Expect(createNamespace(ctx, k8sClient, namespace)).To(Succeed())
+	Expect(k8sClient.Create(ctx, createConfigMap(operatorNamespace, testKubeRBACProxyImage, testTrustAIServiceImage))).To(Succeed())
 
 	caBundle := reconciler.GetCustomCertificatesBundle(ctx, instance)
 
@@ -201,6 +203,7 @@ func setupAndTestDeploymentNoCustomCABundle(instance *trustyaiopendatahubiov1.Tr
 func setupAndTestDeploymentCustomCABundle(instance *trustyaiopendatahubiov1.TrustyAIService, namespace string) {
 	caBundleConfigMap := createTrustedCABundleConfigMap(namespace)
 	Expect(createNamespace(ctx, k8sClient, namespace)).To(Succeed())
+	Expect(k8sClient.Create(ctx, createConfigMap(operatorNamespace, testKubeRBACProxyImage, testTrustAIServiceImage))).To(Succeed())
 	Expect(k8sClient.Create(ctx, caBundleConfigMap)).To(Succeed())
 
 	caBundle := reconciler.GetCustomCertificatesBundle(ctx, instance)
@@ -235,6 +238,7 @@ func setupAndTestDeploymentCustomCABundle(instance *trustyaiopendatahubiov1.Trus
 
 func setupAndTestDeploymentServiceAccount(instance *trustyaiopendatahubiov1.TrustyAIService, namespace string, mode string) {
 	Expect(createNamespace(ctx, k8sClient, namespace)).To(Succeed())
+	Expect(k8sClient.Create(ctx, createConfigMap(operatorNamespace, testKubeRBACProxyImage, testTrustAIServiceImage))).To(Succeed())
 
 	caBundle := reconciler.GetCustomCertificatesBundle(ctx, instance)
 
@@ -398,6 +402,7 @@ var _ = Describe("TrustyAI operator", func() {
 			instance = createDefaultPVCCustomResource(namespace)
 			//printKubeObject(instance)
 			Expect(createNamespace(ctx, k8sClient, namespace)).To(Succeed())
+			Expect(k8sClient.Create(ctx, createConfigMap(operatorNamespace, testKubeRBACProxyImage, testTrustAIServiceImage))).To(Succeed())
 
 			caBundle := reconciler.GetCustomCertificatesBundle(ctx, instance)
 
@@ -489,6 +494,7 @@ var _ = Describe("TrustyAI operator", func() {
 			namespace := "trusty-ns-a-4-db"
 			instance = createDefaultDBCustomResource(namespace)
 			Expect(createNamespace(ctx, k8sClient, namespace)).To(Succeed())
+			Expect(k8sClient.Create(ctx, createConfigMap(operatorNamespace, testKubeRBACProxyImage, testTrustAIServiceImage))).To(Succeed())
 			caBundle := reconciler.GetCustomCertificatesBundle(ctx, instance)
 
 			Expect(createTestPVC(ctx, k8sClient, instance)).To(Succeed())
@@ -599,6 +605,7 @@ var _ = Describe("TrustyAI operator", func() {
 			namespace := "trusty-ns-a-4-migration"
 			instance = createDefaultMigrationCustomResource(namespace)
 			Expect(createNamespace(ctx, k8sClient, namespace)).To(Succeed())
+			Expect(k8sClient.Create(ctx, createConfigMap(operatorNamespace, testKubeRBACProxyImage, testTrustAIServiceImage))).To(Succeed())
 			//printKubeObject(instance)
 			caBundle := reconciler.GetCustomCertificatesBundle(ctx, instance)
 
@@ -888,8 +895,8 @@ var _ = Describe("TrustyAI operator", func() {
 				Expect(deployment.Labels["app.kubernetes.io/version"]).Should(Equal(constants.Version))
 
 				Expect(len(deployment.Spec.Template.Spec.Containers)).Should(Equal(2))
-				Expect(deployment.Spec.Template.Spec.Containers[0].Image).Should(Equal("quay.io/trustyai/trustyai-service:latest"))
-				Expect(deployment.Spec.Template.Spec.Containers[1].Image).Should(Equal("quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable"))
+				Expect(deployment.Spec.Template.Spec.Containers[0].Image).Should(Equal(testTrustAIServiceImage))
+				Expect(deployment.Spec.Template.Spec.Containers[1].Image).Should(Equal(testKubeRBACProxyImage))
 
 				WaitFor(func() error {
 					err := reconciler.createServiceAccount(ctx, instance)

--- a/controllers/tas/deployment_test.go
+++ b/controllers/tas/deployment_test.go
@@ -261,6 +261,10 @@ func setupAndTestDeploymentInferenceService(instance *trustyaiopendatahubiov1.Tr
 	WaitFor(func() error {
 		return createNamespace(ctx, k8sClient, namespace)
 	}, "failed to create namespace")
+	cmErr := k8sClient.Create(ctx, createConfigMap(operatorNamespace, testKubeRBACProxyImage, testTrustAIServiceImage))
+	if cmErr != nil {
+		Expect(apierrors.IsAlreadyExists(cmErr)).To(BeTrue(), "unexpected error creating operator ConfigMap: %v", cmErr)
+	}
 
 	caBundle := reconciler.GetCustomCertificatesBundle(ctx, instance)
 
@@ -864,6 +868,7 @@ var _ = Describe("TrustyAI operator", func() {
 					return createNamespace(ctx, k8sClient, namespace)
 				}, "failed to create namespace")
 			}
+			Expect(k8sClient.Create(ctx, createConfigMap(operatorNamespace, testKubeRBACProxyImage, testTrustAIServiceImage))).To(Succeed())
 
 			for _, instance := range instances {
 				caBundle := reconciler.GetCustomCertificatesBundle(ctx, instance)

--- a/controllers/tas/statuses_test.go
+++ b/controllers/tas/statuses_test.go
@@ -53,15 +53,17 @@ func setupAndTestStatusNoComponent(instance *trustyaiopendatahubiov1.TrustyAISer
 var _ = Describe("Status and condition tests", func() {
 
 	BeforeEach(func() {
+		operatorCM := createConfigMap(operatorNamespace, testKubeRBACProxyImage, testTrustAIServiceImage)
 		k8sClient = fake.NewClientBuilder().WithScheme(scheme.Scheme).WithStatusSubresource(
 			&routev1.Route{},
 			&trustyaiopendatahubiov1.TrustyAIService{},
-		).Build()
+		).WithObjects(operatorCM).Build()
 		recorder = record.NewFakeRecorder(10)
 		reconciler = &TrustyAIServiceReconciler{
 			Client:        k8sClient,
 			Scheme:        scheme.Scheme,
 			EventRecorder: recorder,
+			Namespace:     operatorNamespace,
 		}
 		ctx = context.Background()
 	})

--- a/controllers/tas/suite_test.go
+++ b/controllers/tas/suite_test.go
@@ -384,7 +384,7 @@ func makeDeploymentReady(ctx context.Context, k8sClient client.Client, instance 
 			Containers: []corev1.Container{
 				{
 					Name:  "trustyai-service",
-					Image: "quay.io/trustyai/trustyai-service:latest",
+					Image: testTrustAIServiceImage,
 					Ports: []corev1.ContainerPort{
 						{
 							ContainerPort: 8080,
@@ -551,6 +551,13 @@ var _ = BeforeSuite(func() {
 	Eventually(func() error {
 		return createNamespace(ctx, k8sClient, operatorNamespace)
 	}, time.Second*10, time.Millisecond*250).Should(Succeed(), "failed to create namespace")
+	Eventually(func() error {
+		cm := createConfigMap(operatorNamespace, testKubeRBACProxyImage, testTrustAIServiceImage)
+		if err := k8sClient.Create(ctx, cm); err != nil && !errors.IsAlreadyExists(err) {
+			return err
+		}
+		return nil
+	}, time.Second*10, time.Millisecond*250).Should(Succeed(), "failed to create operator ConfigMap")
 	Eventually(func() error {
 		return createMockPV(ctx, k8sClient, "mypv", "100Gi")
 	}, time.Second*10, time.Millisecond*250).Should(Succeed(), "failed to create PV")

--- a/controllers/tas/test_images_test.go
+++ b/controllers/tas/test_images_test.go
@@ -1,0 +1,6 @@
+package tas
+
+const (
+	testKubeRBACProxyImage  = "quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable"
+	testTrustAIServiceImage = "quay.io/trustyai/trustyai-service:latest"
+)


### PR DESCRIPTION
## What and why

Commit e24f3663 removed all hardcoded image fallbacks from `images.ResolveImage`, making tests that never supplied the operator ConfigMap fail with  `configmap trustyai-service-operator-config not found`. This PR fixes those failures and cleans up the hardcoded image strings that triggered the issue.

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Changes

### Fix: supply operator ConfigMap in tests (TAS)

- `suite_test.go`: BeforeSuite now creates the operator ConfigMap in the envtest cluster immediately after the operator namespace, covering all envtest-backed specs.
- `statuses_test.go`: BeforeEach now passes `Namespace: operatorNamespace` to the reconciler (was empty string) and seeds the fake client with the ConfigMap via `WithObjects`.
- `deployment_test.go`: every helper function and inline `It` body that calls `ensureDeployment` now creates the ConfigMap in its fake client before the call.

### Fix: correct expected error substrings (EvalHub)

`buildDeploymentSpec` resolves `evalHubImage` before `kubeRBACProxyImage`, so the first error when the ConfigMap is absent is `"resolving EvalHub image"`, not `"resolving kube-rbac-proxy image"`. Two tests had the wrong substring.

### Fix: add missing `evalHubImage` key in MCP unit test

`TestBuildMCPDeploymentSpec_envAndArgs` built the operator ConfigMap without the `evalHubImage` key, which `buildMCPDeploymentSpec` looks up first.

### Refactor: extract image constants

All hardcoded `quay.io/…` image strings in test files are replaced by named constants defined in `test_images_test.go` in each package.  10 constants cover the evalhub package (primary, reconciler, build, custom, latest, and MCP
  variants); 2 cover the tas package.

## Testing

- [x] `go build ./...` passes
- [x] `go vet ./controllers/tas/... ./controllers/evalhub/...` passes
- [x] `TestBuildMCPDeploymentSpec_envAndArgs` passes locally
- [ ] Full Ginkgo envtest suites validated in CI (kubebuilder binaries required)

## Breaking changes

None, test-only changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment handling so image values are consistently read from configuration instead of relying on hardcoded defaults.
  * Updated test coverage for EvalHub and TrustyAI Service deployments to better reflect configured images and fallback behavior.
  * Added missing setup for operator configuration in test scenarios, helping prevent reconciliation and status-check regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->