### PR TITLE
feat(evalhub): emit events for job infrastructure failures

### DIFF
--- a/controllers/evalhub/evaluation_failed_kueue_workloads_reconciler.go
+++ b/controllers/evalhub/evaluation_failed_kueue_workloads_reconciler.go
@@ -20,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -58,14 +59,16 @@ func evaluationFailedKueueWorkloadsLogFields() []any {
 }
 
 //+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloads,verbs=get;list;watch;patch
-//+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get
+//+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;patch
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=trustyai.opendatahub.io,resources=evalhubs,verbs=get
 
 // EvalHubEvaluationFailedKueueWorkloadsReconciler POSTs a failed benchmark event to EvalHub when a Kueue
 // Workload has QuotaReserved=False with Reason=Inadmissible and is owned by an EvalHub evaluation Job.
 type EvalHubEvaluationFailedKueueWorkloadsReconciler struct {
 	client.Client
-	RESTConfig *rest.Config
+	RESTConfig    *rest.Config
+	EventRecorder record.EventRecorder
 	// tenantNS is the same instance updated by EvalHubEvaluationJobFailureReconciler's Namespace watch.
 	tenantNS *evalHubTenantNamespaces
 }
@@ -77,9 +80,10 @@ func registerEvalHubEvaluationFailedKueueWorkloadsReconciler(mgr manager.Manager
 		return fmt.Errorf("evalhub failed kueue workloads: tenantNS is nil")
 	}
 	r := &EvalHubEvaluationFailedKueueWorkloadsReconciler{
-		Client:     mgr.GetClient(),
-		RESTConfig: rest.CopyConfig(mgr.GetConfig()),
-		tenantNS:   tenantNS,
+		Client:        mgr.GetClient(),
+		RESTConfig:    rest.CopyConfig(mgr.GetConfig()),
+		tenantNS:      tenantNS,
+		EventRecorder: mgr.GetEventRecorderFor("trustyai-service-operator"),
 	}
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(evalHubEvaluationFailedKueueWorkloadsControllerName).
@@ -281,6 +285,12 @@ func (r *EvalHubEvaluationFailedKueueWorkloadsReconciler) Reconcile(ctx context.
 	if failureAlreadyReported(&job) {
 		return ctrl.Result{}, nil
 	}
+	if serverAlreadyHandledFailure(&job) {
+		log.V(1).Info("skip: EvalHub server already set failure label on Job",
+			append(evaluationFailedKueueWorkloadsLogFields(), "action", "skip_server_handled",
+				"workload", wl.Name, "job", job.Name, "namespace", job.Namespace)...)
+		return ctrl.Result{}, nil
+	}
 
 	jobID := strings.TrimSpace(job.Labels[evalHubJobIDLabel])
 	if jobID == "" {
@@ -325,6 +335,15 @@ func (r *EvalHubEvaluationFailedKueueWorkloadsReconciler) Reconcile(ctx context.
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
+	r.EventRecorder.Eventf(&job, corev1.EventTypeWarning, eventReasonEvaluationFailed, "%s", failureMsg)
+
+	if err := r.patchJobFailureLabels(ctx, &job, failureMsg); err != nil {
+		log.Error(err, "failed to patch Job failure labels after Kueue workload eviction",
+			append(evaluationFailedKueueWorkloadsLogFields(), "action", "patch_job_labels_failed",
+				"job", job.Name, "namespace", job.Namespace)...)
+		// Non-fatal: the POST to EvalHub succeeded; continue to annotate the Workload.
+	}
+
 	if err := r.annotateWorkloadReported(ctx, &wl); err != nil {
 		log.Error(err, "patch workload after EvalHub failed-workload event",
 			append(evaluationFailedKueueWorkloadsLogFields(), "action", "patch_workload_failed",
@@ -350,4 +369,19 @@ func (r *EvalHubEvaluationFailedKueueWorkloadsReconciler) annotateWorkloadReport
 	}
 	wl.Annotations[annotationKueueFailedWorkloadEventReported] = "true"
 	return r.Patch(ctx, wl, client.MergeFrom(patchBase))
+}
+
+// patchJobFailureLabels stamps the owning Job with evaluation-phase=Failed and sets the evaluation-status
+// annotation so the failure is observable on the Job resource even before it is cleaned up.
+func (r *EvalHubEvaluationFailedKueueWorkloadsReconciler) patchJobFailureLabels(ctx context.Context, job *batchv1.Job, statusMsg string) error {
+	base := job.DeepCopy()
+	if job.Labels == nil {
+		job.Labels = map[string]string{}
+	}
+	if job.Annotations == nil {
+		job.Annotations = map[string]string{}
+	}
+	job.Labels[labelEvaluationPhase] = labelEvaluationPhaseFailed
+	job.Annotations[annotationEvaluationStatus] = statusMsg
+	return r.Patch(ctx, job, client.MergeFrom(base))
 }

--- a/controllers/evalhub/evaluation_job_failure_reconciler.go
+++ b/controllers/evalhub/evaluation_job_failure_reconciler.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/transport"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -73,6 +74,17 @@ const (
 	sidecarContainerName    = "sidecar"
 )
 
+// Job lifecycle label and annotation stamped by the operator on infrastructure failures.
+// The same label is also set by the EvalHub server; the operator checks it to prevent duplicate Events.
+const (
+	labelEvaluationPhase        = "trustyai.opendatahub.io/evaluation-phase"
+	labelEvaluationPhaseFailed  = "Failed"
+	annotationEvaluationStatus  = "trustyai.opendatahub.io/evaluation-status"
+	// eventReasonEvaluationFailed matches the reason used by server-emitted Events; source.component
+	// distinguishes operator vs server (set automatically by the EventRecorder).
+	eventReasonEvaluationFailed = "EvaluationFailed"
+)
+
 // evalHubEvaluationJobFailureControllerName matches ctrl.NewControllerManagedBy(mgr).Named(...) for logs and registration.
 const evalHubEvaluationJobFailureControllerName = "evalhub-evaluation-job-failure"
 
@@ -89,6 +101,7 @@ func failureWatcherLogFields() []any {
 //+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=pods/log,verbs=get
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=trustyai.opendatahub.io,resources=evalhubs,verbs=get;list;watch
 
 // EvalHubEvaluationJobFailureReconciler POSTs a failed benchmark event to EvalHub when init, adapter,
@@ -101,7 +114,8 @@ func failureWatcherLogFields() []any {
 type EvalHubEvaluationJobFailureReconciler struct {
 	client.Client
 	// RESTConfig is used to build an HTTP transport that authenticates like the operator (SA token + cluster CA).
-	RESTConfig *rest.Config
+	RESTConfig    *rest.Config
+	EventRecorder record.EventRecorder
 
 	// tenantNS tracks namespaces labelled evalhub.trustyai.opendatahub.io/tenant (shared with the Kueue workload failure reconciler).
 	tenantNS *evalHubTenantNamespaces
@@ -168,9 +182,10 @@ func registerEvalHubEvaluationJobFailureController(mgr manager.Manager, tenantNS
 	}
 
 	r := &EvalHubEvaluationJobFailureReconciler{
-		Client:     mgr.GetClient(),
-		RESTConfig: rest.CopyConfig(mgr.GetConfig()),
-		tenantNS:   tenantNS,
+		Client:        mgr.GetClient(),
+		RESTConfig:    rest.CopyConfig(mgr.GetConfig()),
+		tenantNS:      tenantNS,
+		EventRecorder: mgr.GetEventRecorderFor("trustyai-service-operator"),
 	}
 
 	labelPred, err := predicate.LabelSelectorPredicate(evalHubJobPodLabelSelector())
@@ -328,6 +343,12 @@ func (r *EvalHubEvaluationJobFailureReconciler) Reconcile(ctx context.Context, r
 		}
 		return ctrl.Result{}, nil
 	}
+	if serverAlreadyHandledFailure(&job) {
+		log.Info("skip: EvalHub server already set failure label",
+			append(failureWatcherLogFields(), "action", "skip_server_handled",
+				"job", job.Name, "namespace", job.Namespace)...)
+		return ctrl.Result{}, nil
+	}
 
 	failed, msg, err := r.detectFailure(ctx, &job)
 	if err != nil {
@@ -349,6 +370,8 @@ func (r *EvalHubEvaluationJobFailureReconciler) Reconcile(ctx context.Context, r
 	}
 	log.Info("operator-only failure detected",
 		append(failureWatcherLogFields(), "action", "failure_detected", "job", job.Name, "namespace", job.Namespace, "detail", detailForLog)...)
+
+	r.EventRecorder.Eventf(&job, corev1.EventTypeWarning, eventReasonEvaluationFailed, "%s", msg)
 
 	baseURL, err := evalHubBaseURLFromJob(ctx, r.Client, &job)
 	if err != nil {
@@ -413,8 +436,13 @@ func (r *EvalHubEvaluationJobFailureReconciler) Reconcile(ctx context.Context, r
 	if job.Annotations == nil {
 		job.Annotations = map[string]string{}
 	}
+	if job.Labels == nil {
+		job.Labels = map[string]string{}
+	}
 	delete(job.Annotations, annotationFailurePending)
 	job.Annotations[annotationFailureReported] = "true"
+	job.Annotations[annotationEvaluationStatus] = msg
+	job.Labels[labelEvaluationPhase] = labelEvaluationPhaseFailed
 	if err := r.Patch(ctx, &job, promotePatch); err != nil {
 		log.Error(err, "failed to promote failure-reported annotation after successful POST",
 			append(failureWatcherLogFields(), "action", "promote_reported_failed", "job", job.Name)...)
@@ -727,6 +755,16 @@ func failureAlreadyReported(job *batchv1.Job) bool {
 		return false
 	}
 	return job.Annotations[annotationFailureReported] == "true"
+}
+
+// serverAlreadyHandledFailure returns true when the EvalHub server has already set evaluation-phase=Failed
+// on the Job, indicating the server reported the failure via its own event path. Prevents duplicate
+// Events when both the server and operator can detect the same failure.
+func serverAlreadyHandledFailure(job *batchv1.Job) bool {
+	if job.Labels == nil {
+		return false
+	}
+	return job.Labels[labelEvaluationPhase] == labelEvaluationPhaseFailed
 }
 
 func failurePendingReport(job *batchv1.Job) bool {

--- a/controllers/evalhub/evaluation_job_failure_reconciler.go
+++ b/controllers/evalhub/evaluation_job_failure_reconciler.go
@@ -371,8 +371,6 @@ func (r *EvalHubEvaluationJobFailureReconciler) Reconcile(ctx context.Context, r
 	log.Info("operator-only failure detected",
 		append(failureWatcherLogFields(), "action", "failure_detected", "job", job.Name, "namespace", job.Namespace, "detail", detailForLog)...)
 
-	r.EventRecorder.Eventf(&job, corev1.EventTypeWarning, eventReasonEvaluationFailed, "%s", msg)
-
 	baseURL, err := evalHubBaseURLFromJob(ctx, r.Client, &job)
 	if err != nil {
 		if errors.Is(err, ErrMissingEvalHubLabels) {
@@ -431,6 +429,8 @@ func (r *EvalHubEvaluationJobFailureReconciler) Reconcile(ctx context.Context, r
 		}
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
+
+	r.EventRecorder.Eventf(&job, corev1.EventTypeWarning, eventReasonEvaluationFailed, "%s", msg)
 
 	promotePatch := client.MergeFrom(job.DeepCopy())
 	if job.Annotations == nil {


### PR DESCRIPTION
## What and why

Extends the EvalHub evaluation job failure reconciler and Kueue workloads reconciler to emit Kubernetes Events (`reason: EvaluationFailed`, `type: Warning`) against backing Job resources when infrastructure-level failures are detected (OOM kills, image pull errors, Kueue workload evictions).

Also patches the `trustyai.opendatahub.io/evaluation-phase: Failed` label and `trustyai.opendatahub.io/evaluation-status` annotation onto Jobs after a successful failure report, and adds a deduplication check so the operator skips emission if the EvalHub server has already set the failure label.

## Type

- [x] feat

## Testing

- [ ] Tests added or updated
- [x] Tested manually

## Breaking changes

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes warning events when evaluation failures are detected or reported.
  * Jobs are now marked with failed evaluation status and failure details after successful reporting.
  * Workloads receive failure annotations following evaluation failures.

* **Bug Fixes**
  * Prevented duplicate failure reporting for Jobs already marked as failed.
  * Label update failures no longer prevent Workload failure annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->