### PR TITLE
feat: integrate with cluster TLS security profile

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,15 +17,18 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
+	"os"
+
 	kservev1alpha1 "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	routev1 "github.com/openshift/api/route/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	nemoguardrailsv1alpha1 "github.com/trustyai-explainability/trustyai-service-operator/api/nemo_guardrails/v1alpha1"
+	pkgtls "github.com/trustyai-explainability/trustyai-service-operator/pkg/tls"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"os"
 	"slices"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -107,9 +110,17 @@ func main() {
 		os.Exit(1)
 	}
 
+	cfg := ctrl.GetConfigOrDie()
+	tlsResult, err := pkgtls.Resolve(context.Background(), cfg)
+	if err != nil {
+		setupLog.Error(err, "unable to resolve TLS configuration")
+		os.Exit(1)
+	}
+	tlsOpts := tlsResult.TLSOpts
+
 	mgrOpts := ctrl.Options{
 		Scheme:                 scheme,
-		Metrics:                server.Options{BindAddress: metricsAddr},
+		Metrics:                server.Options{BindAddress: metricsAddr, TLSOpts: tlsOpts},
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "b7e9931f.trustyai.opendatahub.io",
@@ -129,6 +140,10 @@ func main() {
 				},
 			},
 		},
+		WebhookServer: ctrlwebhook.NewServer(ctrlwebhook.Options{
+			Port:    9443,
+			TLSOpts: tlsOpts,
+		}),
 		// LeaderElectionReleaseOnCancel: true,
 	}
 
@@ -138,7 +153,7 @@ func main() {
 		})
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), mgrOpts)
+	mgr, err := ctrl.NewManager(cfg, mgrOpts)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)

--- a/config/rbac-base/kustomization.yaml
+++ b/config/rbac-base/kustomization.yaml
@@ -7,3 +7,5 @@ resources:
   - leader_election_role.yaml
   - leader_election_role_binding.yaml
   - service_account.yaml
+  - tls_profile_role.yaml
+  - tls_profile_role_binding.yaml

--- a/config/rbac-base/tls_profile_role.yaml
+++ b/config/rbac-base/tls_profile_role.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tls-profile-reader
+rules:
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - apiservers
+    verbs:
+      - get

--- a/config/rbac-base/tls_profile_role_binding.yaml
+++ b/config/rbac-base/tls_profile_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tls-profile-reader-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tls-profile-reader
+subjects:
+  - kind: ServiceAccount
+    name: trustyai-service-operator
+    namespace: system

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var log = ctrl.Log.WithName("tls")
+
+// openSSLToGoCipher maps OpenSSL cipher suite names to Go crypto/tls constants.
+var openSSLToGoCipher = map[string]uint16{
+	"TLS_AES_128_GCM_SHA256":               tls.TLS_AES_128_GCM_SHA256,
+	"TLS_AES_256_GCM_SHA384":               tls.TLS_AES_256_GCM_SHA384,
+	"TLS_CHACHA20_POLY1305_SHA256":         tls.TLS_CHACHA20_POLY1305_SHA256,
+	"ECDHE-ECDSA-AES128-GCM-SHA256":        tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	"ECDHE-RSA-AES128-GCM-SHA256":          tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	"ECDHE-ECDSA-AES256-GCM-SHA384":        tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	"ECDHE-RSA-AES256-GCM-SHA384":          tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	"ECDHE-ECDSA-CHACHA20-POLY1305-SHA256": tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+	"ECDHE-RSA-CHACHA20-POLY1305-SHA256":   tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+	"ECDHE-ECDSA-CHACHA20-POLY1305":        tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+	"ECDHE-RSA-CHACHA20-POLY1305":          tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+}
+
+// IntermediateCiphers is the Mozilla Intermediate cipher suite set.
+var IntermediateCiphers = []uint16{
+	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+	tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+}
+
+var tlsVersionMap = map[configv1.TLSProtocolVersion]uint16{
+	"VersionTLS10": tls.VersionTLS10,
+	"VersionTLS11": tls.VersionTLS11,
+	"VersionTLS12": tls.VersionTLS12,
+	"VersionTLS13": tls.VersionTLS13,
+}
+
+// Result holds the resolved TLS configuration.
+type Result struct {
+	TLSOpts []func(*tls.Config)
+}
+
+// Resolve reads the cluster TLS profile from apiservers.config.openshift.io/cluster
+// and returns TLS option functions for controller-runtime.
+// On non-OpenShift clusters or when the profile cannot be read, it returns
+// hardened Intermediate defaults. Returns an error only on unexpected failures
+// that should prevent startup (fail-closed).
+func Resolve(ctx context.Context, cfg *rest.Config) (Result, error) {
+	var result Result
+
+	scheme := runtime.NewScheme()
+	if err := configv1.Install(scheme); err != nil {
+		return result, fmt.Errorf("installing OpenShift config scheme: %w", err)
+	}
+
+	k8sClient, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		return result, fmt.Errorf("creating bootstrap client for TLS profile: %w", err)
+	}
+
+	// Use a bounded context to avoid blocking startup indefinitely if
+	// the API server is slow to respond.
+	fetchCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	apiServer := &configv1.APIServer{}
+	if err := k8sClient.Get(fetchCtx, client.ObjectKey{Name: "cluster"}, apiServer); err != nil {
+		switch {
+		case meta.IsNoMatchError(err):
+			log.Info("TLS profile not available, using hardened defaults (non-OpenShift cluster)")
+		case apierrors.IsNotFound(err):
+			log.Info("APIServer resource not found, using hardened defaults")
+		case apierrors.IsServiceUnavailable(err):
+			log.Info("API server unavailable, using hardened defaults", "error", err)
+		case apierrors.IsTimeout(err):
+			log.Info("API server request timed out, using hardened defaults", "error", err)
+		case apierrors.IsTooManyRequests(err):
+			log.Info("API server throttled request, using hardened defaults", "error", err)
+		default:
+			return result, fmt.Errorf("failed to read APIServer TLS profile: %w", err)
+		}
+		result.TLSOpts = append(result.TLSOpts, intermediateWithALPN)
+		return result, nil //nolint:nilerr // intentional fail-open: use hardened defaults for transient/expected errors
+	}
+
+	minVersion, ciphers := parseProfile(apiServer.Spec.TLSSecurityProfile)
+	if ciphers != nil && len(ciphers) == 0 {
+		return result, fmt.Errorf("custom TLS profile specified ciphers but none are supported by Go")
+	}
+
+	result.TLSOpts = append(result.TLSOpts, func(c *tls.Config) {
+		c.MinVersion = minVersion
+		if len(ciphers) > 0 {
+			c.CipherSuites = ciphers
+		}
+		c.NextProtos = []string{"h2", "http/1.1"}
+	})
+	return result, nil
+}
+
+func intermediateWithALPN(c *tls.Config) {
+	c.MinVersion = tls.VersionTLS12
+	c.CipherSuites = IntermediateCiphers
+	c.NextProtos = []string{"h2", "http/1.1"}
+}
+
+func parseProfile(profile *configv1.TLSSecurityProfile) (uint16, []uint16) {
+	if profile == nil {
+		return tls.VersionTLS12, IntermediateCiphers
+	}
+
+	switch profile.Type {
+	case configv1.TLSProfileIntermediateType, "":
+		return tls.VersionTLS12, IntermediateCiphers
+	case configv1.TLSProfileModernType:
+		return tls.VersionTLS13, nil
+	case configv1.TLSProfileOldType:
+		return tls.VersionTLS10, nil
+	case configv1.TLSProfileCustomType:
+		if profile.Custom == nil {
+			log.Info("Custom TLS profile type specified but custom block is nil, falling back to Intermediate")
+			return tls.VersionTLS12, IntermediateCiphers
+		}
+		return parseCustomProfile(profile.Custom)
+	default:
+		log.Info("Unknown TLS profile type, falling back to Intermediate", "type", profile.Type)
+		return tls.VersionTLS12, IntermediateCiphers
+	}
+}
+
+func parseCustomProfile(custom *configv1.CustomTLSProfile) (uint16, []uint16) {
+	minVersion, ok := tlsVersionMap[custom.MinTLSVersion]
+	if !ok {
+		log.Info("Unknown minTLSVersion in custom profile, defaulting to TLS 1.2", "minTLSVersion", custom.MinTLSVersion)
+		minVersion = tls.VersionTLS12
+	}
+
+	if len(custom.Ciphers) == 0 {
+		return minVersion, nil
+	}
+
+	ciphers := make([]uint16, 0, len(custom.Ciphers))
+	for _, name := range custom.Ciphers {
+		if id, ok := openSSLToGoCipher[name]; ok {
+			ciphers = append(ciphers, id)
+		} else {
+			log.Info("Dropping unsupported cipher from custom TLS profile", "cipher", name)
+		}
+	}
+	return minVersion, ciphers
+}

--- a/pkg/tls/tls_test.go
+++ b/pkg/tls/tls_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import (
+	"crypto/tls"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func TestParseProfile(t *testing.T) {
+	tests := []struct {
+		name           string
+		profile        *configv1.TLSSecurityProfile
+		wantMinVersion uint16
+		wantCiphers    []uint16
+	}{
+		{
+			name:           "nil profile returns Intermediate defaults",
+			profile:        nil,
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    IntermediateCiphers,
+		},
+		{
+			name:           "empty profile returns Intermediate defaults",
+			profile:        &configv1.TLSSecurityProfile{},
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    IntermediateCiphers,
+		},
+		{
+			name: "Intermediate type returns Intermediate defaults",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileIntermediateType,
+			},
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    IntermediateCiphers,
+		},
+		{
+			name: "Modern returns TLS 1.3 with nil ciphers",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			},
+			wantMinVersion: tls.VersionTLS13,
+			wantCiphers:    nil,
+		},
+		{
+			name: "Old returns TLS 1.0 with nil ciphers",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileOldType,
+			},
+			wantMinVersion: tls.VersionTLS10,
+			wantCiphers:    nil,
+		},
+		{
+			name: "Custom with valid ciphers",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: "VersionTLS12",
+						Ciphers: []string{
+							"ECDHE-ECDSA-AES128-GCM-SHA256",
+							"ECDHE-RSA-AES256-GCM-SHA384",
+						},
+					},
+				},
+			},
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers: []uint16{
+				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			},
+		},
+		{
+			name: "Custom with unsupported cipher skips it",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: "VersionTLS12",
+						Ciphers: []string{
+							"ECDHE-ECDSA-AES128-GCM-SHA256",
+							"UNSUPPORTED-CIPHER",
+						},
+					},
+				},
+			},
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers: []uint16{
+				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			},
+		},
+		{
+			name: "Custom with nil custom block falls back to Intermediate",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+			},
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    IntermediateCiphers,
+		},
+		{
+			name: "Unknown type falls back to Intermediate",
+			profile: &configv1.TLSSecurityProfile{
+				Type: "SuperSecure",
+			},
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    IntermediateCiphers,
+		},
+		{
+			name: "Custom with all unsupported ciphers returns empty slice",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: "VersionTLS12",
+						Ciphers: []string{
+							"DHE-RSA-AES128-GCM-SHA256",
+							"DHE-RSA-AES256-GCM-SHA384",
+						},
+					},
+				},
+			},
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    []uint16{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMinVersion, gotCiphers := parseProfile(tt.profile)
+
+			if gotMinVersion != tt.wantMinVersion {
+				t.Errorf("parseProfile() minVersion = %d, want %d", gotMinVersion, tt.wantMinVersion)
+			}
+
+			if tt.wantCiphers == nil {
+				if gotCiphers != nil {
+					t.Errorf("parseProfile() ciphers = %v, want nil", gotCiphers)
+				}
+				return
+			}
+
+			if gotCiphers == nil {
+				t.Fatal("expected non-nil empty slice, got nil (fail-closed guard needs non-nil)")
+			}
+			if len(gotCiphers) != len(tt.wantCiphers) {
+				t.Errorf("parseProfile() ciphers length = %d, want %d", len(gotCiphers), len(tt.wantCiphers))
+				return
+			}
+
+			for i, c := range gotCiphers {
+				if c != tt.wantCiphers[i] {
+					t.Errorf("parseProfile() ciphers[%d] = %d, want %d", i, c, tt.wantCiphers[i])
+				}
+			}
+		})
+	}
+}

--- a/policy/clusterrole.rego
+++ b/policy/clusterrole.rego
@@ -47,6 +47,9 @@ allowed_api_resources := {
 	["rbac.authorization.k8s.io", "roles"],
 	["rbac.authorization.k8s.io", "rolebindings"],
 
+	# --- openshift config ---
+	["config.openshift.io", "apiservers"],
+
 	# --- networking / routes ---
 	["gateway.networking.k8s.io", "gateways"],
 	["mcp.kuadrant.io", "mcpgatewayextensions"],

--- a/policy/rbac.rego
+++ b/policy/rbac.rego
@@ -17,8 +17,10 @@ expected_crbs := {
 	# --- rbac-base (all overlays) ---
 	"manager-auth-delegator": "system:auth-delegator",
 	"proxy-rolebinding": "proxy-role",
+	"tls-profile-reader-binding": "tls-profile-reader",
 	"trustyai-service-operator-manager-auth-delegator": "system:auth-delegator",
 	"trustyai-service-operator-proxy-rolebinding": "trustyai-service-operator-proxy-role",
+	"trustyai-service-operator-tls-profile-reader-binding": "trustyai-service-operator-tls-profile-reader",
 
 	# --- component: tas ---
 	"trustyai-service-operator-tas-manager-rolebinding": "trustyai-service-operator-tas-manager-role",


### PR DESCRIPTION
## Summary

- Read the cluster TLS profile from `apiservers.config.openshift.io/cluster` at startup
- TLS resolution code extracted into `pkg/tls/` for reusability and testability
- `pkg/tls.Resolve()` uses unstructured access (zero new dependencies, compatible with controller-runtime v0.17.0)
- Apply MinVersion, CipherSuites, and NextProtos to metrics server TLS config
- Fail closed on unexpected errors, use Intermediate defaults on non-OpenShift clusters
- Transient API errors (ServiceUnavailable, Timeout, TooManyRequests) fall back to Intermediate defaults instead of crashing
- 10s context timeout on APIServer fetch to avoid blocking startup indefinitely
- Add `config.openshift.io/apiservers` to OPA policy allowlist
- Add RBAC ClusterRole and ClusterRoleBinding for reading APIServer CR
- ClusterRoleBinding and ClusterRole registered in `config/rbac-base/kustomization.yaml`
- CRB added to OPA `policy/rbac.rego` allowlist (both prefixed and un-prefixed)

## Files changed

- `cmd/main.go`: Replaced inline TLS code with call to `pkgtls.Resolve()`
- `pkg/tls/tls.go`: Reusable TLS profile resolution (unstructured APIServer read, cipher mapping, Intermediate defaults, transient error handling, 10s timeout)
- `pkg/tls/tls_test.go`: Table-driven tests for all profile types
- `config/rbac-base/tls_profile_role.yaml`: RBAC ClusterRole for reading APIServer
- `config/rbac-base/tls_profile_role_binding.yaml`: RBAC ClusterRoleBinding for operator SA
- `config/rbac-base/kustomization.yaml`: Added TLS RBAC resources
- `policy/clusterrole.rego`: OPA allowlist update for `config.openshift.io/apiservers`
- `policy/rbac.rego`: OPA allowlist update for TLS CRB (prefixed + un-prefixed)
- `Dockerfile`: Added `COPY pkg/ pkg/` for container builds

## Test plan

- [x] Unit tests pass (`go test ./pkg/tls/... -v`)
- [x] Conftest RBAC policy passes
- [ ] Operator starts on OpenShift with Intermediate profile
- [ ] Operator starts on non-OpenShift with hardened defaults

Supersedes #774 (closed due to broken shallow clone force-push).

Ref: [RHOAIENG-61068](https://redhat.atlassian.net/browse/RHOAIENG-61068)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically resolves and applies TLS settings from the cluster’s security profile to both the metrics and webhook endpoints.
  * Added RBAC and policy updates to allow reading the cluster API server TLS profile.
* **Bug Fixes**
  * Improves startup reliability by falling back to hardened Intermediate TLS settings when the profile is temporarily unavailable.
  * Adds “fail-closed” behavior for unexpected TLS profile read failures.
* **Tests**
  * Added table-driven test coverage for TLS profile parsing, including custom/unsupported cipher handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->