### PR TITLE
fix: SAR record and role update for EH health API

### DIFF
--- a/controllers/evalhub/configmap.go
+++ b/controllers/evalhub/configmap.go
@@ -323,6 +323,18 @@ func validateOTELDuration(fieldName, value string) error {
 func generateAuthConfigData() string {
 	return `authorization:
   endpoints:
+    - path: /api/v1/health
+      mappings:
+        - methods: [get]
+          resources:
+            - rewrites:
+                byHttpHeader:
+                  name: X-Tenant
+              resourceAttributes:
+                namespace: "{{.FromHeader}}"
+                apiGroup: trustyai.opendatahub.io
+                resource: health
+                verb: get
     - path: /api/v1/evaluations/jobs/*/events
       mappings:
         - methods: [post]

--- a/controllers/evalhub/tenant_roles.go
+++ b/controllers/evalhub/tenant_roles.go
@@ -139,6 +139,11 @@ func tenantAdminRules(instance *evalhubv1.EvalHub) []rbacv1.PolicyRule {
 		},
 		{
 			APIGroups: []string{"trustyai.opendatahub.io"},
+			Resources: []string{"health"},
+			Verbs:     []string{"get"},
+		},
+		{
+			APIGroups: []string{"trustyai.opendatahub.io"},
 			Resources: []string{"evaluations", "collections", "providers", "status-events"},
 			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
 		},
@@ -164,6 +169,11 @@ func tenantUserRules(instance *evalhubv1.EvalHub) []rbacv1.PolicyRule {
 			APIGroups: []string{"trustyai.opendatahub.io"},
 			Resources: []string{"evalhubs"},
 			Verbs:     []string{"get", "list"},
+		},
+		{
+			APIGroups: []string{"trustyai.opendatahub.io"},
+			Resources: []string{"health"},
+			Verbs:     []string{"get"},
 		},
 		{
 			APIGroups: []string{"trustyai.opendatahub.io"},


### PR DESCRIPTION
`/api/v1/health` calls are expected to be authenticated now, but we were missing the SAR record and permission on tenant role. This PR handles them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added health endpoint authorization using tenant-scoped access controls.
  * Updated tenant administrator and tenant user permissions to allow health status checks.

* **Bug Fixes**
  * Improved access to the service health endpoint for authorized tenant users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->