### PR TITLE
fix(module): drop clusterrolebindings from RBAC permissions 

### DIFF
--- a/trustyai-operator-module/config/rbac/role.yaml
+++ b/trustyai-operator-module/config/rbac/role.yaml
@@ -95,7 +95,6 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
-  - clusterrolebindings
   - rolebindings
   verbs:
   - get

--- a/trustyai-operator-module/pkg/trustyaimodule/migration.go
+++ b/trustyai-operator-module/pkg/trustyaimodule/migration.go
@@ -123,6 +123,7 @@ func (r *TrustyAIModuleReconciler) adoptDeployments(ctx context.Context) (int, e
 	return count, nil
 }
 
+// adoptRBACResources adopts RoleBindings managed by the in-tree component.
 func (r *TrustyAIModuleReconciler) adoptRBACResources(ctx context.Context) (int, error) {
 	logger := log.FromContext(ctx)
 	labelSelector := labels.SelectorFromSet(labels.Set{InTreeManagedByLabel: "true"})
@@ -141,22 +142,6 @@ func (r *TrustyAIModuleReconciler) adoptRBACResources(ctx context.Context) (int,
 		logger.Info("Adopting RoleBinding", "name", rb.Name)
 		if err := r.adoptResource(ctx, rb); err != nil {
 			return count, fmt.Errorf("failed to adopt RoleBinding %s: %w", rb.Name, err)
-		}
-		count++
-	}
-
-	clusterRoleBindingList := &rbacv1.ClusterRoleBindingList{}
-	if err := r.List(ctx, clusterRoleBindingList, &client.ListOptions{
-		LabelSelector: labelSelector,
-	}); err != nil {
-		return count, fmt.Errorf("failed to list in-tree ClusterRoleBindings: %w", err)
-	}
-
-	for i := range clusterRoleBindingList.Items {
-		crb := &clusterRoleBindingList.Items[i]
-		logger.Info("Adopting ClusterRoleBinding", "name", crb.Name)
-		if err := r.adoptResource(ctx, crb); err != nil {
-			return count, fmt.Errorf("failed to adopt ClusterRoleBinding %s: %w", crb.Name, err)
 		}
 		count++
 	}

--- a/trustyai-operator-module/pkg/trustyaimodule/reconciler.go
+++ b/trustyai-operator-module/pkg/trustyaimodule/reconciler.go
@@ -43,7 +43,7 @@ type TrustyAIModuleReconciler struct {
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch;update
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;patch
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings;clusterrolebindings,verbs=get;list;patch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;patch
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
 
 func (r *TrustyAIModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION

The patch verb on clusterrolebindings was only used by the one-time SSA migration (adoptRBACResources). Since the in-tree controller must already be stopped before this migration runs, there is no live field manager conflict on CRBs to resolve. Removing CRB adoption and its corresponding RBAC permission avoids granting a permanent cluster-wide patch privilege for a one-time operation that can safely be skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted manager and controller permissions to namespace-scoped RoleBindings.
  * Removed access to ClusterRoleBindings.
  * Updated resource migration behavior to adopt only namespace-scoped RoleBindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->