### PR TITLE
chore(github): add bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,52 @@
+name: Bug report
+description: Something isn't working
+title: "fix: "
+labels: ["kind/fix", "status/triage"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: What did you expect, and what happened instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      options:
+        - Operator
+        - CRD / API
+        - Reconciliation
+        - Deployment / Kubernetes
+        - Configuration
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      placeholder: e.g. 1.0.0
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or errors
+      render: shell


### PR DESCRIPTION
## What and why

Adds a structured GitHub bug report issue template (`.github/ISSUE_TEMPLATE/bug_report.yml`) so that reporters are prompted for the information needed to triage and reproduce issues.

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [x] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

## Breaking changes

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new bug report issue template with guided fields for describing the problem, reproduction steps, affected component, version, and relevant logs.
  * Pre-fills issue details like title format and labels to make reporting faster and more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->