### PR TITLE
feat(module): register module controller in cmd/main.go

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
+COPY trustyai-operator-module/go.mod trustyai-operator-module/go.mod
+COPY trustyai-operator-module/go.sum trustyai-operator-module/go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
@@ -16,6 +18,8 @@ COPY cmd/ cmd/
 COPY api/ api/
 COPY controllers/ controllers/
 COPY pkg/ pkg/
+COPY trustyai-operator-module/pkg/ trustyai-operator-module/pkg/
+COPY trustyai-operator-module/cmd/ trustyai-operator-module/cmd/
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -26,6 +26,7 @@ import (
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	routev1 "github.com/openshift/api/route/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	modulev1alpha1 "github.com/trustyai-explainability/trustyai-operator-module/pkg/apis/v1alpha1"
 	nemoguardrailsv1alpha1 "github.com/trustyai-explainability/trustyai-service-operator/api/nemo_guardrails/v1alpha1"
 	pkgtls "github.com/trustyai-explainability/trustyai-service-operator/pkg/tls"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -84,6 +85,7 @@ func init() {
 	utilruntime.Must(kueuev1beta1.AddToScheme(scheme))
 	utilruntime.Must(gorchv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(nemoguardrailsv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(modulev1alpha1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 

--- a/controllers/trustyai_module.go
+++ b/controllers/trustyai_module.go
@@ -1,0 +1,34 @@
+package controllers
+
+import (
+	"os"
+
+	"github.com/trustyai-explainability/trustyai-operator-module/pkg/trustyaimodule"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+const (
+	serviceNameModule             = "TRUSTYAI_MODULE"
+	defaultManifestsTemplatePath  = "/opt/manifests-template"
+	envManifestsTemplatePath      = "MANIFESTS_TEMPLATE_PATH"
+)
+
+func init() {
+	registerService(serviceNameModule, setupTrustyAIModuleController)
+}
+
+func setupTrustyAIModuleController(mgr manager.Manager, ns, _ string, recorder record.EventRecorder) error {
+	manifestsPath := os.Getenv(envManifestsTemplatePath)
+	if manifestsPath == "" {
+		manifestsPath = defaultManifestsTemplatePath
+	}
+
+	return (&trustyaimodule.TrustyAIModuleReconciler{
+		Client:                mgr.GetClient(),
+		Scheme:                mgr.GetScheme(),
+		Namespace:             ns,
+		ManifestsTemplatePath: manifestsPath,
+		EventRecorder:         recorder,
+	}).SetupWithManager(mgr)
+}

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,8 @@ require (
 	sigs.k8s.io/kueue v0.16.0-devel
 )
 
+require github.com/trustyai-explainability/trustyai-operator-module v0.0.0-00010101000000-000000000000
+
 require (
 	cel.dev/expr v0.25.1 // indirect
 	cloud.google.com/go/auth v0.20.0 // indirect
@@ -179,5 +181,7 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/yaml v1.6.0
 )
+
+replace github.com/trustyai-explainability/trustyai-operator-module => ./trustyai-operator-module
 
 exclude github.com/openshift/api v3.9.0+incompatible


### PR DESCRIPTION
Addressed jira: https://redhat.atlassian.net/browse/RHOAIENG-67663

Wire the trustyai-operator-module sub-project into the main operator so the module CR is watched and reconciled at runtime. This adds:

- go.mod require + replace directive for the local sub-project
- Module API group scheme registration (components.platform.opendatahub.io/v1alpha1)
- Controller registration shim following the existing init() pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for managing TrustyAI modules through the operator.
  * TrustyAI module resources are now recognized and automatically reconciled.
  * Module services are registered during operator startup for improved integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->