### PR TITLE
docs(readme): add EvalHub to component list

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The TrustyAI Kubernetes Operator aims at simplifying the deployment and manageme
 inference data to enable model explainability, fairness monitoring, and drift tracking.
 - [FMS-Guardrails](https://github.com/foundation-model-stack/fms-guardrails-orchestrator): A modular framework for guardrailing LLMs
 - [LM-Eval](https://github.com/EleutherAI/lm-evaluation-harness/tree/main): A job-based architecture for deploying and managing LLM evaluations, based on EleutherAI's lm-evaluation-harness library.
+- [EvalHub](https://github.com/eval-hub): A service for orchestrating AI/ML model evaluations, providing a unified API for running benchmarks across multiple evaluation providers and frameworks, with support for multi-tenant and single-tenant deployments.
 
 ## Prerequisites
 - Kubernetes cluster v1.19+ or OpenShift cluster v4.6+


### PR DESCRIPTION
## Summary

Adds EvalHub to the operator's component list in the README, bringing it in line with the other managed services.

## What and why

The README overview lists the services managed by the TrustyAI operator, but EvalHub was missing despite the operator shipping a full `EVALHUB` controller since this branch was introduced. This adds a one-line description and a link to the upstream org.

## Type

- [ ] feat
- [x] docs
- [ ] fix
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tested manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added EvalHub to the overview as a service for orchestrating AI/ML model evaluations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->