### PR TITLE
feat(evalhub): expose extended OTEL settings on v1 EvalHub CR

### DIFF
--- a/api/evalhub/v1/evalhub_types.go
+++ b/api/evalhub/v1/evalhub_types.go
@@ -63,6 +63,31 @@ type OTELSpec struct {
 	EnableMetrics bool `json:"enableMetrics,omitempty"`
 	// +optional
 	EnableLogs bool `json:"enableLogs,omitempty"`
+	// TracerTimeout is the trace export timeout (Go duration string, e.g. "30s").
+	// +optional
+	TracerTimeout string `json:"tracerTimeout,omitempty"`
+	// TracerBatchInterval is the trace batch flush interval (Go duration string, e.g. "5s").
+	// +optional
+	TracerBatchInterval string `json:"tracerBatchInterval,omitempty"`
+	// EnableJobContainerLogs exports adapter container logs at job terminal transition.
+	// Requires enableLogs.
+	// +optional
+	EnableJobContainerLogs bool `json:"enableJobContainerLogs,omitempty"`
+	// ServiceName overrides the default OTEL service.name resource attribute.
+	// +optional
+	ServiceName string `json:"serviceName,omitempty"`
+	// EnableEcsResourceDetection enables ECS resource detection on the OTEL resource.
+	// +optional
+	EnableEcsResourceDetection bool `json:"enableEcsResourceDetection,omitempty"`
+	// DisableRedirectOtelLogs prevents OTEL SDK diagnostic logs from being redirected to the main logger.
+	// +optional
+	DisableRedirectOtelLogs bool `json:"disableRedirectOtelLogs,omitempty"`
+	// DisableDatabaseOtelScans disables database query spans while still allowing DB metrics when enabled.
+	// +optional
+	DisableDatabaseOtelScans bool `json:"disableDatabaseOtelScans,omitempty"`
+	// MetricExportInterval is the metrics export interval (Go duration string, e.g. "60s").
+	// +optional
+	MetricExportInterval string `json:"metricExportInterval,omitempty"`
 }
 
 // EvalHubMCPSpec defines the optional MCP server deployment configuration.

--- a/api/evalhub/v1/evalhub_types.go
+++ b/api/evalhub/v1/evalhub_types.go
@@ -64,9 +64,11 @@ type OTELSpec struct {
 	// +optional
 	EnableLogs bool `json:"enableLogs,omitempty"`
 	// TracerTimeout is the trace export timeout (Go duration string, e.g. "30s").
+	// +kubebuilder:validation:Pattern=`^((\d+(\.\d+)?(ns|us|µs|ms|s|m|h))+)$`
 	// +optional
 	TracerTimeout string `json:"tracerTimeout,omitempty"`
 	// TracerBatchInterval is the trace batch flush interval (Go duration string, e.g. "5s").
+	// +kubebuilder:validation:Pattern=`^((\d+(\.\d+)?(ns|us|µs|ms|s|m|h))+)$`
 	// +optional
 	TracerBatchInterval string `json:"tracerBatchInterval,omitempty"`
 	// EnableJobContainerLogs exports adapter container logs at job terminal transition.
@@ -86,6 +88,7 @@ type OTELSpec struct {
 	// +optional
 	DisableDatabaseOtelScans bool `json:"disableDatabaseOtelScans,omitempty"`
 	// MetricExportInterval is the metrics export interval (Go duration string, e.g. "60s").
+	// +kubebuilder:validation:Pattern=`^((\d+(\.\d+)?(ns|us|µs|ms|s|m|h))+)$`
 	// +optional
 	MetricExportInterval string `json:"metricExportInterval,omitempty"`
 }

--- a/api/evalhub/v1alpha1/conversion.go
+++ b/api/evalhub/v1alpha1/conversion.go
@@ -30,7 +30,12 @@ func (src *EvalHub) ConvertTo(dstRaw conversion.Hub) error {
 	}
 
 	if src.Spec.Otel != nil {
-		dst.Spec.Otel = copyOTELSpecToV1(src.Spec.Otel)
+		if dst.Spec.Otel == nil {
+			dst.Spec.Otel = &v1.OTELSpec{}
+		}
+		mergeOTELSpecToV1(src.Spec.Otel, dst.Spec.Otel)
+	} else {
+		dst.Spec.Otel = nil
 	}
 
 	if src.Spec.MCP != nil {
@@ -192,20 +197,14 @@ func copyInt32Ptr(p *int32) *int32 {
 	return &v
 }
 
-func copyOTELSpecToV1(src *OTELSpec) *v1.OTELSpec {
-	if src == nil {
-		return nil
-	}
-	dst := &v1.OTELSpec{
-		ExporterType:     src.ExporterType,
-		ExporterEndpoint: src.ExporterEndpoint,
-		ExporterInsecure: src.ExporterInsecure,
-		SamplingRatio:    src.SamplingRatio,
-		EnableTracing:    src.EnableTracing,
-		EnableMetrics:    src.EnableMetrics,
-		EnableLogs:       src.EnableLogs,
-	}
-	return dst
+func mergeOTELSpecToV1(src *OTELSpec, dst *v1.OTELSpec) {
+	dst.ExporterType = src.ExporterType
+	dst.ExporterEndpoint = src.ExporterEndpoint
+	dst.ExporterInsecure = src.ExporterInsecure
+	dst.SamplingRatio = src.SamplingRatio
+	dst.EnableTracing = src.EnableTracing
+	dst.EnableMetrics = src.EnableMetrics
+	dst.EnableLogs = src.EnableLogs
 }
 
 func copyOTELSpecFromV1(src *v1.OTELSpec) *OTELSpec {

--- a/api/evalhub/v1alpha1/conversion.go
+++ b/api/evalhub/v1alpha1/conversion.go
@@ -30,15 +30,7 @@ func (src *EvalHub) ConvertTo(dstRaw conversion.Hub) error {
 	}
 
 	if src.Spec.Otel != nil {
-		dst.Spec.Otel = &v1.OTELSpec{
-			ExporterType:     src.Spec.Otel.ExporterType,
-			ExporterEndpoint: src.Spec.Otel.ExporterEndpoint,
-			ExporterInsecure: src.Spec.Otel.ExporterInsecure,
-			SamplingRatio:    src.Spec.Otel.SamplingRatio,
-			EnableTracing:    src.Spec.Otel.EnableTracing,
-			EnableMetrics:    src.Spec.Otel.EnableMetrics,
-			EnableLogs:       src.Spec.Otel.EnableLogs,
-		}
+		dst.Spec.Otel = copyOTELSpecToV1(src.Spec.Otel)
 	}
 
 	if src.Spec.MCP != nil {
@@ -112,15 +104,7 @@ func (dst *EvalHub) ConvertFrom(srcRaw conversion.Hub) error {
 	}
 
 	if src.Spec.Otel != nil {
-		dst.Spec.Otel = &OTELSpec{
-			ExporterType:     src.Spec.Otel.ExporterType,
-			ExporterEndpoint: src.Spec.Otel.ExporterEndpoint,
-			ExporterInsecure: src.Spec.Otel.ExporterInsecure,
-			SamplingRatio:    src.Spec.Otel.SamplingRatio,
-			EnableTracing:    src.Spec.Otel.EnableTracing,
-			EnableMetrics:    src.Spec.Otel.EnableMetrics,
-			EnableLogs:       src.Spec.Otel.EnableLogs,
-		}
+		dst.Spec.Otel = copyOTELSpecFromV1(src.Spec.Otel)
 	}
 
 	if src.Spec.MCP != nil {
@@ -206,4 +190,36 @@ func copyInt32Ptr(p *int32) *int32 {
 	}
 	v := *p
 	return &v
+}
+
+func copyOTELSpecToV1(src *OTELSpec) *v1.OTELSpec {
+	if src == nil {
+		return nil
+	}
+	dst := &v1.OTELSpec{
+		ExporterType:     src.ExporterType,
+		ExporterEndpoint: src.ExporterEndpoint,
+		ExporterInsecure: src.ExporterInsecure,
+		SamplingRatio:    src.SamplingRatio,
+		EnableTracing:    src.EnableTracing,
+		EnableMetrics:    src.EnableMetrics,
+		EnableLogs:       src.EnableLogs,
+	}
+	return dst
+}
+
+func copyOTELSpecFromV1(src *v1.OTELSpec) *OTELSpec {
+	if src == nil {
+		return nil
+	}
+	dst := &OTELSpec{
+		ExporterType:     src.ExporterType,
+		ExporterEndpoint: src.ExporterEndpoint,
+		ExporterInsecure: src.ExporterInsecure,
+		SamplingRatio:    src.SamplingRatio,
+		EnableTracing:    src.EnableTracing,
+		EnableMetrics:    src.EnableMetrics,
+		EnableLogs:       src.EnableLogs,
+	}
+	return dst
 }

--- a/api/evalhub/v1alpha1/conversion.go
+++ b/api/evalhub/v1alpha1/conversion.go
@@ -88,6 +88,8 @@ func (src *EvalHub) ConvertTo(dstRaw conversion.Hub) error {
 }
 
 // ConvertFrom converts the v1 EvalHub (hub version) to v1alpha1 EvalHub
+// Note: This conversion is not used in the operator, but it is here for completeness.
+// Note: The v1-only fields are not copied to the v1alpha1 EvalHub.
 func (dst *EvalHub) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1.EvalHub)
 

--- a/api/evalhub/v1alpha1/conversion_test.go
+++ b/api/evalhub/v1alpha1/conversion_test.go
@@ -195,6 +195,58 @@ func TestConvertNilPointerFields(t *testing.T) {
 	}
 }
 
+func TestConvertToPreservesV1OnlyOTELFields(t *testing.T) {
+	hub := &v1.EvalHub{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-evalhub"},
+		Spec: v1.EvalHubSpec{
+			Replicas: int32Ptr(1),
+			Otel: &v1.OTELSpec{
+				ExporterType:               "otlp-grpc",
+				ExporterEndpoint:           "otel-collector:4317",
+				TracerTimeout:              "30s",
+				TracerBatchInterval:        "5s",
+				EnableJobContainerLogs:     true,
+				ServiceName:                "evalhub-test",
+				EnableEcsResourceDetection: true,
+				DisableRedirectOtelLogs:    true,
+				DisableDatabaseOtelScans:   true,
+				MetricExportInterval:       "60s",
+			},
+		},
+	}
+
+	spoke := &EvalHub{
+		Spec: EvalHubSpec{
+			Replicas: int32Ptr(1),
+			Otel: &OTELSpec{
+				ExporterType:     "otlp-http",
+				ExporterEndpoint: "new-endpoint:4318",
+				EnableTracing:    true,
+			},
+		},
+	}
+
+	if err := spoke.ConvertTo(hub); err != nil {
+		t.Fatalf("ConvertTo failed: %v", err)
+	}
+
+	if hub.Spec.Otel.ExporterEndpoint != "new-endpoint:4318" {
+		t.Errorf("ExporterEndpoint = %q, want %q", hub.Spec.Otel.ExporterEndpoint, "new-endpoint:4318")
+	}
+	if hub.Spec.Otel.TracerTimeout != "30s" {
+		t.Errorf("TracerTimeout = %q, want %q", hub.Spec.Otel.TracerTimeout, "30s")
+	}
+	if hub.Spec.Otel.ServiceName != "evalhub-test" {
+		t.Errorf("ServiceName = %q, want %q", hub.Spec.Otel.ServiceName, "evalhub-test")
+	}
+	if hub.Spec.Otel.MetricExportInterval != "60s" {
+		t.Errorf("MetricExportInterval = %q, want %q", hub.Spec.Otel.MetricExportInterval, "60s")
+	}
+	if !hub.Spec.Otel.EnableJobContainerLogs {
+		t.Error("EnableJobContainerLogs was cleared")
+	}
+}
+
 func TestConvertFromDropsV1OnlyOTELFields(t *testing.T) {
 	hub := &v1.EvalHub{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-evalhub"},

--- a/api/evalhub/v1alpha1/conversion_test.go
+++ b/api/evalhub/v1alpha1/conversion_test.go
@@ -195,6 +195,34 @@ func TestConvertNilPointerFields(t *testing.T) {
 	}
 }
 
+func TestConvertFromDropsV1OnlyOTELFields(t *testing.T) {
+	hub := &v1.EvalHub{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-evalhub"},
+		Spec: v1.EvalHubSpec{
+			Replicas: int32Ptr(1),
+			Otel: &v1.OTELSpec{
+				ExporterType:           "otlp-grpc",
+				ExporterEndpoint:       "otel-collector:4317",
+				TracerTimeout:          "30s",
+				ServiceName:            "evalhub-test",
+				MetricExportInterval:   "60s",
+			},
+		},
+	}
+
+	dst := &EvalHub{}
+	if err := dst.ConvertFrom(hub); err != nil {
+		t.Fatalf("ConvertFrom failed: %v", err)
+	}
+
+	if dst.Spec.Otel == nil {
+		t.Fatal("Otel should be converted")
+	}
+	if dst.Spec.Otel.ExporterEndpoint != "otel-collector:4317" {
+		t.Errorf("ExporterEndpoint = %q, want %q", dst.Spec.Otel.ExporterEndpoint, "otel-collector:4317")
+	}
+}
+
 func TestConvertDeepCopyIsolation(t *testing.T) {
 	src := fullEvalHubV1Alpha1()
 	dst := &v1.EvalHub{}

--- a/api/evalhub/v1alpha1/conversion_test.go
+++ b/api/evalhub/v1alpha1/conversion_test.go
@@ -201,11 +201,11 @@ func TestConvertFromDropsV1OnlyOTELFields(t *testing.T) {
 		Spec: v1.EvalHubSpec{
 			Replicas: int32Ptr(1),
 			Otel: &v1.OTELSpec{
-				ExporterType:           "otlp-grpc",
-				ExporterEndpoint:       "otel-collector:4317",
-				TracerTimeout:          "30s",
-				ServiceName:            "evalhub-test",
-				MetricExportInterval:   "60s",
+				ExporterType:         "otlp-grpc",
+				ExporterEndpoint:     "otel-collector:4317",
+				TracerTimeout:        "30s",
+				ServiceName:          "evalhub-test",
+				MetricExportInterval: "60s",
 			},
 		},
 	}

--- a/config/components/evalhub/crd/trustyai.opendatahub.io_evalhubs.yaml
+++ b/config/components/evalhub/crd/trustyai.opendatahub.io_evalhubs.yaml
@@ -532,7 +532,7 @@ spec:
                   enableJobContainerLogs:
                     description: |-
                       EnableJobContainerLogs exports adapter container logs at job terminal transition.
-                      Requires enableLogs.
+                      Requires enableLogs to be true.
                     type: boolean
                   enableLogs:
                     type: boolean

--- a/config/components/evalhub/crd/trustyai.opendatahub.io_evalhubs.yaml
+++ b/config/components/evalhub/crd/trustyai.opendatahub.io_evalhubs.yaml
@@ -556,6 +556,7 @@ spec:
                   metricExportInterval:
                     description: MetricExportInterval is the metrics export interval
                       (Go duration string, e.g. "60s").
+                    pattern: ^((\d+(\.\d+)?(ns|us|µs|ms|s|m|h))+)$
                     type: string
                   samplingRatio:
                     default: "1.0"
@@ -570,10 +571,12 @@ spec:
                   tracerBatchInterval:
                     description: TracerBatchInterval is the trace batch flush interval
                       (Go duration string, e.g. "5s").
+                    pattern: ^((\d+(\.\d+)?(ns|us|µs|ms|s|m|h))+)$
                     type: string
                   tracerTimeout:
                     description: TracerTimeout is the trace export timeout (Go duration
                       string, e.g. "30s").
+                    pattern: ^((\d+(\.\d+)?(ns|us|µs|ms|s|m|h))+)$
                     type: string
                 type: object
               providers:

--- a/config/components/evalhub/crd/trustyai.opendatahub.io_evalhubs.yaml
+++ b/config/components/evalhub/crd/trustyai.opendatahub.io_evalhubs.yaml
@@ -517,6 +517,23 @@ spec:
                   When set, the operator includes OTEL settings in the generated config.
                   When omitted, the service uses its defaults (OTEL disabled).
                 properties:
+                  disableDatabaseOtelScans:
+                    description: DisableDatabaseOtelScans disables database query
+                      spans while still allowing DB metrics when enabled.
+                    type: boolean
+                  disableRedirectOtelLogs:
+                    description: DisableRedirectOtelLogs prevents OTEL SDK diagnostic
+                      logs from being redirected to the main logger.
+                    type: boolean
+                  enableEcsResourceDetection:
+                    description: EnableEcsResourceDetection enables ECS resource detection
+                      on the OTEL resource.
+                    type: boolean
+                  enableJobContainerLogs:
+                    description: |-
+                      EnableJobContainerLogs exports adapter container logs at job terminal transition.
+                      Requires enableLogs.
+                    type: boolean
                   enableLogs:
                     type: boolean
                   enableMetrics:
@@ -536,11 +553,27 @@ spec:
                     - otlp-http
                     - stdout
                     type: string
+                  metricExportInterval:
+                    description: MetricExportInterval is the metrics export interval
+                      (Go duration string, e.g. "60s").
+                    type: string
                   samplingRatio:
                     default: "1.0"
                     description: |-
                       Trace sampling ratio as a string-encoded float between "0" and "1" (e.g. "0.5").
                       Defaults to "1.0" (sample everything) when omitted.
+                    type: string
+                  serviceName:
+                    description: ServiceName overrides the default OTEL service.name
+                      resource attribute.
+                    type: string
+                  tracerBatchInterval:
+                    description: TracerBatchInterval is the trace batch flush interval
+                      (Go duration string, e.g. "5s").
+                    type: string
+                  tracerTimeout:
+                    description: TracerTimeout is the trace export timeout (Go duration
+                      string, e.g. "30s").
                     type: string
                 type: object
               providers:

--- a/controllers/evalhub/configmap.go
+++ b/controllers/evalhub/configmap.go
@@ -41,22 +41,22 @@ type DatabaseConfig struct {
 // OTELConfig represents the OpenTelemetry configuration in config.yaml.
 // Field names match eval-hub internal/eval_hub/config/otel.go.
 type OTELConfig struct {
-	Enabled                    bool              `json:"enabled"`
-	ExporterType               string            `json:"exporter_type,omitempty"`
-	ExporterEndpoint           string            `json:"exporter_endpoint,omitempty"`
-	ExporterInsecure           bool              `json:"exporter_insecure,omitempty"`
-	SamplingRatio              *float64          `json:"sampling_ratio,omitempty"`
-	EnableTracing              bool              `json:"enable_tracing,omitempty"`
-	TracerTimeout              string            `json:"tracer_timeout,omitempty"`
-	TracerBatchInterval        string            `json:"tracer_batch_interval,omitempty"`
-	EnableMetrics              bool              `json:"enable_metrics,omitempty"`
-	EnableLogs                 bool              `json:"enable_logs,omitempty"`
-	EnableJobContainerLogs     bool              `json:"enable_job_container_logs,omitempty"`
-	ServiceName                string `json:"service_name,omitempty"`
-	EnableECSResourceDetection bool   `json:"enable_ecs_resource_detection,omitempty"`
-	DisableRedirectOTELLogs    bool              `json:"disable_redirect_otel_logs,omitempty"`
-	DisableDatabaseOTELScans   bool              `json:"disable_database_otel_scan,omitempty"`
-	MetricExportInterval       string            `json:"metric_export_interval,omitempty"`
+	Enabled                    bool     `json:"enabled"`
+	ExporterType               string   `json:"exporter_type,omitempty"`
+	ExporterEndpoint           string   `json:"exporter_endpoint,omitempty"`
+	ExporterInsecure           bool     `json:"exporter_insecure,omitempty"`
+	SamplingRatio              *float64 `json:"sampling_ratio,omitempty"`
+	EnableTracing              bool     `json:"enable_tracing,omitempty"`
+	TracerTimeout              string   `json:"tracer_timeout,omitempty"`
+	TracerBatchInterval        string   `json:"tracer_batch_interval,omitempty"`
+	EnableMetrics              bool     `json:"enable_metrics,omitempty"`
+	EnableLogs                 bool     `json:"enable_logs,omitempty"`
+	EnableJobContainerLogs     bool     `json:"enable_job_container_logs,omitempty"`
+	ServiceName                string   `json:"service_name,omitempty"`
+	EnableECSResourceDetection bool     `json:"enable_ecs_resource_detection,omitempty"`
+	DisableRedirectOTELLogs    bool     `json:"disable_redirect_otel_logs,omitempty"`
+	DisableDatabaseOTELScans   bool     `json:"disable_database_otel_scan,omitempty"`
+	MetricExportInterval       string   `json:"metric_export_interval,omitempty"`
 }
 
 // SecretsMapping represents the secrets mapping configuration in config.yaml
@@ -257,6 +257,10 @@ func buildOTELConfig(spec *evalhubv1.OTELSpec) (*OTELConfig, error) {
 		return nil, fmt.Errorf("otel spec is nil")
 	}
 
+	if spec.EnableJobContainerLogs && !spec.EnableLogs {
+		return nil, fmt.Errorf("enableJobContainerLogs requires enableLogs to be true")
+	}
+
 	otelCfg := &OTELConfig{
 		Enabled:                    true,
 		ExporterType:               spec.ExporterType,
@@ -264,7 +268,7 @@ func buildOTELConfig(spec *evalhubv1.OTELSpec) (*OTELConfig, error) {
 		ExporterInsecure:           spec.ExporterInsecure,
 		EnableTracing:              spec.EnableTracing,
 		EnableMetrics:              spec.EnableMetrics,
-		EnableLogs:                   spec.EnableLogs,
+		EnableLogs:                 spec.EnableLogs,
 		EnableJobContainerLogs:     spec.EnableJobContainerLogs,
 		ServiceName:                spec.ServiceName,
 		EnableECSResourceDetection: spec.EnableEcsResourceDetection,
@@ -302,8 +306,12 @@ func buildOTELConfig(spec *evalhubv1.OTELSpec) (*OTELConfig, error) {
 }
 
 func validateOTELDuration(fieldName, value string) error {
-	if _, err := time.ParseDuration(value); err != nil {
+	d, err := time.ParseDuration(value)
+	if err != nil {
 		return fmt.Errorf("invalid %s %q: %w", fieldName, value, err)
+	}
+	if d <= 0 {
+		return fmt.Errorf("invalid %s %q: duration must be greater than zero", fieldName, value)
 	}
 	return nil
 }

--- a/controllers/evalhub/configmap.go
+++ b/controllers/evalhub/configmap.go
@@ -310,8 +310,8 @@ func validateOTELDuration(fieldName, value string) error {
 	if err != nil {
 		return fmt.Errorf("invalid %s %q: %w", fieldName, value, err)
 	}
-	if d <= 0 {
-		return fmt.Errorf("invalid %s %q: duration must be greater than zero", fieldName, value)
+	if d < 0 {
+		return fmt.Errorf("invalid %s %q: duration must be greater than, or equal, to zero", fieldName, value)
 	}
 	return nil
 }

--- a/controllers/evalhub/configmap.go
+++ b/controllers/evalhub/configmap.go
@@ -38,16 +38,25 @@ type DatabaseConfig struct {
 	MaxIdleConns int    `json:"max_idle_conns,omitempty"`
 }
 
-// OTELConfig represents the OpenTelemetry configuration in config.yaml
+// OTELConfig represents the OpenTelemetry configuration in config.yaml.
+// Field names match eval-hub internal/eval_hub/config/otel.go.
 type OTELConfig struct {
-	Enabled          bool     `json:"enabled"`
-	ExporterType     string   `json:"exporter_type,omitempty"`
-	ExporterEndpoint string   `json:"exporter_endpoint,omitempty"`
-	ExporterInsecure bool     `json:"exporter_insecure,omitempty"`
-	SamplingRatio    *float64 `json:"sampling_ratio,omitempty"`
-	EnableTracing    bool     `json:"enable_tracing,omitempty"`
-	EnableMetrics    bool     `json:"enable_metrics,omitempty"`
-	EnableLogs       bool     `json:"enable_logs,omitempty"`
+	Enabled                    bool              `json:"enabled"`
+	ExporterType               string            `json:"exporter_type,omitempty"`
+	ExporterEndpoint           string            `json:"exporter_endpoint,omitempty"`
+	ExporterInsecure           bool              `json:"exporter_insecure,omitempty"`
+	SamplingRatio              *float64          `json:"sampling_ratio,omitempty"`
+	EnableTracing              bool              `json:"enable_tracing,omitempty"`
+	TracerTimeout              string            `json:"tracer_timeout,omitempty"`
+	TracerBatchInterval        string            `json:"tracer_batch_interval,omitempty"`
+	EnableMetrics              bool              `json:"enable_metrics,omitempty"`
+	EnableLogs                 bool              `json:"enable_logs,omitempty"`
+	EnableJobContainerLogs     bool              `json:"enable_job_container_logs,omitempty"`
+	ServiceName                string `json:"service_name,omitempty"`
+	EnableECSResourceDetection bool   `json:"enable_ecs_resource_detection,omitempty"`
+	DisableRedirectOTELLogs    bool              `json:"disable_redirect_otel_logs,omitempty"`
+	DisableDatabaseOTELScans   bool              `json:"disable_database_otel_scan,omitempty"`
+	MetricExportInterval       string            `json:"metric_export_interval,omitempty"`
 }
 
 // SecretsMapping represents the secrets mapping configuration in config.yaml
@@ -224,21 +233,9 @@ func (r *EvalHubReconciler) generateConfigData(ctx context.Context, instance *ev
 
 	// Override OTEL configuration when explicitly configured
 	if instance.Spec.IsOTELConfigured() {
-		otelCfg := &OTELConfig{
-			Enabled:          true,
-			ExporterType:     instance.Spec.Otel.ExporterType,
-			ExporterEndpoint: instance.Spec.Otel.ExporterEndpoint,
-			ExporterInsecure: instance.Spec.Otel.ExporterInsecure,
-			EnableTracing:    instance.Spec.Otel.EnableTracing,
-			EnableMetrics:    instance.Spec.Otel.EnableMetrics,
-			EnableLogs:       instance.Spec.Otel.EnableLogs,
-		}
-		if instance.Spec.Otel.SamplingRatio != "" {
-			ratio, err := strconv.ParseFloat(instance.Spec.Otel.SamplingRatio, 64)
-			if err != nil {
-				return nil, fmt.Errorf("invalid samplingRatio %q: %w", instance.Spec.Otel.SamplingRatio, err)
-			}
-			otelCfg.SamplingRatio = &ratio
+		otelCfg, err := buildOTELConfig(instance.Spec.Otel)
+		if err != nil {
+			return nil, err
 		}
 		config.OTEL = otelCfg
 	}
@@ -253,6 +250,62 @@ func (r *EvalHubReconciler) generateConfigData(ctx context.Context, instance *ev
 		"config.yaml": string(configYAML),
 		"auth.yaml":   generateAuthConfigData(),
 	}, nil
+}
+
+func buildOTELConfig(spec *evalhubv1.OTELSpec) (*OTELConfig, error) {
+	if spec == nil {
+		return nil, fmt.Errorf("otel spec is nil")
+	}
+
+	otelCfg := &OTELConfig{
+		Enabled:                    true,
+		ExporterType:               spec.ExporterType,
+		ExporterEndpoint:           spec.ExporterEndpoint,
+		ExporterInsecure:           spec.ExporterInsecure,
+		EnableTracing:              spec.EnableTracing,
+		EnableMetrics:              spec.EnableMetrics,
+		EnableLogs:                   spec.EnableLogs,
+		EnableJobContainerLogs:     spec.EnableJobContainerLogs,
+		ServiceName:                spec.ServiceName,
+		EnableECSResourceDetection: spec.EnableEcsResourceDetection,
+		DisableRedirectOTELLogs:    spec.DisableRedirectOtelLogs,
+		DisableDatabaseOTELScans:   spec.DisableDatabaseOtelScans,
+	}
+
+	if spec.SamplingRatio != "" {
+		ratio, err := strconv.ParseFloat(spec.SamplingRatio, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid samplingRatio %q: %w", spec.SamplingRatio, err)
+		}
+		otelCfg.SamplingRatio = &ratio
+	}
+
+	for _, field := range []struct {
+		name  string
+		value string
+		dest  *string
+	}{
+		{name: "tracerTimeout", value: spec.TracerTimeout, dest: &otelCfg.TracerTimeout},
+		{name: "tracerBatchInterval", value: spec.TracerBatchInterval, dest: &otelCfg.TracerBatchInterval},
+		{name: "metricExportInterval", value: spec.MetricExportInterval, dest: &otelCfg.MetricExportInterval},
+	} {
+		if field.value == "" {
+			continue
+		}
+		if err := validateOTELDuration(field.name, field.value); err != nil {
+			return nil, err
+		}
+		*field.dest = field.value
+	}
+
+	return otelCfg, nil
+}
+
+func validateOTELDuration(fieldName, value string) error {
+	if _, err := time.ParseDuration(value); err != nil {
+		return fmt.Errorf("invalid %s %q: %w", fieldName, value, err)
+	}
+	return nil
 }
 
 // generateAuthConfigData returns the authorization configuration for the ConfigMap.

--- a/controllers/evalhub/unit_test.go
+++ b/controllers/evalhub/unit_test.go
@@ -1236,8 +1236,8 @@ func TestGenerateConfigData_WithOTEL(t *testing.T) {
 					EnableJobContainerLogs:     true,
 					ServiceName:                "my-evalhub",
 					EnableEcsResourceDetection: true,
-					DisableRedirectOtelLogs:   true,
-					DisableDatabaseOtelScans:  true,
+					DisableRedirectOtelLogs:    true,
+					DisableDatabaseOtelScans:   true,
 					MetricExportInterval:       "10s",
 				},
 			},
@@ -1272,6 +1272,45 @@ func TestGenerateConfigData_WithOTEL(t *testing.T) {
 	})
 
 	t.Run("should reject invalid otel duration fields", func(t *testing.T) {
+		for _, tc := range []struct {
+			name  string
+			value string
+		}{
+			{name: "unparseable", value: "not-a-duration"},
+			{name: "zero", value: "0s"},
+			{name: "negative", value: "-5s"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				evalHub := &evalhubv1.EvalHub{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-evalhub",
+						Namespace: "test-namespace",
+					},
+					Spec: evalhubv1.EvalHubSpec{
+						Otel: &evalhubv1.OTELSpec{
+							TracerTimeout: tc.value,
+						},
+					},
+				}
+
+				configMap := createConfigMap(configMapName, evalHub.Namespace)
+				fakeClient := fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(evalHub, configMap).
+					Build()
+				reconciler := &EvalHubReconciler{
+					Client:    fakeClient,
+					Scheme:    scheme,
+					Namespace: evalHub.Namespace,
+				}
+				_, err := reconciler.generateConfigData(context.Background(), evalHub)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "tracerTimeout")
+			})
+		}
+	})
+
+	t.Run("should reject enableJobContainerLogs without enableLogs", func(t *testing.T) {
 		evalHub := &evalhubv1.EvalHub{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-evalhub",
@@ -1279,7 +1318,8 @@ func TestGenerateConfigData_WithOTEL(t *testing.T) {
 			},
 			Spec: evalhubv1.EvalHubSpec{
 				Otel: &evalhubv1.OTELSpec{
-					TracerTimeout: "not-a-duration",
+					EnableJobContainerLogs: true,
+					EnableLogs:             false,
 				},
 			},
 		}
@@ -1296,7 +1336,7 @@ func TestGenerateConfigData_WithOTEL(t *testing.T) {
 		}
 		_, err := reconciler.generateConfigData(context.Background(), evalHub)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "tracerTimeout")
+		assert.Contains(t, err.Error(), "enableJobContainerLogs")
 	})
 
 	t.Run("should use custom values", func(t *testing.T) {

--- a/controllers/evalhub/unit_test.go
+++ b/controllers/evalhub/unit_test.go
@@ -1277,7 +1277,6 @@ func TestGenerateConfigData_WithOTEL(t *testing.T) {
 			value string
 		}{
 			{name: "unparseable", value: "not-a-duration"},
-			{name: "zero", value: "0s"},
 			{name: "negative", value: "-5s"},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
@@ -1308,6 +1307,39 @@ func TestGenerateConfigData_WithOTEL(t *testing.T) {
 				assert.Contains(t, err.Error(), "tracerTimeout")
 			})
 		}
+	})
+
+	t.Run("should accept zero otel duration fields", func(t *testing.T) {
+		evalHub := &evalhubv1.EvalHub{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-evalhub",
+				Namespace: "test-namespace",
+			},
+			Spec: evalhubv1.EvalHubSpec{
+				Otel: &evalhubv1.OTELSpec{
+					TracerTimeout: "0s",
+				},
+			},
+		}
+
+		configMap := createConfigMap(configMapName, evalHub.Namespace)
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(evalHub, configMap).
+			Build()
+		reconciler := &EvalHubReconciler{
+			Client:    fakeClient,
+			Scheme:    scheme,
+			Namespace: evalHub.Namespace,
+		}
+		configData, err := reconciler.generateConfigData(context.Background(), evalHub)
+		require.NoError(t, err)
+
+		var config EvalHubConfig
+		err = yaml.Unmarshal([]byte(configData["config.yaml"]), &config)
+		require.NoError(t, err)
+		require.NotNil(t, config.OTEL)
+		assert.Equal(t, "0s", config.OTEL.TracerTimeout)
 	})
 
 	t.Run("should reject enableJobContainerLogs without enableLogs", func(t *testing.T) {

--- a/controllers/evalhub/unit_test.go
+++ b/controllers/evalhub/unit_test.go
@@ -1218,6 +1218,87 @@ func TestGenerateConfigData_WithOTEL(t *testing.T) {
 		assert.False(t, config.OTEL.EnableLogs)
 	})
 
+	t.Run("should map extended otel fields", func(t *testing.T) {
+		evalHub := &evalhubv1.EvalHub{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-evalhub",
+				Namespace: "test-namespace",
+			},
+			Spec: evalhubv1.EvalHubSpec{
+				Otel: &evalhubv1.OTELSpec{
+					ExporterType:               "otlp-grpc",
+					ExporterEndpoint:           "otel-collector:4317",
+					EnableTracing:              true,
+					EnableMetrics:              true,
+					EnableLogs:                 true,
+					TracerTimeout:              "30s",
+					TracerBatchInterval:        "5s",
+					EnableJobContainerLogs:     true,
+					ServiceName:                "my-evalhub",
+					EnableEcsResourceDetection: true,
+					DisableRedirectOtelLogs:   true,
+					DisableDatabaseOtelScans:  true,
+					MetricExportInterval:       "10s",
+				},
+			},
+		}
+
+		configMap := createConfigMap(configMapName, evalHub.Namespace)
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(evalHub, configMap).
+			Build()
+		reconciler := &EvalHubReconciler{
+			Client:    fakeClient,
+			Scheme:    scheme,
+			Namespace: evalHub.Namespace,
+		}
+		configData, err := reconciler.generateConfigData(context.Background(), evalHub)
+		require.NoError(t, err)
+
+		var config EvalHubConfig
+		err = yaml.Unmarshal([]byte(configData["config.yaml"]), &config)
+		require.NoError(t, err)
+
+		require.NotNil(t, config.OTEL)
+		assert.Equal(t, "30s", config.OTEL.TracerTimeout)
+		assert.Equal(t, "5s", config.OTEL.TracerBatchInterval)
+		assert.Equal(t, "10s", config.OTEL.MetricExportInterval)
+		assert.Equal(t, "my-evalhub", config.OTEL.ServiceName)
+		assert.True(t, config.OTEL.EnableJobContainerLogs)
+		assert.True(t, config.OTEL.EnableECSResourceDetection)
+		assert.True(t, config.OTEL.DisableRedirectOTELLogs)
+		assert.True(t, config.OTEL.DisableDatabaseOTELScans)
+	})
+
+	t.Run("should reject invalid otel duration fields", func(t *testing.T) {
+		evalHub := &evalhubv1.EvalHub{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-evalhub",
+				Namespace: "test-namespace",
+			},
+			Spec: evalhubv1.EvalHubSpec{
+				Otel: &evalhubv1.OTELSpec{
+					TracerTimeout: "not-a-duration",
+				},
+			},
+		}
+
+		configMap := createConfigMap(configMapName, evalHub.Namespace)
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(evalHub, configMap).
+			Build()
+		reconciler := &EvalHubReconciler{
+			Client:    fakeClient,
+			Scheme:    scheme,
+			Namespace: evalHub.Namespace,
+		}
+		_, err := reconciler.generateConfigData(context.Background(), evalHub)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tracerTimeout")
+	})
+
 	t.Run("should use custom values", func(t *testing.T) {
 		evalHub := &evalhubv1.EvalHub{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Summary

Extends `spec.otel` on the **v1** `EvalHub` CR with the remaining eval-hub `OTELConfig` fields that were previously only configurable via `config.yaml` defaults. The operator now maps these CR fields into the generated `config.yaml` when the EvalHub service starts.

This aligns the operator with eval-hub's OpenTelemetry configuration surface documented in [eval-hub OTELConfig](https://github.com/eval-hub/eval-hub/blob/main/internal/eval_hub/config/otel.go).

### New v1 CR fields (`spec.otel`)

| CR field (camelCase) | config.yaml field | Type |
|---|---|---|
| `tracerTimeout` | `tracer_timeout` | Go duration string (e.g. `"30s"`) |
| `tracerBatchInterval` | `tracer_batch_interval` | Go duration string (e.g. `"5s"`) |
| `metricExportInterval` | `metric_export_interval` | Go duration string (e.g. `"60s"`) |
| `enableJobContainerLogs` | `enable_job_container_logs` | boolean |
| `serviceName` | `service_name` | string |
| `enableEcsResourceDetection` | `enable_ecs_resource_detection` | boolean |
| `disableRedirectOtelLogs` | `disable_redirect_otel_logs` | boolean |
| `disableDatabaseOtelScans` | `disable_database_otel_scan` | boolean |

Duration fields are validated with `time.ParseDuration` during config generation; invalid values fail reconciliation with a descriptive error.

### Unchanged / intentionally excluded

- **Existing fields** (`exporterType`, `exporterEndpoint`, `exporterInsecure`, `samplingRatio`, `enableTracing`, `enableMetrics`, `enableLogs`) behave as before.
- **`additionalAttributes`** — deferred; not exposed on the CR in this PR.
- **`TLSConfig`** — runtime-only in eval-hub; not suitable for the CR.
- **v1alpha1** — extended fields are **v1-only**. v1alpha1 retains the original OTEL subset; hub conversion copies shared fields only and drops v1-only settings on `ConvertFrom`.

### Example

```yaml
apiVersion: trustyai.opendatahub.io/v1
kind: EvalHub
metadata:
  name: my-evalhub
spec:
  otel:
    exporterType: otlp-grpc
    exporterEndpoint: otel-collector:4317
    enableTracing: true
    enableMetrics: true
    enableLogs: true
    tracerTimeout: "30s"
    tracerBatchInterval: "5s"
    metricExportInterval: "60s"
    serviceName: my-evalhub
    enableJobContainerLogs: true
    enableEcsResourceDetection: true
    disableRedirectOtelLogs: true
    disableDatabaseOtelScans: true
```

## Changes by area

### API (`api/evalhub/v1`)
- Extended `OTELSpec` with the eight new fields above.
- Regenerated CRD schema for the **v1** version only.

### Conversion (`api/evalhub/v1alpha1`)
- Refactored OTEL copying into `copyOTELSpecToV1` / `copyOTELSpecFromV1` helpers.
- Added `TestConvertFromDropsV1OnlyOTELFields` to verify v1-only OTEL settings are not written back to v1alpha1.

### Controller (`controllers/evalhub/configmap.go`)
- Extended internal `OTELConfig` struct to match eval-hub JSON field names.
- Replaced inline OTEL mapping with `buildOTELConfig()` and `validateOTELDuration()`.

### Tests
- `controllers/evalhub/unit_test.go`: extended field mapping and invalid duration rejection.
- `api/evalhub/v1alpha1/conversion_test.go`: v1-only field drop on downgrade.

## Test plan

- [x] `go test ./api/evalhub/v1alpha1/... -run TestConvert`
- [x] `go test ./controllers/evalhub/... -run OTEL`
- [ ] Deploy an EvalHub with extended `spec.otel` and confirm generated ConfigMap `config.yaml` contains expected snake_case OTEL keys
- [ ] Confirm eval-hub pod starts and OTEL settings are applied (trace/metrics export as configured)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added additional OpenTelemetry options to EvalHub `spec.otel`, including tracer timing controls, metric export interval, service name override, ECS resource detection, and job container log export.
  * Updated configuration generation so these options appear in the produced runtime config.

* **Bug Fixes**
  * Improved validation for OTEL duration values and enforced dependencies (job log export requires general logs enabled).

* **Tests**
  * Added conversion and controller unit-test coverage for preserving/dropping v1-only OTEL fields and for the new validation behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->