### PR TITLE
fix(module): switch dependency validation from Service Mesh to KServe InferenceService

### DIFF
--- a/trustyai-operator-module/config/rbac/role.yaml
+++ b/trustyai-operator-module/config/rbac/role.yaml
@@ -32,6 +32,7 @@ rules:
   - get
   - list
   - patch
+  - watch
 - apiGroups:
   - apps
   resources:
@@ -40,6 +41,7 @@ rules:
   - get
   - list
   - patch
+  - watch
 - apiGroups:
   - components.platform.opendatahub.io
   resources:
@@ -79,9 +81,9 @@ rules:
   - update
   - watch
 - apiGroups:
-  - maistra.io
+  - serving.kserve.io
   resources:
-  - servicemeshcontrolplanes
+  - inferenceservices
   verbs:
   - get
   - list
@@ -100,3 +102,4 @@ rules:
   - get
   - list
   - patch
+  - watch

--- a/trustyai-operator-module/pkg/trustyaimodule/dependencies.go
+++ b/trustyai-operator-module/pkg/trustyaimodule/dependencies.go
@@ -25,11 +25,11 @@ func (r *TrustyAIModuleReconciler) checkDependencies(ctx context.Context) ([]Dep
 
 	var results []DependencyCheckResult
 
-	serviceMeshResult, err := r.checkServiceMesh(ctx)
+	inferenceServiceResult, err := r.checkInferenceService(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to check Service Mesh: %w", err)
+		return nil, fmt.Errorf("failed to check InferenceService: %w", err)
 	}
-	results = append(results, serviceMeshResult)
+	results = append(results, inferenceServiceResult)
 
 	monitoringResult, err := r.checkMonitoring(ctx)
 	if err != nil {
@@ -40,15 +40,15 @@ func (r *TrustyAIModuleReconciler) checkDependencies(ctx context.Context) ([]Dep
 	return results, nil
 }
 
-func (r *TrustyAIModuleReconciler) checkServiceMesh(ctx context.Context) (DependencyCheckResult, error) {
+func (r *TrustyAIModuleReconciler) checkInferenceService(ctx context.Context) (DependencyCheckResult, error) {
 	logger := log.FromContext(ctx)
 
-	result := DependencyCheckResult{Name: "ServiceMesh"}
+	result := DependencyCheckResult{Name: "InferenceService"}
 
 	gvk := schema.GroupVersionKind{
-		Group:   "maistra.io",
-		Version: "v2",
-		Kind:    "ServiceMeshControlPlane",
+		Group:   "serving.kserve.io",
+		Version: "v1beta1",
+		Kind:    "InferenceService",
 	}
 
 	list := &unstructured.UnstructuredList{}
@@ -57,44 +57,16 @@ func (r *TrustyAIModuleReconciler) checkServiceMesh(ctx context.Context) (Depend
 	if err := r.List(ctx, list); err != nil {
 		if errors.IsNotFound(err) || isNoMatchError(err) {
 			result.Satisfied = false
-			result.Message = "Service Mesh is not installed (ServiceMeshControlPlane CRD not found)"
-			logger.Info("Service Mesh dependency not satisfied", "reason", result.Message)
+			result.Message = "InferenceService CRD not found (KServe is not installed)"
+			logger.Info("InferenceService dependency not satisfied", "reason", result.Message)
 			return result, nil
 		}
-		return result, fmt.Errorf("failed to list ServiceMeshControlPlane: %w", err)
+		return result, fmt.Errorf("failed to list InferenceService: %w", err)
 	}
 
-	if len(list.Items) == 0 {
-		result.Satisfied = false
-		result.Message = "Service Mesh is installed but no ServiceMeshControlPlane instance found"
-		logger.Info("Service Mesh dependency not satisfied", "reason", result.Message)
-		return result, nil
-	}
-
-	for _, item := range list.Items {
-		conditions, found, err := unstructured.NestedSlice(item.Object, "status", "conditions")
-		if err != nil || !found {
-			continue
-		}
-		for _, cond := range conditions {
-			condMap, ok := cond.(map[string]interface{})
-			if !ok {
-				continue
-			}
-			condType, _, _ := unstructured.NestedString(condMap, "type")
-			condStatus, _, _ := unstructured.NestedString(condMap, "status")
-			if condType == "Ready" && condStatus == "True" {
-				result.Satisfied = true
-				result.Message = fmt.Sprintf("Service Mesh is ready (instance: %s)", item.GetName())
-				logger.Info("Service Mesh dependency satisfied", "instance", item.GetName())
-				return result, nil
-			}
-		}
-	}
-
-	result.Satisfied = false
-	result.Message = "Service Mesh instances found but none are ready"
-	logger.Info("Service Mesh dependency not satisfied", "reason", result.Message)
+	result.Satisfied = true
+	result.Message = "InferenceService CRD is available"
+	logger.Info("InferenceService dependency satisfied")
 	return result, nil
 }
 

--- a/trustyai-operator-module/pkg/trustyaimodule/reconciler.go
+++ b/trustyai-operator-module/pkg/trustyaimodule/reconciler.go
@@ -37,7 +37,7 @@ type TrustyAIModuleReconciler struct {
 // +kubebuilder:rbac:groups=components.platform.opendatahub.io,resources=trustyais,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=components.platform.opendatahub.io,resources=trustyais/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=components.platform.opendatahub.io,resources=trustyais/finalizers,verbs=update
-// +kubebuilder:rbac:groups=maistra.io,resources=servicemeshcontrolplanes,verbs=get;list
+// +kubebuilder:rbac:groups=serving.kserve.io,resources=inferenceservices,verbs=get;list
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheuses,verbs=get;list
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch;update


### PR DESCRIPTION
## Summary

Replaces the Service Mesh (Maistra) dependency check in the `trustyai-operator-module` with a KServe `InferenceService` check. The previous check probed for a ready `ServiceMeshControlPlane` instance via `maistra.io`; the new check simply verifies that the `serving.kserve.io/v1beta1` `InferenceService` CRD is registered in the cluster. RBAC and kubebuilder markers are updated to match.

## Changes
  
- **`dependencies.go`**: Replaces `checkServiceMesh()` with `checkInferenceService()`, which checks for the presence of the KServe `InferenceService` CRD. Removes the instance-enumeration and Ready-condition logic (CRD presence alone is sufficient to satisfy the dependency).
- **`reconciler.go`**: Updates the RBAC kubebuilder marker from `maistra.io/servicemeshcontrolplanes` to `serving.kserve.io/inferenceservices`.
- **`config/rbac/role.yaml`**: Swaps the `maistra.io` rule for a `serving.kserve.io` rule; also adds missing `watch` verbs to several existing rules (`configmaps`, `deployments`, and `secrets`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dependency detection for KServe InferenceServices.
  * Added the permissions required to monitor services, deployments, role bindings, and InferenceServices.

* **Bug Fixes**
  * Updated dependency validation to recognize KServe InferenceService availability instead of service-mesh control-plane resources.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->