### PR TITLE
chore(rbac): add events:create and jobs:patch/get permissions for EvalHub

### DIFF
--- a/config/components/evalhub/kustomization.yaml
+++ b/config/components/evalhub/kustomization.yaml
@@ -6,6 +6,8 @@ resources:
   - crd/trustyai.opendatahub.io_evalhubs.yaml
   - rbac/evalhub_auth_reviewer_role.yaml
   - rbac/evalhub_collections_access_binding.yaml
+  - rbac/evalhub_events_binding.yaml
+  - rbac/evalhub_events_role.yaml
   - rbac/evalhub_collections_access_role.yaml
   - rbac/evalhub_hardware_profiles_reader_role.yaml
   - rbac/evalhub_job_config_binding.yaml

--- a/config/components/evalhub/rbac/evalhub_events_binding.yaml
+++ b/config/components/evalhub/rbac/evalhub_events_binding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: evalhub
+    app.kubernetes.io/name: trustyai-service-operator
+  name: evalhub-events-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: evalhub-events
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system

--- a/config/components/evalhub/rbac/evalhub_events_role.yaml
+++ b/config/components/evalhub/rbac/evalhub_events_role.yaml
@@ -1,0 +1,17 @@
+---
+# ClusterRole for EvalHub event emission
+# Grants create on core events so the EvalHub server can emit Kubernetes
+# Events against backing Job resources on evaluation lifecycle transitions
+# (EvaluationStarted, EvaluationCompleted, EvaluationFailed, EvaluationThresholdViolated).
+# Split from evalhub-jobs-writer for least-privilege.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: evalhub-events
+  labels:
+    app.kubernetes.io/name: trustyai-service-operator
+    app.kubernetes.io/component: evalhub
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create"]

--- a/config/components/evalhub/rbac/evalhub_events_role.yaml
+++ b/config/components/evalhub/rbac/evalhub_events_role.yaml
@@ -14,4 +14,4 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["events"]
-    verbs: ["create"]
+    verbs: ["create", "patch"]

--- a/config/components/evalhub/rbac/evalhub_jobs_writer_role.yaml
+++ b/config/components/evalhub/rbac/evalhub_jobs_writer_role.yaml
@@ -11,4 +11,4 @@ metadata:
 rules:
   - apiGroups: ["batch"]
     resources: ["jobs"]
-    verbs: ["create", "delete", "list"]
+    verbs: ["create", "delete", "get", "list", "patch"]

--- a/policy/rbac.rego
+++ b/policy/rbac.rego
@@ -31,6 +31,7 @@ expected_crbs := {
 
 	# --- component: evalhub (prefixed overlays: odh, rhoai, dev, testing) ---
 	"trustyai-service-operator-evalhub-manager-rolebinding": "trustyai-service-operator-evalhub-manager-role",
+	"trustyai-service-operator-evalhub-events-binding": "trustyai-service-operator-evalhub-events",
 	"trustyai-service-operator-evalhub-collections-access-binding": "trustyai-service-operator-evalhub-collections-access",
 	"trustyai-service-operator-evalhub-providers-access-binding": "trustyai-service-operator-evalhub-providers-access",
 	"trustyai-service-operator-evalhub-mlflow-access-binding": "trustyai-service-operator-evalhub-mlflow-access",
@@ -40,6 +41,7 @@ expected_crbs := {
 
 	# --- component: evalhub (un-prefixed overlay: evalhub-only) ---
 	"evalhub-manager-rolebinding": "trustyai-service-operator-evalhub-manager-role",
+	"evalhub-events-binding": "evalhub-events",
 	"evalhub-collections-access-binding": "evalhub-collections-access",
 	"evalhub-providers-access-binding": "evalhub-providers-access",
 	"evalhub-mlflow-access-binding": "evalhub-mlflow-access",


### PR DESCRIPTION
Add two new ClusterRoles for the EvalHub ServiceAccount:
- evalhub-events: grants events create, so the EvalHub server can emit Kubernetes Events against backing Job resources on evaluation lifecycle transitions (EvaluationStarted, EvaluationCompleted, EvaluationFailed, EvaluationThresholdViolated)
- evalhub-jobs-writer extended with get and patch verbs, so the server can read-modify-patch the trustyai.opendatahub.io/evaluation-phase label on running Jobs

Both new ClusterRoleBindings are added to the OPA policy allowlist. No functional code changes; this is the RBAC prerequisite for RHAI-277.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * EvalHub can now create and publish Kubernetes events.
  * Improved job management permissions, including retrieving and updating batch jobs.
  * Added RBAC configuration to ensure EvalHub event access is correctly authorized across supported deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->