### PR TITLE
fix(rbac,lmes): correct TLS profile role binding subject and harden device detection test

### DIFF
--- a/config/rbac-base/tls_profile_role_binding.yaml
+++ b/config/rbac-base/tls_profile_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: tls-profile-reader
 subjects:
   - kind: ServiceAccount
-    name: trustyai-service-operator
+    name: controller-manager
     namespace: system

--- a/controllers/lmes/driver/driver_test.go
+++ b/controllers/lmes/driver/driver_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
@@ -217,6 +218,10 @@ func Test_MultipleProgressUpdate(t *testing.T) {
 }
 
 func Test_DetectDeviceError(t *testing.T) {
+	if err := exec.Command("python", "-c", "import torch").Run(); err == nil {
+		t.Skip("torch is available; device detection would succeed, skipping error-path test")
+	}
+
 	info := setupTest(t, false)
 	defer info.tearDown(t)
 
@@ -232,9 +237,8 @@ func Test_DetectDeviceError(t *testing.T) {
 	assert.Nil(t, err)
 
 	msgs, _ := runDriverAndWait4Complete(t, driver, true)
-	assert.Equal(t, []string{
-		"failed to detect available device(s): exit status 1",
-	}, msgs)
+	assert.Len(t, msgs, 1)
+	assert.Contains(t, msgs[0], "failed to detect available device(s):")
 
 	assert.Nil(t, driver.Shutdown())
 


### PR DESCRIPTION
## What and why

Two unrelated fixes bundled together:

1. **RBAC**: The `tls-profile-reader` RoleBinding referenced `trustyai-service-operator` as the ServiceAccount subject, but the actual manager ServiceAccount is named `controller-manager`. This mismatch prevented the operator from reading TLS profile resources at runtime.

2. **LMES driver test**: `Test_DetectDeviceError` assumed `torch` was never installed in the test environment, causing it to fail on machines where PyTorch is present (the device detection would succeed, making the error-path assertion incorrect). The fix skips the test when `torch` is available, and relaxes the message assertion to use `Contains` rather than `Equal` so minor variations in the error string don't break the test.

## Type

- [x] fix
- [ ] feat
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [ ] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated TLS profile access permissions to use the correct controller service account, improving reliable certificate profile handling.

- **Tests**
  - Improved device-detection error testing across environments by skipping the test when hardware support is available and using more resilient error-message validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->