### PR TITLE
fix(evalhub): detect pods stuck in Pending due to missing PVC and mark job as FAILED

### DIFF
--- a/controllers/evalhub/evaluation_job_failure_reconciler.go
+++ b/controllers/evalhub/evaluation_job_failure_reconciler.go
@@ -578,6 +578,8 @@ func (r *EvalHubEvaluationJobFailureReconciler) pendingSchedulingRequeueAfter(ct
 	if err := r.List(ctx, list, client.InNamespace(job.Namespace), client.MatchingLabels{
 		"batch.kubernetes.io/job-name": job.Name,
 	}); err != nil {
+		log.FromContext(ctx).Error(err, "pendingSchedulingRequeueAfter: failed to list pods",
+			append(failureWatcherLogFields(), "job", job.Name, "namespace", job.Namespace)...)
 		return 0
 	}
 	var earliest time.Duration

--- a/controllers/evalhub/evaluation_job_failure_reconciler.go
+++ b/controllers/evalhub/evaluation_job_failure_reconciler.go
@@ -332,6 +332,11 @@ func (r *EvalHubEvaluationJobFailureReconciler) Reconcile(ctx context.Context, r
 	if !failed {
 		log.Info("skip EvalHub POST: no operator-only container failure",
 			append(failureWatcherLogFields(), "action", "skip_no_operator_failure", "job", job.Name, "namespace", job.Namespace)...)
+		if requeue := r.pendingSchedulingRequeueAfter(ctx, &job); requeue > 0 {
+			log.Info("pod unschedulable within grace period — requeuing",
+				append(failureWatcherLogFields(), "action", "requeue_scheduling_grace", "job", job.Name, "namespace", job.Namespace, "requeueAfter", requeue)...)
+			return ctrl.Result{RequeueAfter: requeue}, nil
+		}
 		return ctrl.Result{}, nil
 	}
 	detailForLog := msg
@@ -524,6 +529,47 @@ func podSchedulingFailureMessage(pod *corev1.Pod) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+// schedulingGracePeriodRemaining returns the time left in the grace period for an Unschedulable pod,
+// or 0 if the pod is not pending/unschedulable or the grace period has already elapsed.
+func schedulingGracePeriodRemaining(pod *corev1.Pod) time.Duration {
+	if pod.Status.Phase != corev1.PodPending {
+		return 0
+	}
+	for _, c := range pod.Status.Conditions {
+		if c.Type == corev1.PodScheduled &&
+			c.Status == corev1.ConditionFalse &&
+			c.Reason == corev1.PodReasonUnschedulable &&
+			!c.LastTransitionTime.IsZero() {
+			elapsed := time.Since(c.LastTransitionTime.Time)
+			if elapsed < schedulingGracePeriod {
+				return schedulingGracePeriod - elapsed
+			}
+		}
+	}
+	return 0
+}
+
+// pendingSchedulingRequeueAfter returns the earliest requeue duration needed across all pods of the
+// job that are within the scheduling grace period, so the reconciler re-runs once the period expires.
+func (r *EvalHubEvaluationJobFailureReconciler) pendingSchedulingRequeueAfter(ctx context.Context, job *batchv1.Job) time.Duration {
+	list := &corev1.PodList{}
+	if err := r.List(ctx, list, client.InNamespace(job.Namespace), client.MatchingLabels{
+		"batch.kubernetes.io/job-name": job.Name,
+	}); err != nil {
+		return 0
+	}
+	var earliest time.Duration
+	for i := range list.Items {
+		pod := &list.Items[i]
+		if remaining := schedulingGracePeriodRemaining(pod); remaining > 0 {
+			if earliest == 0 || remaining < earliest {
+				earliest = remaining
+			}
+		}
+	}
+	return earliest
 }
 
 // podOperatorOnlyFailureMessage returns true when the eval-hub init, adapter, or sidecar is in a state

--- a/controllers/evalhub/evaluation_job_failure_reconciler.go
+++ b/controllers/evalhub/evaluation_job_failure_reconciler.go
@@ -498,15 +498,23 @@ func podIndicatesOperatorOnlyFailure(pod *corev1.Pod) bool {
 	return ok
 }
 
-// podSchedulingFailureMessage returns a non-empty message and true when the pod is stuck in Pending
-// because the scheduler could not place it (e.g. a referenced PVC does not exist).
-// The pod never starts, so no container callback to EvalHub is possible.
+// schedulingGracePeriod is how long a pod may remain Unschedulable before the operator treats it as
+// a terminal failure. This allows transient conditions (e.g. autoscaler node provisioning) to resolve
+// before EvalHub is notified. Permanent conditions (e.g. missing PVC) still fire after the period.
+const schedulingGracePeriod = 2 * time.Minute
+
+// podSchedulingFailureMessage returns a non-empty message and true when the pod has been stuck in
+// Pending/Unschedulable for longer than schedulingGracePeriod. The grace period prevents false
+// positives on autoscaling clusters where a node may take a minute or two to become available.
 func podSchedulingFailureMessage(pod *corev1.Pod) (string, bool) {
 	if pod.Status.Phase != corev1.PodPending {
 		return "", false
 	}
 	for _, c := range pod.Status.Conditions {
-		if c.Type == corev1.PodScheduled && c.Status == corev1.ConditionFalse && c.Reason == corev1.PodReasonUnschedulable {
+		if c.Type == corev1.PodScheduled &&
+			c.Status == corev1.ConditionFalse &&
+			c.Reason == corev1.PodReasonUnschedulable &&
+			time.Since(c.LastTransitionTime.Time) > schedulingGracePeriod {
 			msg := c.Message
 			if msg == "" {
 				msg = "pod unschedulable"

--- a/controllers/evalhub/evaluation_job_failure_reconciler.go
+++ b/controllers/evalhub/evaluation_job_failure_reconciler.go
@@ -541,11 +541,10 @@ func podSchedulingFailureMessage(pod *corev1.Pod) (string, bool) {
 			c.Reason == corev1.PodReasonUnschedulable &&
 			!c.LastTransitionTime.IsZero() &&
 			time.Since(c.LastTransitionTime.Time) > schedulingGracePeriod {
-			msg := c.Message
-			if msg == "" {
-				msg = "pod unschedulable"
+			if c.Message == "" {
+				return "pod unschedulable", true
 			}
-			return fmt.Sprintf("pod unschedulable: %s", msg), true
+			return fmt.Sprintf("pod unschedulable: %s", c.Message), true
 		}
 	}
 	return "", false

--- a/controllers/evalhub/evaluation_job_failure_reconciler.go
+++ b/controllers/evalhub/evaluation_job_failure_reconciler.go
@@ -498,9 +498,33 @@ func podIndicatesOperatorOnlyFailure(pod *corev1.Pod) bool {
 	return ok
 }
 
+// podSchedulingFailureMessage returns a non-empty message and true when the pod is stuck in Pending
+// because the scheduler could not place it (e.g. a referenced PVC does not exist).
+// The pod never starts, so no container callback to EvalHub is possible.
+func podSchedulingFailureMessage(pod *corev1.Pod) (string, bool) {
+	if pod.Status.Phase != corev1.PodPending {
+		return "", false
+	}
+	for _, c := range pod.Status.Conditions {
+		if c.Type == corev1.PodScheduled && c.Status == corev1.ConditionFalse && c.Reason == corev1.PodReasonUnschedulable {
+			msg := c.Message
+			if msg == "" {
+				msg = "pod unschedulable"
+			}
+			return fmt.Sprintf("pod unschedulable: %s", msg), true
+		}
+	}
+	return "", false
+}
+
 // podOperatorOnlyFailureMessage returns true when the eval-hub init, adapter, or sidecar is in a state
 // that typically means EvalHub was never notified (vs. adapter exiting after reporting failure).
+// Scheduling failures (pod stuck in Pending, e.g. missing PVC) are also detected here.
 func podOperatorOnlyFailureMessage(pod *corev1.Pod) (string, bool) {
+	// A pod that never scheduled cannot run any container and will never call EvalHub.
+	if msg, ok := podSchedulingFailureMessage(pod); ok {
+		return msg, true
+	}
 	for _, name := range []string{initContainerName, adapterContainerName, sidecarContainerName} {
 		if msg, ok := containerCannotReportToEvalHub(pod, name); ok {
 			return fmt.Sprintf("%s: %s", name, msg), true

--- a/controllers/evalhub/evaluation_job_failure_reconciler.go
+++ b/controllers/evalhub/evaluation_job_failure_reconciler.go
@@ -259,7 +259,8 @@ func podUpdatePredicate(r *EvalHubEvaluationJobFailureReconciler) predicate.Pred
 				return false
 			}
 			// Replay and rare creates where status already shows operator-only failure.
-			return podIndicatesOperatorOnlyFailure(newPod)
+			// Also pass through Unschedulable pods so the reconciler can schedule a requeue.
+			return podIndicatesOperatorOnlyFailure(newPod) || podIsUnschedulable(newPod)
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			oldPod, okOld := e.ObjectOld.(*corev1.Pod)
@@ -267,8 +268,10 @@ func podUpdatePredicate(r *EvalHubEvaluationJobFailureReconciler) predicate.Pred
 			if !okOld || !okNew || !podOwnedByJob(newPod) || !r.tenantNS.IsTenant(newPod.Namespace) {
 				return false
 			}
-			// Only enqueue when init/adapter/sidecar transition into a state that implies no EvalHub callback
-			return !podIndicatesOperatorOnlyFailure(oldPod) && podIndicatesOperatorOnlyFailure(newPod)
+			// Enqueue when transitioning into an operator-only failure state, or when a pod
+			// first becomes Unschedulable so the reconciler can schedule a grace-period requeue.
+			return (!podIndicatesOperatorOnlyFailure(oldPod) && podIndicatesOperatorOnlyFailure(newPod)) ||
+				(!podIsUnschedulable(oldPod) && podIsUnschedulable(newPod))
 		},
 		DeleteFunc:  func(event.DeleteEvent) bool { return false },
 		GenericFunc: func(event.GenericEvent) bool { return false },
@@ -501,6 +504,23 @@ func (r *EvalHubEvaluationJobFailureReconciler) operatorOnlyFailureFromPods(ctx 
 func podIndicatesOperatorOnlyFailure(pod *corev1.Pod) bool {
 	_, ok := podOperatorOnlyFailureMessage(pod)
 	return ok
+}
+
+// podIsUnschedulable returns true when the pod is Pending and has an Unschedulable condition,
+// regardless of whether the grace period has elapsed. Used by the predicate to let events through
+// so the reconciler can schedule its own requeue.
+func podIsUnschedulable(pod *corev1.Pod) bool {
+	if pod.Status.Phase != corev1.PodPending {
+		return false
+	}
+	for _, c := range pod.Status.Conditions {
+		if c.Type == corev1.PodScheduled &&
+			c.Status == corev1.ConditionFalse &&
+			c.Reason == corev1.PodReasonUnschedulable {
+			return true
+		}
+	}
+	return false
 }
 
 // schedulingGracePeriod is how long a pod may remain Unschedulable before the operator treats it as

--- a/controllers/evalhub/evaluation_job_failure_reconciler.go
+++ b/controllers/evalhub/evaluation_job_failure_reconciler.go
@@ -514,6 +514,7 @@ func podSchedulingFailureMessage(pod *corev1.Pod) (string, bool) {
 		if c.Type == corev1.PodScheduled &&
 			c.Status == corev1.ConditionFalse &&
 			c.Reason == corev1.PodReasonUnschedulable &&
+			!c.LastTransitionTime.IsZero() &&
 			time.Since(c.LastTransitionTime.Time) > schedulingGracePeriod {
 			msg := c.Message
 			if msg == "" {

--- a/controllers/evalhub/evaluation_job_failure_reconciler_test.go
+++ b/controllers/evalhub/evaluation_job_failure_reconciler_test.go
@@ -121,5 +121,95 @@ var _ = Describe("Evaluation job failure reconciler helpers", func() {
 			_, ok := podOperatorOnlyFailureMessage(pod)
 			Expect(ok).To(BeTrue(), "expected operator-only failure for sidecar CrashLoopBackOff")
 		})
+
+		It("reports pod unschedulable (e.g. missing PVC)", func() {
+			pod := &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					Conditions: []corev1.PodCondition{{
+						Type:    corev1.PodScheduled,
+						Status:  corev1.ConditionFalse,
+						Reason:  corev1.PodReasonUnschedulable,
+						Message: "0/3 nodes available: persistentvolumeclaim \"my-pvc\" not found",
+					}},
+				},
+			}
+			msg, ok := podOperatorOnlyFailureMessage(pod)
+			Expect(ok).To(BeTrue(), "expected operator-only failure for unschedulable pod")
+			Expect(msg).To(ContainSubstring("unschedulable"))
+			Expect(msg).To(ContainSubstring("my-pvc"))
+		})
+
+		It("does not report scheduled pod as unschedulable", func() {
+			pod := &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{{
+						Type:   corev1.PodScheduled,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			}
+			_, ok := podOperatorOnlyFailureMessage(pod)
+			Expect(ok).To(BeFalse(), "should not report a successfully scheduled running pod")
+		})
+
+		It("does not report pending pod without Unschedulable reason", func() {
+			pod := &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					Conditions: []corev1.PodCondition{{
+						Type:   corev1.PodScheduled,
+						Status: corev1.ConditionFalse,
+						Reason: "ContainersNotReady",
+					}},
+				},
+			}
+			_, ok := podOperatorOnlyFailureMessage(pod)
+			Expect(ok).To(BeFalse(), "should not report pending pod without Unschedulable reason")
+		})
+	})
+
+	Describe("podSchedulingFailureMessage", func() {
+		It("returns false for non-pending pod", func() {
+			pod := &corev1.Pod{
+				Status: corev1.PodStatus{Phase: corev1.PodRunning},
+			}
+			_, ok := podSchedulingFailureMessage(pod)
+			Expect(ok).To(BeFalse())
+		})
+
+		It("returns true with message for Unschedulable pending pod", func() {
+			pod := &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					Conditions: []corev1.PodCondition{{
+						Type:    corev1.PodScheduled,
+						Status:  corev1.ConditionFalse,
+						Reason:  corev1.PodReasonUnschedulable,
+						Message: "persistentvolumeclaim \"datasets-pvc\" not found",
+					}},
+				},
+			}
+			msg, ok := podSchedulingFailureMessage(pod)
+			Expect(ok).To(BeTrue())
+			Expect(msg).To(ContainSubstring("datasets-pvc"))
+		})
+
+		It("uses fallback message when condition message is empty", func() {
+			pod := &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					Conditions: []corev1.PodCondition{{
+						Type:   corev1.PodScheduled,
+						Status: corev1.ConditionFalse,
+						Reason: corev1.PodReasonUnschedulable,
+					}},
+				},
+			}
+			msg, ok := podSchedulingFailureMessage(pod)
+			Expect(ok).To(BeTrue())
+			Expect(msg).To(ContainSubstring("pod unschedulable"))
+		})
 	})
 })

--- a/controllers/evalhub/evaluation_job_failure_reconciler_test.go
+++ b/controllers/evalhub/evaluation_job_failure_reconciler_test.go
@@ -250,5 +250,21 @@ var _ = Describe("Evaluation job failure reconciler helpers", func() {
 			Expect(ok).To(BeTrue())
 			Expect(msg).To(ContainSubstring("pod unschedulable"))
 		})
+
+		It("does not fire when LastTransitionTime is zero", func() {
+			pod := &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					Conditions: []corev1.PodCondition{{
+						Type:   corev1.PodScheduled,
+						Status: corev1.ConditionFalse,
+						Reason: corev1.PodReasonUnschedulable,
+						// LastTransitionTime intentionally zero — treat as not yet eligible
+					}},
+				},
+			}
+			_, ok := podSchedulingFailureMessage(pod)
+			Expect(ok).To(BeFalse(), "zero LastTransitionTime should not be treated as past grace period")
+		})
 	})
 })

--- a/controllers/evalhub/evaluation_job_failure_reconciler_test.go
+++ b/controllers/evalhub/evaluation_job_failure_reconciler_test.go
@@ -8,6 +8,8 @@ you may not use this file except in compliance with the License.
 package evalhub
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -122,22 +124,40 @@ var _ = Describe("Evaluation job failure reconciler helpers", func() {
 			Expect(ok).To(BeTrue(), "expected operator-only failure for sidecar CrashLoopBackOff")
 		})
 
-		It("reports pod unschedulable (e.g. missing PVC)", func() {
+		It("reports pod unschedulable (e.g. missing PVC) after grace period", func() {
 			pod := &corev1.Pod{
 				Status: corev1.PodStatus{
 					Phase: corev1.PodPending,
 					Conditions: []corev1.PodCondition{{
-						Type:    corev1.PodScheduled,
-						Status:  corev1.ConditionFalse,
-						Reason:  corev1.PodReasonUnschedulable,
-						Message: "0/3 nodes available: persistentvolumeclaim \"my-pvc\" not found",
+						Type:               corev1.PodScheduled,
+						Status:             corev1.ConditionFalse,
+						Reason:             corev1.PodReasonUnschedulable,
+						Message:            "0/3 nodes available: persistentvolumeclaim \"my-pvc\" not found",
+						LastTransitionTime: metav1.NewTime(time.Now().Add(-3 * time.Minute)),
 					}},
 				},
 			}
 			msg, ok := podOperatorOnlyFailureMessage(pod)
-			Expect(ok).To(BeTrue(), "expected operator-only failure for unschedulable pod")
+			Expect(ok).To(BeTrue(), "expected operator-only failure for unschedulable pod past grace period")
 			Expect(msg).To(ContainSubstring("unschedulable"))
 			Expect(msg).To(ContainSubstring("my-pvc"))
+		})
+
+		It("does not report pod unschedulable within grace period (transient autoscaler condition)", func() {
+			pod := &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					Conditions: []corev1.PodCondition{{
+						Type:               corev1.PodScheduled,
+						Status:             corev1.ConditionFalse,
+						Reason:             corev1.PodReasonUnschedulable,
+						Message:            "0/3 nodes available: insufficient memory",
+						LastTransitionTime: metav1.NewTime(time.Now().Add(-30 * time.Second)),
+					}},
+				},
+			}
+			_, ok := podOperatorOnlyFailureMessage(pod)
+			Expect(ok).To(BeFalse(), "should not report unschedulable pod within grace period")
 		})
 
 		It("does not report scheduled pod as unschedulable", func() {
@@ -179,15 +199,16 @@ var _ = Describe("Evaluation job failure reconciler helpers", func() {
 			Expect(ok).To(BeFalse())
 		})
 
-		It("returns true with message for Unschedulable pending pod", func() {
+		It("returns true with message for Unschedulable pending pod past grace period", func() {
 			pod := &corev1.Pod{
 				Status: corev1.PodStatus{
 					Phase: corev1.PodPending,
 					Conditions: []corev1.PodCondition{{
-						Type:    corev1.PodScheduled,
-						Status:  corev1.ConditionFalse,
-						Reason:  corev1.PodReasonUnschedulable,
-						Message: "persistentvolumeclaim \"datasets-pvc\" not found",
+						Type:               corev1.PodScheduled,
+						Status:             corev1.ConditionFalse,
+						Reason:             corev1.PodReasonUnschedulable,
+						Message:            "persistentvolumeclaim \"datasets-pvc\" not found",
+						LastTransitionTime: metav1.NewTime(time.Now().Add(-3 * time.Minute)),
 					}},
 				},
 			}
@@ -196,14 +217,32 @@ var _ = Describe("Evaluation job failure reconciler helpers", func() {
 			Expect(msg).To(ContainSubstring("datasets-pvc"))
 		})
 
+		It("returns false for Unschedulable pod within grace period", func() {
+			pod := &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					Conditions: []corev1.PodCondition{{
+						Type:               corev1.PodScheduled,
+						Status:             corev1.ConditionFalse,
+						Reason:             corev1.PodReasonUnschedulable,
+						Message:            "insufficient memory",
+						LastTransitionTime: metav1.NewTime(time.Now().Add(-10 * time.Second)),
+					}},
+				},
+			}
+			_, ok := podSchedulingFailureMessage(pod)
+			Expect(ok).To(BeFalse(), "should not fire within grace period")
+		})
+
 		It("uses fallback message when condition message is empty", func() {
 			pod := &corev1.Pod{
 				Status: corev1.PodStatus{
 					Phase: corev1.PodPending,
 					Conditions: []corev1.PodCondition{{
-						Type:   corev1.PodScheduled,
-						Status: corev1.ConditionFalse,
-						Reason: corev1.PodReasonUnschedulable,
+						Type:               corev1.PodScheduled,
+						Status:             corev1.ConditionFalse,
+						Reason:             corev1.PodReasonUnschedulable,
+						LastTransitionTime: metav1.NewTime(time.Now().Add(-3 * time.Minute)),
 					}},
 				},
 			}

--- a/controllers/evalhub/evaluation_job_failure_reconciler_test.go
+++ b/controllers/evalhub/evaluation_job_failure_reconciler_test.go
@@ -267,4 +267,60 @@ var _ = Describe("Evaluation job failure reconciler helpers", func() {
 			Expect(ok).To(BeFalse(), "zero LastTransitionTime should not be treated as past grace period")
 		})
 	})
+
+	Describe("schedulingGracePeriodRemaining", func() {
+		It("returns remaining duration for pod within grace period", func() {
+			pod := &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					Conditions: []corev1.PodCondition{{
+						Type:               corev1.PodScheduled,
+						Status:             corev1.ConditionFalse,
+						Reason:             corev1.PodReasonUnschedulable,
+						LastTransitionTime: metav1.NewTime(time.Now().Add(-30 * time.Second)),
+					}},
+				},
+			}
+			remaining := schedulingGracePeriodRemaining(pod)
+			Expect(remaining).To(BeNumerically(">", 0), "should have remaining grace period")
+			Expect(remaining).To(BeNumerically("<=", schedulingGracePeriod))
+		})
+
+		It("returns 0 for pod past grace period", func() {
+			pod := &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					Conditions: []corev1.PodCondition{{
+						Type:               corev1.PodScheduled,
+						Status:             corev1.ConditionFalse,
+						Reason:             corev1.PodReasonUnschedulable,
+						LastTransitionTime: metav1.NewTime(time.Now().Add(-3 * time.Minute)),
+					}},
+				},
+			}
+			remaining := schedulingGracePeriodRemaining(pod)
+			Expect(remaining).To(Equal(time.Duration(0)))
+		})
+
+		It("returns 0 for non-pending pod", func() {
+			pod := &corev1.Pod{
+				Status: corev1.PodStatus{Phase: corev1.PodRunning},
+			}
+			Expect(schedulingGracePeriodRemaining(pod)).To(Equal(time.Duration(0)))
+		})
+
+		It("returns 0 when LastTransitionTime is zero", func() {
+			pod := &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					Conditions: []corev1.PodCondition{{
+						Type:   corev1.PodScheduled,
+						Status: corev1.ConditionFalse,
+						Reason: corev1.PodReasonUnschedulable,
+					}},
+				},
+			}
+			Expect(schedulingGracePeriodRemaining(pod)).To(Equal(time.Duration(0)))
+		})
+	})
 })


### PR DESCRIPTION
When an eval job references a PVC that doesn't exist, the Kubernetes scheduler sets `PodScheduled=False/Unschedulable` on the pod but never starts it. Because no container runs, the adapter cannot POST a failure event back to EvalHub, the job stays in a running state with no user-visible error.
The existing `jobStatusIndicatesTerminalFailure()` check requires Active=0, Failed>0 on the Job. A pod stuck in Pending keeps Active=1, Failed=0, so that path never fires. This PR extends the pod predicate path instead.

Testing:
1. created an evaluation job with non-existing pvc:

```
{
  "resource": {
    "id": "d33ae87a-a8ae-47d4-8fd7-0acf2323cc2d",
    "tenant": "tenant",
    "created_at": "2026-07-13T10:50:49.64252227Z",
    "owner": "system:serviceaccount:tenant:tenant-user",
    "mlflow_experiment_id": "1"
  },
  "status": {
    "state": "pending",
    "message": {
      "message": "Evaluation job created",
      "message_code": "evaluation_job_created"
    }
  },
  "results": {
    "mlflow_experiment_url": "https://mlflow.opendatahub.svc.cluster.local:8443/api/2.0/mlflow/experiments"
  },
  "name": "model api key/cert test",
  "model": {
    "url": "https://vllm-llama-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1",
    "name": "meta-llama/Llama-3.2-1B-Instruct",
    "auth": {
      "secret_ref": "vllm-api-key"
    }
  },
  "benchmarks": [
    {
      "id": "arc_easy",
      "provider_id": "lm_evaluation_harness",
      "parameters": {
        "limit": 5
      },
      "test_data_ref": {
        "pvc": {
          "claim_name": "my-test-storage-pvc-in-prabhu-ns"
        }
      }
    }
  ],
  "experiment": {
    "name": "exp12"
  }
}
```

2. Logs show that job is marked as FAILED after about 2min as expected

```
2026-07-13T10:50:49Z	INFO	pod unschedulable within grace period — requeuing	{"controller": "evalhub-evaluation-job-failure", "controllerGroup": "batch", "controllerKind": "Job", "Job": {"name":"d33ae87a-a8ae-47d4-8fd7-0a-56b6bf13-7973-460e-8fae-4a16cd5e4d98","namespace":"tenant"}, "namespace": "tenant", "name": "d33ae87a-a8ae-47d4-8fd7-0a-56b6bf13-7973-460e-8fae-4a16cd5e4d98", "reconcileID": "3d041298-2edf-4487-9e51-25931c9a7ff7", "evalhub_watcher": "failure_sync", "controller": "evalhub-evaluation-job-failure", "action": "requeue_scheduling_grace", "job": "d33ae87a-a8ae-47d4-8fd7-0a-56b6bf13-7973-460e-8fae-4a16cd5e4d98", "namespace": "tenant", "requeueAfter": "1m59.243314458s"}
2026-07-13T10:52:49Z	INFO	reconcile start	{"controller": "evalhub-evaluation-job-failure", "controllerGroup": "batch", "controllerKind": "Job", "Job": {"name":"d33ae87a-a8ae-47d4-8fd7-0a-56b6bf13-7973-460e-8fae-4a16cd5e4d98","namespace":"tenant"}, "namespace": "tenant", "name": "d33ae87a-a8ae-47d4-8fd7-0a-56b6bf13-7973-460e-8fae-4a16cd5e4d98", "reconcileID": "217977fb-1fdf-42dd-a8ac-b6424a527353", "evalhub_watcher": "failure_sync", "controller": "evalhub-evaluation-job-failure", "action": "reconcile", "namespace": "tenant", "name": "d33ae87a-a8ae-47d4-8fd7-0a-56b6bf13-7973-460e-8fae-4a16cd5e4d98"}

2026-07-13T10:52:49Z	INFO	operator-only failure detected	{"controller": "evalhub-evaluation-job-failure", "controllerGroup": "batch", "controllerKind": "Job", "Job": {"name":"d33ae87a-a8ae-47d4-8fd7-0a-56b6bf13-7973-460e-8fae-4a16cd5e4d98","namespace":"tenant"}, "namespace": "tenant", "name": "d33ae87a-a8ae-47d4-8fd7-0a-56b6bf13-7973-460e-8fae-4a16cd5e4d98", "reconcileID": "217977fb-1fdf-42dd-a8ac-b6424a527353", "evalhub_watcher": "failure_sync", "controller": "evalhub-evaluation-job-failure", "action": "failure_detected", "job": "d33ae87a-a8ae-47d4-8fd7-0a-56b6bf13-7973-460e-8fae-4a16cd5e4d98", "namespace": "tenant", "detail": "pod d33ae87a-a8ae-47d4-8fd7-0a-56b6bf13-7973-460e-8fae-4a16cd5lbc9n: pod unschedulable: 0/1 nodes are available: persistentvolumeclaim \"my-test-storage-pvc-in-prabhu-ns\" not found. preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling."}
2026-07-13T10:52:49Z	INFO	deleted evaluation job after EvalHub failure sync	{"controller": "evalhub-evaluation-job-failure", "controllerGroup": "batch", "controllerKind": "Job", "Job": {"name":"d33ae87a-a8ae-47d4-8fd7-0a-56b6bf13-7973-460e-8fae-4a16cd5e4d98","namespace":"tenant"}, "namespace": "tenant", "name": "d33ae87a-a8ae-47d4-8fd7-0a-56b6bf13-7973-460e-8fae-4a16cd5e4d98", "reconcileID": "217977fb-1fdf-42dd-a8ac-b6424a527353", "evalhub_watcher": "failure_sync", "controller": "evalhub-evaluation-job-failure", "action": "delete_job_ok", "job": "d33ae87a-a8ae-47d4-8fd7-0a-56b6bf13-7973-460e-8fae-4a16cd5e4d98", "namespace": "tenant"}
2026-07-13T10:52:49Z	INFO	posted EvalHub benchmark failure event	{"controller": "evalhub-evaluation-job-failure", "controllerGroup": "batch", "controllerKind": "Job", "Job": {"name":"d33ae87a-a8ae-47d4-8fd7-0a-56b6bf13-7973-460e-8fae-4a16cd5e4d98","namespace":"tenant"}, "namespace": "tenant", "name": "d33ae87a-a8ae-47d4-8fd7-0a-56b6bf13-7973-460e-8fae-4a16cd5e4d98", "reconcileID": "217977fb-1fdf-42dd-a8ac-b6424a527353", "evalhub_watcher": "failure_sync", "controller": "evalhub-evaluation-job-failure", "action": "post_events_ok", "evalJobID": "d33ae87a-a8ae-47d4-8fd7-0acf2323cc2d", "k8sJob": "d33ae87a-a8ae-47d4-8fd7-0a-56b6bf13-7973-460e-8fae-4a16cd5e4d98", "namespace": "tenant"}

```

3. Job is updated to FAILED:
```
{
  "resource": {
    "id": "d33ae87a-a8ae-47d4-8fd7-0acf2323cc2d",
    "tenant": "tenant",
    "created_at": "2026-07-13T10:50:49.642618Z",
    "updated_at": "2026-07-13T10:52:49.048111Z",
    "owner": "system:serviceaccount:tenant:tenant-user",
    "mlflow_experiment_id": "1"
  },
  "status": {
    "state": "failed",
    "message": {
      "message": "Evaluation job is failed. \nBenchmark arc_easy failed with message: pod d33ae87a-a8ae-47d4-8fd7-0a-56b6bf13-7973-460e-8fae-4a16cd5lbc9n: pod unschedulable: 0/1 nodes are available: persistentvolumeclaim \"my-test-storage-pvc-in-prabhu-ns\" not found. preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling.\n",
      "message_code": "evaluation_job_updated"
    },
    "benchmarks": [
      {
        "provider_id": "lm_evaluation_harness",
        "id": "arc_easy",
        "benchmark_index": 0,
        "status": "failed",
        "error_message": {
          "message": "pod d33ae87a-a8ae-47d4-8fd7-0a-56b6bf13-7973-460e-8fae-4a16cd5lbc9n: pod unschedulable: 0/1 nodes are available: persistentvolumeclaim \"my-test-storage-pvc-in-prabhu-ns\" not found. preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling.",
          "message_code": "RUNTIME_FAILURE"
        }
      }
    ]
  },
  "results": {
    "benchmarks": [
      {
        "id": "arc_easy",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 0
      }
    ],
    "mlflow_experiment_url": "https://mlflow.opendatahub.svc.cluster.local:8443/api/2.0/mlflow/experiments"
  },
  "name": "model api key/cert test",
  "model": {
    "url": "https://vllm-llama-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1",
    "name": "meta-llama/Llama-3.2-1B-Instruct",
    "auth": {
      "secret_ref": "vllm-api-key"
    }
  },
  "benchmarks": [
    {
      "id": "arc_easy",
      "provider_id": "lm_evaluation_harness",
      "parameters": {
        "limit": 5
      },
      "test_data_ref": {
        "pvc": {
          "claim_name": "my-test-storage-pvc-in-prabhu-ns"
        }
      }
    }
  ],
  "experiment": {
    "name": "exp12"
  }
}

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling for pods stuck `Pending` with `PodScheduled=False`/`Unschedulable` by introducing a configurable scheduling grace period and adjusting requeue decisions until the grace window expires.
  * Refined operator-only failure detection and messaging for unschedulable pending pods, including PVC context when available and a fallback message when details are missing.

* **Tests**
  * Expanded unit tests to validate grace-period timing behavior, operator-only detection rules, and scheduling helper edge cases (including missing or zero transition times).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->