### PR TITLE
fix(evalhub): grant evaluation verbs to evalhub-user Role

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ EvalHub deployment mode is controlled by `spec.tenancy` on the EvalHub CR (`mult
 - **`multi` (default)**: One EvalHub in a control-plane namespace serves multiple tenant namespaces labelled `evalhub.trustyai.opendatahub.io/tenant`. The operator provisions job ServiceAccounts, ClusterRole RoleBindings, service-CA ConfigMaps, and `evalhub-discovery` ConfigMaps in each tenant namespace — `tenant_namespaces.go`.
 - **`single`**: EvalHub runs in the workload namespace only. No cross-namespace tenant discovery or propagation. The operator creates namespace-scoped convenience Roles — `tenant_roles.go`:
   - `evalhub-tenant-admin` — full CRUD on EvalHub resources + MLflow experiment read
-  - `evalhub-user` — read collections/providers, submit via `evalhubs/proxy`, create status-events
+  - `evalhub-user` — evaluations job lifecycle (get/list/create/update/patch/delete), read collections/providers, submit via `evalhubs/proxy`, create status-events
   - `evalhub-tenant-admin-binding` — binds admin Role to `system:serviceaccounts:<namespace>`
   - Roles are GC'd via owner references; cleaned up on switch back to `multi`.
 

--- a/controllers/evalhub/tenant_roles.go
+++ b/controllers/evalhub/tenant_roles.go
@@ -157,7 +157,7 @@ func tenantAdminRules(instance *evalhubv1.EvalHub) []rbacv1.PolicyRule {
 }
 
 // tenantUserRules returns the PolicyRules for the evalhub-user Role.
-// Evaluation job lifecycle (list/create/get/update/delete), read collections/providers,
+// Evaluation job lifecycle (list/create/get/update/patch/delete), read collections/providers,
 // submit via proxy, create status-events, and MLflow experiment access for submission.
 func tenantUserRules(instance *evalhubv1.EvalHub) []rbacv1.PolicyRule {
 	return []rbacv1.PolicyRule{

--- a/controllers/evalhub/tenant_roles.go
+++ b/controllers/evalhub/tenant_roles.go
@@ -157,13 +157,19 @@ func tenantAdminRules(instance *evalhubv1.EvalHub) []rbacv1.PolicyRule {
 }
 
 // tenantUserRules returns the PolicyRules for the evalhub-user Role.
-// Read on collections/providers, submit evaluations, read MLflow experiments.
+// Evaluation job lifecycle (list/create/get/update/delete), read collections/providers,
+// submit via proxy, create status-events, and MLflow experiment access for submission.
 func tenantUserRules(instance *evalhubv1.EvalHub) []rbacv1.PolicyRule {
 	return []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{"trustyai.opendatahub.io"},
 			Resources: []string{"evalhubs"},
 			Verbs:     []string{"get", "list"},
+		},
+		{
+			APIGroups: []string{"trustyai.opendatahub.io"},
+			Resources: []string{"evaluations"},
+			Verbs:     []string{"get", "list", "create", "update", "patch", "delete"},
 		},
 		{
 			APIGroups: []string{"trustyai.opendatahub.io"},

--- a/controllers/evalhub/tenant_roles_test.go
+++ b/controllers/evalhub/tenant_roles_test.go
@@ -2,11 +2,16 @@ package evalhub
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	evalhubv1 "github.com/trustyai-explainability/trustyai-service-operator/api/evalhub/v1"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -91,21 +96,6 @@ func TestReconcileSingleTenancyRoles_SingleMode(t *testing.T) {
 		assert.True(t, found, "user Role must include an evalhubs rule for BFF discovery")
 	})
 
-	t.Run("user Role grants evaluations job lifecycle", func(t *testing.T) {
-		role := &rbacv1.Role{}
-		require.NoError(t, fc.Get(ctx, types.NamespacedName{Name: tenantUserRoleName, Namespace: "team-a"}, role))
-		found := false
-		for _, rule := range role.Rules {
-			if len(rule.Resources) == 1 && rule.Resources[0] == "evaluations" {
-				for _, verb := range []string{"get", "list", "create", "update", "patch", "delete"} {
-					assert.Contains(t, rule.Verbs, verb)
-				}
-				found = true
-			}
-		}
-		assert.True(t, found, "user Role must grant evaluations for ListEvaluationJobs and job lifecycle")
-	})
-
 	t.Run("creates admin RoleBinding", func(t *testing.T) {
 		rb := &rbacv1.RoleBinding{}
 		require.NoError(t, fc.Get(ctx, types.NamespacedName{Name: tenantAdminBindingName, Namespace: "team-a"}, rb))
@@ -173,3 +163,64 @@ func TestReconcileSingleTenancyRoles_SwitchSingleToMulti(t *testing.T) {
 		assert.True(t, errors.IsNotFound(err))
 	})
 }
+
+var _ = Describe("reconcileSingleTenancyRoles evaluations access", func() {
+	const evalHubName = "tenant-roles-evalhub"
+
+	var (
+		testNamespace string
+		namespace     *corev1.Namespace
+		evalHub       *evalhubv1.EvalHub
+		reconciler    *EvalHubReconciler
+	)
+
+	BeforeEach(func() {
+		testNamespace = fmt.Sprintf("evalhub-tenant-roles-%d", time.Now().UnixNano())
+		namespace = createNamespace(testNamespace)
+		Expect(k8sClient.Create(ctx, namespace)).To(Succeed())
+
+		evalHub = createEvalHubInstanceWithSQLite(evalHubName, testNamespace)
+		evalHub.Spec.Tenancy = evalhubv1.TenancySingle
+		Expect(k8sClient.Create(ctx, evalHub)).To(Succeed())
+
+		reconciler, _ = setupReconciler(testNamespace)
+	})
+
+	AfterEach(func() {
+		cleanupResourcesInNamespace(testNamespace, evalHub, nil)
+		_ = k8sClient.Delete(ctx, &rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{Name: tenantUserRoleName, Namespace: testNamespace},
+		})
+		_ = k8sClient.Delete(ctx, &rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{Name: tenantAdminRoleName, Namespace: testNamespace},
+		})
+		_ = k8sClient.Delete(ctx, &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: tenantAdminBindingName, Namespace: testNamespace},
+		})
+		deleteNamespace(namespace)
+		evalHub, namespace = nil, nil
+	})
+
+	It("user Role grants evaluations job lifecycle", func() {
+		Expect(reconciler.reconcileSingleTenancyRoles(ctx, evalHub)).To(Succeed())
+
+		role := &rbacv1.Role{}
+		Eventually(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{
+				Name:      tenantUserRoleName,
+				Namespace: testNamespace,
+			}, role)
+		}, timeout, interval).Should(Succeed())
+
+		found := false
+		for _, rule := range role.Rules {
+			if len(rule.Resources) == 1 && rule.Resources[0] == "evaluations" {
+				for _, verb := range []string{"get", "list", "create", "update", "patch", "delete"} {
+					Expect(rule.Verbs).To(ContainElement(verb))
+				}
+				found = true
+			}
+		}
+		Expect(found).To(BeTrue(), "user Role must grant evaluations for ListEvaluationJobs and job lifecycle")
+	})
+})

--- a/controllers/evalhub/tenant_roles_test.go
+++ b/controllers/evalhub/tenant_roles_test.go
@@ -91,6 +91,21 @@ func TestReconcileSingleTenancyRoles_SingleMode(t *testing.T) {
 		assert.True(t, found, "user Role must include an evalhubs rule for BFF discovery")
 	})
 
+	t.Run("user Role grants evaluations job lifecycle", func(t *testing.T) {
+		role := &rbacv1.Role{}
+		require.NoError(t, fc.Get(ctx, types.NamespacedName{Name: tenantUserRoleName, Namespace: "team-a"}, role))
+		found := false
+		for _, rule := range role.Rules {
+			if len(rule.Resources) == 1 && rule.Resources[0] == "evaluations" {
+				for _, verb := range []string{"get", "list", "create", "update", "patch", "delete"} {
+					assert.Contains(t, rule.Verbs, verb)
+				}
+				found = true
+			}
+		}
+		assert.True(t, found, "user Role must grant evaluations for ListEvaluationJobs and job lifecycle")
+	})
+
 	t.Run("creates admin RoleBinding", func(t *testing.T) {
 		rb := &rbacv1.RoleBinding{}
 		require.NoError(t, fc.Get(ctx, types.NamespacedName{Name: tenantAdminBindingName, Namespace: "team-a"}, rb))

--- a/controllers/evalhub/tenant_roles_test.go
+++ b/controllers/evalhub/tenant_roles_test.go
@@ -215,9 +215,9 @@ var _ = Describe("reconcileSingleTenancyRoles evaluations access", func() {
 		found := false
 		for _, rule := range role.Rules {
 			if len(rule.Resources) == 1 && rule.Resources[0] == "evaluations" {
-				for _, verb := range []string{"get", "list", "create", "update", "patch", "delete"} {
-					Expect(rule.Verbs).To(ContainElement(verb))
-				}
+				Expect(rule.APIGroups).To(Equal([]string{"trustyai.opendatahub.io"}))
+				Expect(rule.ResourceNames).To(BeEmpty())
+				Expect(rule.Verbs).To(ConsistOf("get", "list", "create", "update", "patch", "delete"))
 				found = true
 			}
 		}


### PR DESCRIPTION
## Summary
- Grant `evaluations` (`get`, `list`, `create`, `update`, `patch`, `delete`) on the single-tenancy `evalhub-user` Role so principals can list/create/manage evaluation jobs via SAR (fixes Forbidden on `ListEvaluationJobs`).
- Aligns `evalhub-user` with the multi-tenant `evalhub-evaluator` evaluation permissions while keeping collections/providers read-only.
- Update CLAUDE.md description of `evalhub-user`.

## Test plan
- [x] `go test -v ./controllers/evalhub/... -run TestReconcileSingleTenancyRoles`
- [ ] On a single-tenancy EvalHub, bind a principal only to `evalhub-user`, reconcile, then confirm `GET /api/v1/evaluations/jobs` and `POST /api/v1/evaluations/jobs` succeed
- [ ] Confirm collections/providers remain read-only for `evalhub-user` (create/update/delete still Forbidden)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tenant users with the `evalhub-user` role can now manage the complete evaluations job lifecycle: list, get, create, update, patch, and delete.
  * Existing access for submitting evaluations, creating status events, and related experiment data remains in place.

* **Documentation**
  * Updated tenancy role documentation to reflect the expanded `evalhub-user` permissions.

* **Tests**
  * Added coverage to verify single-tenancy role reconciliation produces the expected evaluations access rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->