### PR TITLE
ci: update disconnected-readiness-scorer SHA to latest main

### DIFF
--- a/.github/workflows/disconnected-readiness.yaml
+++ b/.github/workflows/disconnected-readiness.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Clone disconnected-readiness-scorer
         run: |
           git clone https://github.com/opendatahub-io/disconnected-readiness-scorer.git /tmp/scorer
-          git -C /tmp/scorer checkout 64e6c53e17c7528fb41146fce9342d24a831517b # main
+          git -C /tmp/scorer checkout 5c27fa14178e0b38bb4409c06c0f8757362872bb # main
 
       - name: Install scorer dependencies
         run: |


### PR DESCRIPTION
## Summary

Bumps the pinned `disconnected-readiness-scorer` SHA in the disconnected readiness GHA workflow to the latest `main`.

- **Previous SHA:** `64e6c53e17c7528fb41146fce9342d24a831517b`
- **New SHA:** `5c27fa14178e0b38bb4409c06c0f8757362872bb`

## What and why

Keeps the disconnected readiness check in sync with upstream scorer improvements and fixes on `main`.


## Type

- [ ] feat
- [x] fix
- [ ] docs
- [x] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated disconnected-readiness check to use a newer scoring tool version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->