### PR TITLE
feat: integrate with cluster TLS security profile

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -151,7 +151,8 @@ func main() {
 
 	if slices.Contains(enabledServices, serviceEvalHub) {
 		mgrOpts.WebhookServer = ctrlwebhook.NewServer(ctrlwebhook.Options{
-			Port: 9443,
+			Port:    9443,
+			TLSOpts: tlsOpts,
 		})
 	}
 

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -19,6 +19,7 @@ package tls
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"time"
 
@@ -102,10 +103,12 @@ func Resolve(ctx context.Context, cfg *rest.Config) (Result, error) {
 			log.Info("APIServer resource not found, using hardened defaults")
 		case apierrors.IsServiceUnavailable(err):
 			log.Info("API server unavailable, using hardened defaults", "error", err)
-		case apierrors.IsTimeout(err):
+		case apierrors.IsTimeout(err), apierrors.IsServerTimeout(err):
 			log.Info("API server request timed out, using hardened defaults", "error", err)
 		case apierrors.IsTooManyRequests(err):
 			log.Info("API server throttled request, using hardened defaults", "error", err)
+		case errors.Is(err, context.DeadlineExceeded):
+			log.Info("API server request deadline exceeded, using hardened defaults", "error", err)
 		default:
 			return result, fmt.Errorf("failed to read APIServer TLS profile: %w", err)
 		}


### PR DESCRIPTION
## Summary

- Integrates with the OpenShift cluster TLS security profile (`tls.openshift.io/v1alpha1`) to configure TLS settings for the operator's metrics and webhook servers
- Adds transient error handling for TLS profile resolution: gracefully falls back to hardened defaults (TLS 1.2 minimum) when the API server is temporarily unavailable (`ServiceUnavailable`, `Timeout`, `TooManyRequests`, `context.DeadlineExceeded`)
- Fixes the EvalHub webhook server override to include TLSOpts, ensuring consistent TLS enforcement regardless of which code path creates the webhook server

## Test plan

- [ ] Verify operator starts correctly on a cluster with a TLS security profile configured
- [ ] Verify operator starts correctly on a cluster without TLS security profile (falls back to TLS 1.2 defaults)
- [ ] Verify EvalHub webhook server uses the TLS profile when EvalHub is enabled
- [ ] Verify metrics server uses the TLS profile
- [ ] Verify transient API errors during TLS profile fetch result in graceful fallback, not crash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added automatic TLS profile detection for supported OpenShift environments.
  * Applies secure minimum TLS versions, cipher suites, and HTTP protocols to webhook services.
  * Uses hardened TLS defaults when the platform profile is unavailable or still initializing.
  * Prevents startup when an unexpected TLS configuration error occurs.
* **Bug Fixes**
  * Ensured the EvalHub webhook server uses the resolved TLS settings in addition to its configured port.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->