### PR TITLE
chore(repo): add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,32 @@
+# CODEOWNERS
+# Each line is a file pattern followed by one or more owners.
+# The last matching pattern takes precedence.
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Global fallback — core maintainers review everything not matched below
+* @ruivieira @RobGeada @ABeltramo
+
+# CI/CD and repository configuration
+/.github/ @ruivieira @RobGeada @ABeltramo
+/Makefile @ruivieira @RobGeada @ABeltramo
+/config/ @ruivieira @RobGeada @ABeltramo
+
+# TrustyAI Service (TAS)
+/controllers/tas/ @ruivieira @RobGeada @SudipSinha
+/api/tas/ @ruivieira @RobGeada @SudipSinha
+
+# LMEval
+/controllers/lmes/ @ruivieira
+/api/lmes/ @ruivieira
+
+# Guardrails Orchestrator
+/controllers/gorch/ @RobGeada @christinaexyou @m-misiura
+/api/gorch/ @RobGeada @christinaexyou @m-misiura
+
+# NeMo Guardrails
+/controllers/nemo_guardrails/ @RobGeada @m-misiura @christinaexyou
+/api/nemo_guardrails/ @RobGeada @m-misiura @christinaexyou
+
+# EvalHub
+/controllers/evalhub/ @ruivieira @julpayne
+/api/evalhub/ @ruivieira @julpayne


### PR DESCRIPTION
## What and why

Adds `.github/CODEOWNERS` to configure default reviewers per subsystem.

Note: CODEOWNERS assigns reviewers automatically when a PR is opened, it does **not** restrict who can approve. Approval requirements are governed separately by branch protection rules.
This file establishes sensible defaults so the right people are notified without any hard gate being introduced.

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [x] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

## Breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository ownership coverage to improve review routing and accountability.
  * Defined fallback ownership for unassigned files and set more specific ownership for key areas of the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->