### PR TITLE
fix(evalhub): grant evalhubs CR read access to single-tenancy roles

### DIFF
--- a/controllers/evalhub/tenant_roles.go
+++ b/controllers/evalhub/tenant_roles.go
@@ -134,6 +134,11 @@ func tenantAdminRules(instance *evalhubv1.EvalHub) []rbacv1.PolicyRule {
 	return []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{"trustyai.opendatahub.io"},
+			Resources: []string{"evalhubs"},
+			Verbs:     []string{"get", "list"},
+		},
+		{
+			APIGroups: []string{"trustyai.opendatahub.io"},
 			Resources: []string{"evaluations", "collections", "providers", "status-events"},
 			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
 		},
@@ -155,6 +160,11 @@ func tenantAdminRules(instance *evalhubv1.EvalHub) []rbacv1.PolicyRule {
 // Read on collections/providers, submit evaluations, read MLflow experiments.
 func tenantUserRules(instance *evalhubv1.EvalHub) []rbacv1.PolicyRule {
 	return []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{"trustyai.opendatahub.io"},
+			Resources: []string{"evalhubs"},
+			Verbs:     []string{"get", "list"},
+		},
 		{
 			APIGroups: []string{"trustyai.opendatahub.io"},
 			Resources: []string{"collections", "providers"},

--- a/controllers/evalhub/tenant_roles_test.go
+++ b/controllers/evalhub/tenant_roles_test.go
@@ -55,10 +55,40 @@ func TestReconcileSingleTenancyRoles_SingleMode(t *testing.T) {
 		assert.NotEmpty(t, role.Rules)
 	})
 
+	t.Run("admin Role grants evalhubs read for CR discovery", func(t *testing.T) {
+		role := &rbacv1.Role{}
+		require.NoError(t, fc.Get(ctx, types.NamespacedName{Name: tenantAdminRoleName, Namespace: "team-a"}, role))
+		found := false
+		for _, rule := range role.Rules {
+			if len(rule.Resources) == 1 && rule.Resources[0] == "evalhubs" {
+				assert.Contains(t, rule.Verbs, "get")
+				assert.Contains(t, rule.Verbs, "list")
+				assert.Empty(t, rule.ResourceNames, "must not scope by resourceNames so list works")
+				found = true
+			}
+		}
+		assert.True(t, found, "admin Role must include an evalhubs rule for BFF discovery")
+	})
+
 	t.Run("creates user Role", func(t *testing.T) {
 		role := &rbacv1.Role{}
 		require.NoError(t, fc.Get(ctx, types.NamespacedName{Name: tenantUserRoleName, Namespace: "team-a"}, role))
 		assert.NotEmpty(t, role.Rules)
+	})
+
+	t.Run("user Role grants evalhubs read for CR discovery", func(t *testing.T) {
+		role := &rbacv1.Role{}
+		require.NoError(t, fc.Get(ctx, types.NamespacedName{Name: tenantUserRoleName, Namespace: "team-a"}, role))
+		found := false
+		for _, rule := range role.Rules {
+			if len(rule.Resources) == 1 && rule.Resources[0] == "evalhubs" {
+				assert.Contains(t, rule.Verbs, "get")
+				assert.Contains(t, rule.Verbs, "list")
+				assert.Empty(t, rule.ResourceNames, "must not scope by resourceNames so list works")
+				found = true
+			}
+		}
+		assert.True(t, found, "user Role must include an evalhubs rule for BFF discovery")
 	})
 
 	t.Run("creates admin RoleBinding", func(t *testing.T) {


### PR DESCRIPTION
## What and why

The BFF cannot discover the EvalHub service URL in single-tenancy mode using the user's token. In multi-tenancy, the operator creates an `evalhub-discovery` ConfigMap in each tenant namespace, but in single-tenancy no such ConfigMap exists: the alternative is reading `Status.URL` from the EvalHub CR directly. Neither `evalhub-user` nor `evalhub-tenant-admin` Roles grant `get` or `list` on the `evalhubs` resource, so the CR lookup fails with a 403.

This adds a read-only (`get`, `list`) rule for `evalhubs` to both single-tenancy convenience Roles. The permission is namespace-scoped (Role, not ClusterRole) and only created when `spec.tenancy: single`.

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [ ] Tested manually

## Breaking changes

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tenant administrators and users can now discover EvalHub resources by listing or viewing them within their namespace.

* **Bug Fixes**
  * Updated access permissions so required EvalHub resources are visible in single-tenant environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->