### PR TITLE
chore(sync-providers): remove ragas exclusion from provider sync script

### DIFF
--- a/config/configmaps/evalhub/kustomization.yaml
+++ b/config/configmaps/evalhub/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - provider-ibm-clear.yaml
   - provider-lighteval.yaml
   - provider-lm-evaluation-harness.yaml
+  - provider-ragas.yaml
   - collection-coding-v1.yaml
   - collection-instruction-following-v1.yaml
   - collection-leaderboard-v2.yaml

--- a/config/configmaps/evalhub/provider-ragas.yaml
+++ b/config/configmaps/evalhub/provider-ragas.yaml
@@ -1,0 +1,70 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: evalhub-provider-ragas
+  labels:
+    trustyai.opendatahub.io/evalhub-provider-type: system
+    trustyai.opendatahub.io/evalhub-provider-name: ragas
+data:
+  ragas.yaml: |
+    id: ragas
+    name: RAGAS
+    title: RAGAS
+    description: >
+      Retrieval Augmented Generation Assessment — evaluates RAG pipeline quality
+      using metrics like faithfulness, answer relevancy, context precision/recall,
+      and more. Models are accessed via OpenAI-compatible endpoints.
+    runtime:
+      k8s:
+        image: $(evalhub-provider-ragas-image)
+        entrypoint:
+          - python
+          - main.py
+        cpu_request: 100m
+        memory_request: 128Mi
+        cpu_limit: 1000m
+        memory_limit: 2Gi
+      local:
+        command: python tests/features/test_data/runtime/main.py
+    benchmarks:
+      - id: ragas_rag_default
+        name: RAG Default Suite
+        description: Default RAG evaluation with answer relevancy, context precision, faithfulness, and context recall
+        category: rag_evaluation
+        metrics:
+          - answer_relevancy
+          - context_precision
+          - faithfulness
+          - context_recall
+        tags:
+          - ragas
+          - rag
+          - default
+        primary_score:
+          metric: faithfulness
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.5
+
+      - id: ragas_rag_full
+        name: RAG Full Suite
+        description: Comprehensive RAG evaluation with all available RAGAS metrics
+        category: rag_evaluation
+        metrics:
+          - answer_relevancy
+          - answer_similarity
+          - context_precision
+          - faithfulness
+          - context_recall
+          - context_entity_recall
+          - factual_correctness
+          - noise_sensitivity
+        tags:
+          - ragas
+          - rag
+          - comprehensive
+        primary_score:
+          metric: faithfulness
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.5

--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -22,3 +22,4 @@ nemo-guardrails-image=quay.io/trustyai/nemo-guardrails-server:latest
 evalhub-provider-guidellm-image=quay.io/evalhub/community-guidellm:v0.3.0
 evalhub-provider-lighteval-image=quay.io/evalhub/community-lighteval:v0.3.0
 evalhub-provider-ibm-clear-image=quay.io/evalhub/community-ibm-clear:v0.3.0
+evalhub-provider-ragas-image=quay.io/evalhub/community-ragas:latest

--- a/config/overlays/rhoai/params.env
+++ b/config/overlays/rhoai/params.env
@@ -22,3 +22,4 @@ nemo-guardrails-image=quay.io/trustyai/nemo-guardrails-server:latest
 evalhub-provider-guidellm-image=quay.io/evalhub/community-guidellm:v0.3.0
 evalhub-provider-lighteval-image=quay.io/evalhub/community-lighteval:v0.3.0
 evalhub-provider-ibm-clear-image=quay.io/evalhub/community-ibm-clear:v0.3.0
+evalhub-provider-ragas-image=quay.io/evalhub/community-ragas:latest

--- a/hack/sync-evalhub-providers.py
+++ b/hack/sync-evalhub-providers.py
@@ -29,9 +29,7 @@ COLLECTION_TYPE_LABEL = "trustyai.opendatahub.io/evalhub-collection-type"
 COLLECTION_NAME_LABEL = "trustyai.opendatahub.io/evalhub-collection-name"
 
 # Files to exclude from the upstream repository (by filename)
-EXCLUDE_FILES = {
-    "ragas.yaml",
-}
+EXCLUDE_FILES: set[str] = set()
 
 # Providers that reuse an existing kustomize image variable instead of
 # the default ``evalhub-provider-<id>-image`` naming convention.


### PR DESCRIPTION
## What and why

Remove `ragas.yaml` from the `EXCLUDE_FILES` set in `hack/sync-evalhub-providers.py` so the ragas provider is included when syncing upstream EvalHub provider ConfigMaps.

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [x] refactor / chore
- [ ] test / ci

## Testing

- [x] Tested manually: `python hack/sync-evalhub-providers.py` now generates a `provider-ragas.yaml` ConfigMap alongside the other providers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new Ragas evaluation provider.
  * Included benchmark suites with scoring and pass/fail thresholds.
  * Enabled the new provider image in supported deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->