### PR TITLE
fix(evalhub): grant pods/log get permission to manager ClusterRole

### DIFF
--- a/config/components/evalhub/rbac/manager-rbac.yaml
+++ b/config/components/evalhub/rbac/manager-rbac.yaml
@@ -5,61 +5,6 @@ metadata:
   name: evalhub-manager-role
 rules:
 - apiGroups:
-  - kueue.x-k8s.io
-  resources:
-  - workloads
-  verbs:
-  - get
-  - list
-  - watch
-  - patch
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  verbs:
-  - get
-- apiGroups:
-  - trustyai.opendatahub.io
-  resources:
-  - evalhubs
-  verbs:
-  - get
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  verbs:
-  - get
-  - list
-  - watch
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - trustyai.opendatahub.io
-  resources:
-  - evalhubs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - trustyai.opendatahub.io
   resources:
   - evalhubs
@@ -282,3 +227,64 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - workloads
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+- apiGroups:
+  - trustyai.opendatahub.io
+  resources:
+  - evalhubs
+  verbs:
+  - get
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
+  - trustyai.opendatahub.io
+  resources:
+  - evalhubs
+  verbs:
+  - get
+  - list
+  - watch

--- a/controllers/evalhub/evaluation_job_failure_reconciler.go
+++ b/controllers/evalhub/evaluation_job_failure_reconciler.go
@@ -88,6 +88,7 @@ func failureWatcherLogFields() []any {
 //+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;patch;delete
 //+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=pods/log,verbs=get
 //+kubebuilder:rbac:groups=trustyai.opendatahub.io,resources=evalhubs,verbs=get;list;watch
 
 // EvalHubEvaluationJobFailureReconciler POSTs a failed benchmark event to EvalHub when init, adapter,

--- a/policy/clusterrole.rego
+++ b/policy/clusterrole.rego
@@ -16,6 +16,7 @@ allowed_api_resources := {
 	["", "persistentvolumes"],
 	["", "pods"],
 	["", "pods/exec"],
+	["", "pods/log"],
 	["", "secrets"],
 	["", "serviceaccounts"],
 	["", "services"],


### PR DESCRIPTION
## Summary

The EvalHub reconciler creates a per-instance namespaced `Role` that grants `pods/log: get` to the EvalHub service account. This was failing with:

> roles.rbac.authorization.k8s.io "…-service-pod-logs-role" is forbidden:
> user "system:serviceaccount:opendatahub:trustyai-service-operator-controller-manager"
> is attempting to grant RBAC permissions not currently held: {pods/log get}

Kubernetes prevents privilege escalation: an actor cannot grant permissions it does not itself hold. The operator's `evalhub-manager-role` ClusterRole was missing `pods/log: get`.

**Fix:** added `//+kubebuilder:rbac:groups="",resources=pods/log,verbs=get` to `evaluation_job_failure_reconciler.go` and regenerated `config/components/evalhub/rbac/manager-rbac.yaml` via `controller-gen` + `hack/generate-components.sh`.

## Testing

- [ ] Deploy operator with updated manifests; create an `EvalHub` CR and confirm it reaches `Ready` without the RBAC error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved permissions for evaluation job management and monitoring.
  - Added access to pod logs to support troubleshooting failed evaluation jobs.
  - Ensured required resources, including workloads, jobs, namespaces, pods, and evaluation hubs, can be viewed or managed as intended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->