### PR TITLE
fix(operator): guard webhook registration behind TAS service check

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -60,7 +60,10 @@ import (
 	//+kubebuilder:scaffold:imports
 )
 
-const serviceEvalHub = "EVALHUB"
+const (
+	serviceEvalHub = "EVALHUB"
+	serviceTAS     = "TAS"
+)
 
 var (
 	scheme   = runtime.NewScheme()
@@ -142,16 +145,17 @@ func main() {
 				},
 			},
 		},
-		WebhookServer: ctrlwebhook.NewServer(ctrlwebhook.Options{
-			Port:    9443,
-			TLSOpts: tlsOpts,
-		}),
 		// LeaderElectionReleaseOnCancel: true,
 	}
 
 	if slices.Contains(enabledServices, serviceEvalHub) {
 		mgrOpts.WebhookServer = ctrlwebhook.NewServer(ctrlwebhook.Options{
 			Port: 9443,
+		})
+	} else if slices.Contains(enabledServices, serviceTAS) {
+		mgrOpts.WebhookServer = ctrlwebhook.NewServer(ctrlwebhook.Options{
+			Port:    9443,
+			TLSOpts: tlsOpts,
 		})
 	}
 
@@ -168,9 +172,11 @@ func main() {
 		}
 	}
 
-	if err := ctrl.NewWebhookManagedBy(mgr).For(&tasv1.TrustyAIService{}).Complete(); err != nil {
-		setupLog.Error(err, "unable to create TrustyAIService conversion webhook")
-		os.Exit(1)
+	if slices.Contains(enabledServices, serviceTAS) {
+		if err := ctrl.NewWebhookManagedBy(mgr).For(&tasv1.TrustyAIService{}).Complete(); err != nil {
+			setupLog.Error(err, "unable to create TrustyAIService conversion webhook")
+			os.Exit(1)
+		}
 	}
 
 	recorder := mgr.GetEventRecorderFor("trustyai-service-operator")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -148,11 +148,7 @@ func main() {
 		// LeaderElectionReleaseOnCancel: true,
 	}
 
-	if slices.Contains(enabledServices, serviceEvalHub) {
-		mgrOpts.WebhookServer = ctrlwebhook.NewServer(ctrlwebhook.Options{
-			Port: 9443,
-		})
-	} else if slices.Contains(enabledServices, serviceTAS) {
+	if slices.Contains(enabledServices, serviceEvalHub) || slices.Contains(enabledServices, serviceTAS) {
 		mgrOpts.WebhookServer = ctrlwebhook.NewServer(ctrlwebhook.Options{
 			Port:    9443,
 			TLSOpts: tlsOpts,


### PR DESCRIPTION
## What and why

Fixes a regression introduced in 4384502 where the `TrustyAIService` conversion webhook was registered unconditionally in `cmd/main.go`, outside the `EVALHUB` guard. This caused the operator to crash in `mcp-guardrails` mode (which only enables `NEMO_GUARDRAILS`) because the webhook server was never properly set up for that mode and no TLS certs are injected in that overlay.

Two changes:

- The webhook server is now only started when `TAS` (with TLS) or `EVALHUB` (without TLS) is in `--enable-services`; modes like `mcp-guardrails` no longer start a webhook server at all.
- The `TrustyAIService` conversion webhook registration is guarded behind `slices.Contains(enabledServices, serviceTAS)`, mirroring the existing `EvalHub` guard pattern.

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tested manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook server configuration so TLS is consistently applied when the relevant service is enabled.
  * Prevented the TrustyAI conversion webhook from being created when the TAS service is disabled.
  * Kept EvalHub webhook creation tied to its corresponding service being enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->