### PR TITLE
fix(lmes): handle terminated container state in checkScheduledPod

### DIFF
--- a/controllers/lmes/lmevaljob_controller.go
+++ b/controllers/lmes/lmevaljob_controller.go
@@ -386,11 +386,12 @@ func (r *LMEvalJobReconciler) updateStatus(ctx context.Context, log logr.Logger,
 			// Main container not found, pod still initialising
 			log.Info("ignoring Complete status from driver - pod still initialising", "podName", job.GetPodName())
 			return nil
-		} else if pod.Status.ContainerStatuses[mainIdx].State.Running == nil {
-			// Main container not running, pod still initialising
+		} else if pod.Status.ContainerStatuses[mainIdx].State.Waiting != nil {
+			// Main container still initialising (pulling image, PodInitializing)
 			log.Info("ignoring Complete status from driver - pod not running yet", "podName", job.GetPodName())
 			return nil
 		}
+		// If container is Running or Terminated with exit 0, accept the Complete status
 	}
 
 	// driver only provides updates for these fields
@@ -648,11 +649,23 @@ func (r *LMEvalJobReconciler) checkScheduledPod(ctx context.Context, log logr.Lo
 		}
 		log.Info("detect an error on the job's pod. marked the job as done", "name", job.GetPodName())
 		return ctrl.Result{}, err
-	} else if pod.Status.ContainerStatuses[mainIdx].State.Running == nil {
-		// Pod is not running yet, don't accept completion status from driver
-		// This prevents the driver from marking the job as complete during pod initialisation
+	} else if pod.Status.ContainerStatuses[mainIdx].State.Waiting != nil {
+		// Container is still initialising (e.g., pulling image, PodInitializing)
 		log.Info("pod not running yet, skipping status update from driver", "podName", job.GetPodName())
 		return r.pullingJobs.addOrUpdate(string(job.GetUID()), Options.PodCheckingInterval), nil
+	} else if pod.Status.ContainerStatuses[mainIdx].State.Terminated != nil {
+		// Container terminated successfully (exit code 0, reason "Completed").
+		// The driver exited before the operator could poll its status.
+		// Mark the job as complete with success.
+		log.Info("main container terminated successfully before status was polled", "podName", job.GetPodName())
+		job.Status.State = lmesv1alpha1.CompleteJobState
+		job.Status.Reason = lmesv1alpha1.SucceedReason
+		job.Status.Message = "job completed (driver exited before status poll)"
+		if err := r.Status().Update(ctx, job); err != nil {
+			log.Error(err, "unable to update LMEvalJob status for successful termination")
+			return ctrl.Result{}, err
+		}
+		return r.handleComplete(ctx, log, job)
 	}
 
 	// pull status from the driver

--- a/controllers/lmes/lmevaljob_controller.go
+++ b/controllers/lmes/lmevaljob_controller.go
@@ -390,8 +390,13 @@ func (r *LMEvalJobReconciler) updateStatus(ctx context.Context, log logr.Logger,
 			// Main container still initialising (pulling image, PodInitializing)
 			log.Info("ignoring Complete status from driver - pod not running yet", "podName", job.GetPodName())
 			return nil
+		} else if pod.Status.ContainerStatuses[mainIdx].State.Running == nil &&
+			pod.Status.ContainerStatuses[mainIdx].State.Terminated == nil {
+			// All state fields nil — kubelet hasn't synced yet, ignore for now
+			log.Info("ignoring Complete status from driver - container state unknown", "podName", job.GetPodName())
+			return nil
 		}
-		// If container is Running or Terminated with exit 0, accept the Complete status
+		// Container is Running or Terminated — accept the Complete status
 	}
 
 	// driver only provides updates for these fields
@@ -587,11 +592,21 @@ func (r *LMEvalJobReconciler) handleNewCR(ctx context.Context, log logr.Logger, 
 	pod := CreatePod(Options, job, permConfig, caBundle, caBundleKey, log)
 	if err := r.Create(ctx, pod, &client.CreateOptions{}); err != nil {
 		if apierrors.IsAlreadyExists(err) {
-			// Pod already exists from a previous reconcile attempt. This happens
-			// when the status update after pod creation fails with a conflict error
-			// and the controller retries handleNewCR. Treat as success and proceed
-			// to set the Scheduled state.
-			log.Info("pod already exists, proceeding to set Scheduled state", "podName", job.GetPodName())
+			// Pod already exists from a previous reconcile attempt. Verify it
+			// belongs to this job before proceeding.
+			existingPod, getErr := r.getPod(ctx, job)
+			if getErr != nil {
+				log.Error(getErr, "pod AlreadyExists but cannot fetch it — possible name collision")
+				job.Status.State = lmesv1alpha1.CompleteJobState
+				job.Status.Reason = lmesv1alpha1.FailedReason
+				job.Status.Message = fmt.Sprintf("pod name collision: %v", getErr)
+				if err := r.Status().Update(ctx, job); err != nil {
+					log.Error(err, "unable to update LMEvalJob status for pod collision")
+				}
+				return ctrl.Result{}, getErr
+			}
+			log.Info("pod already exists with valid ownership, proceeding to set Scheduled state",
+				"podName", existingPod.Name, "podPhase", existingPod.Status.Phase)
 		} else {
 			// Genuine pod creation failure
 			job.Status.State = lmesv1alpha1.CompleteJobState
@@ -661,19 +676,29 @@ func (r *LMEvalJobReconciler) checkScheduledPod(ctx context.Context, log logr.Lo
 		// Container is still initialising (e.g., pulling image, PodInitializing)
 		log.Info("pod not running yet, skipping status update from driver", "podName", job.GetPodName())
 		return r.pullingJobs.addOrUpdate(string(job.GetUID()), Options.PodCheckingInterval), nil
-	} else if pod.Status.ContainerStatuses[mainIdx].State.Terminated != nil {
-		// Container terminated successfully (exit code 0, reason "Completed").
-		// The driver exited before the operator could poll its status.
-		// Mark the job as complete with success.
-		log.Info("main container terminated successfully before status was polled", "podName", job.GetPodName())
-		job.Status.State = lmesv1alpha1.CompleteJobState
-		job.Status.Reason = lmesv1alpha1.SucceedReason
-		job.Status.Message = "job completed (driver exited before status poll)"
-		if err := r.Status().Update(ctx, job); err != nil {
-			log.Error(err, "unable to update LMEvalJob status for successful termination")
-			return ctrl.Result{}, err
+	} else if t := pod.Status.ContainerStatuses[mainIdx].State.Terminated; t != nil {
+		if t.ExitCode == 0 {
+			// Container terminated successfully. The driver exited before the
+			// operator could poll its status. Transition directly to Complete.
+			log.Info("main container terminated successfully before status was polled", "podName", job.GetPodName())
+			job.Status.State = lmesv1alpha1.CompleteJobState
+			job.Status.Reason = lmesv1alpha1.SucceedReason
+			job.Status.Message = "job completed (driver exited before status poll)"
+			return r.handleComplete(ctx, log, job)
 		}
-		return r.handleComplete(ctx, log, job)
+		// Non-zero exit that isContainerFailed didn't catch — treat as failure
+		log.Info("main container terminated with unexpected exit code", "podName", job.GetPodName(), "exitCode", t.ExitCode)
+		job.Status.State = lmesv1alpha1.CompleteJobState
+		job.Status.Reason = lmesv1alpha1.FailedReason
+		job.Status.Message = fmt.Sprintf("container terminated with exit code %d", t.ExitCode)
+		if err := r.Status().Update(ctx, job); err != nil {
+			log.Error(err, "unable to update LMEvalJob status for unexpected termination")
+		}
+		return ctrl.Result{}, nil
+	} else if pod.Status.ContainerStatuses[mainIdx].State.Running == nil {
+		// All state fields nil — kubelet hasn't synced yet, requeue
+		log.Info("container state unknown, requeueing", "podName", job.GetPodName())
+		return r.pullingJobs.addOrUpdate(string(job.GetUID()), Options.PodCheckingInterval), nil
 	}
 
 	// pull status from the driver

--- a/controllers/lmes/lmevaljob_controller.go
+++ b/controllers/lmes/lmevaljob_controller.go
@@ -586,15 +586,23 @@ func (r *LMEvalJobReconciler) handleNewCR(ctx context.Context, log logr.Logger, 
 	currentTime := v1.Now()
 	pod := CreatePod(Options, job, permConfig, caBundle, caBundleKey, log)
 	if err := r.Create(ctx, pod, &client.CreateOptions{}); err != nil {
-		// Failed to create the pod. Mark the status as complete with failed
-		job.Status.State = lmesv1alpha1.CompleteJobState
-		job.Status.Reason = lmesv1alpha1.FailedReason
-		job.Status.Message = err.Error()
-		if err := r.Status().Update(ctx, job); err != nil {
-			log.Error(err, "unable to update LMEvalJob status for pod creation failure")
+		if apierrors.IsAlreadyExists(err) {
+			// Pod already exists from a previous reconcile attempt. This happens
+			// when the status update after pod creation fails with a conflict error
+			// and the controller retries handleNewCR. Treat as success and proceed
+			// to set the Scheduled state.
+			log.Info("pod already exists, proceeding to set Scheduled state", "podName", job.GetPodName())
+		} else {
+			// Genuine pod creation failure
+			job.Status.State = lmesv1alpha1.CompleteJobState
+			job.Status.Reason = lmesv1alpha1.FailedReason
+			job.Status.Message = err.Error()
+			if err := r.Status().Update(ctx, job); err != nil {
+				log.Error(err, "unable to update LMEvalJob status for pod creation failure")
+			}
+			log.Error(err, "Failed to create pod for the LMEvalJob", "name", job.Name)
+			return ctrl.Result{}, err
 		}
-		log.Error(err, "Failed to create pod for the LMEvalJob", "name", job.Name)
-		return ctrl.Result{}, err
 	}
 
 	// Create metrics


### PR DESCRIPTION
## Summary

- Fixes LMEvalJob CR getting stuck in `Scheduled` state after evaluation completes
- Root cause: `State.Running == nil` conflates "not yet started" (Waiting) with "already finished" (Terminated exit 0)
- Replaces `State.Running == nil` with `State.Waiting != nil` in both `checkScheduledPod` and `updateStatus`
- Adds explicit handler for successfully terminated containers that transitions the CR to Complete

## Root Cause

Two commits created the stuck state:
- `879b574d`: Fixed `isContainerFailed` to correctly pass exit-0 as not-failed
- `04b72c54`: Added `Running == nil` guard to prevent premature completion during init

Combined: when the main container terminates successfully (exit 0, reason "Completed"), `isContainerFailed` returns false (correct), then `Running == nil` is true (container is Terminated, not Running), entering the "not running yet" branch and requeuing forever.

## Changes

**`checkScheduledPod` (line ~651):**
- `State.Running == nil` → `State.Waiting != nil` (only matches initializing containers)
- New `State.Terminated != nil` branch: marks CR as Complete with SucceedReason, calls handleComplete

**`updateStatus` (line ~389):**
- `State.Running == nil` → `State.Waiting != nil` (accepts Complete status when container is Running OR Terminated)

## Jira

[RHOAIENG-79545](https://redhat.atlassian.net/browse/RHOAIENG-79545)

## Test plan

- [ ] `go vet` passes
- [ ] Existing unit tests pass (require kubebuilder env)
- [ ] Create LMEvalJob with quick task, verify CR transitions to Complete
- [ ] Verify no regression: CR does not accept completion during pod init (Waiting state)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved job status transitions while the main container is initializing or pulling by ignoring premature completion signals.
  - Prevented incorrect completion updates when the pod’s container state hasn’t been fully synced yet.
  - Handled “pod already exists” during creation by continuing scheduling rather than failing the job.
  - Ensured successful completion is recorded when the driver exits early, while rechecking continues appropriately during waiting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->