### PR TITLE
fix(evalhub): update health probe endpoint to /api/v1/health

### DIFF
--- a/controllers/evalhub/constants.go
+++ b/controllers/evalhub/constants.go
@@ -14,11 +14,10 @@ const (
 	// evalHubAppPort is the eval-hub container listen port on loopback (API_HOST=127.0.0.1, PORT in deployment env).
 	// kube-rbac-proxy upstream is http://127.0.0.1:<evalHubAppPort>/ on the pod network (TLS is terminated on servicePort).
 	evalHubAppPort = 8444
-	// evalHubHealthPath is the application health check path exposed via the Route (SAR-protected by kube-rbac-proxy).
-	evalHubHealthPath = "/api/v1/health"
-	// evalHubInternalHealthPath is the cluster-internal health check path served by the main API server on evalHubAppPort.
-	// Kubelet probes reach it via kube-rbac-proxy (servicePort), which bypasses SAR for this path (--ignore-paths).
-	evalHubInternalHealthPath = "/healthz"
+	// evalHubInternalHealthPath is the health check path used for kubelet startup/readiness probes and passed to
+	// kube-rbac-proxy via --ignore-paths so probes are not subject to SAR. The eval-hub service serves this path
+	// without requiring identity headers (X-Tenant / X-User), making it safe for unauthenticated kubelet probes.
+	evalHubInternalHealthPath = "/api/v1/health"
 	// kubeRBACProxyHealthPath is served by kube-rbac-proxy on kubeRBACProxyHealthPort (see --proxy-endpoints-port).
 	kubeRBACProxyHealthPath = "/healthz"
 


### PR DESCRIPTION
## What and why

Updates the EvalHub probe endpoint from `/healthz` to `/api/v1/health` in line with eval-hub/eval-hub#797, which removes the `/healthz` route and makes `GET /api/v1/health` the single unauthenticated liveness/readiness probe endpoint.

The `--ignore-paths` flag passed to kube-rbac-proxy is updated via the same constant, so kubelet probes continue to bypass SAR enforcement.

Also removes the unused `evalHubHealthPath` constant (was defined but never referenced).

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

## Breaking changes

Requires eval-hub >= the version from eval-hub/eval-hub#797 (which removes `/healthz`). Deploying this operator change against an older eval-hub image will cause probe failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the health check endpoint used by system probes.
  - Health checks can now reach the service without requiring identity headers, improving probe reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->