### PR TITLE
feat(evalhub): define Prometheus metrics package for EvalHub controller

### DIFF
--- a/controllers/evalhub/metrics.go
+++ b/controllers/evalhub/metrics.go
@@ -78,13 +78,32 @@ func init() {
 	)
 }
 
-func recordReconcile(controller, result string, duration time.Duration) {
-	reconcileTotal.WithLabelValues(controller, result).Inc()
-	reconcileDuration.WithLabelValues(controller, result).Observe(duration.Seconds())
+func normalizeResult(result string) string {
+	switch result {
+	case resultSuccess, resultRequeue, resultError:
+		return result
+	default:
+		return resultError
+	}
 }
 
-func recordReconcileError(controller, errorType string) {
-	reconcileErrors.WithLabelValues(controller, errorType).Inc()
+func normalizeFailureReason(reason string) string {
+	switch reason {
+	case failureReasonRuntimeFailure, failureReasonQueueError, failureReasonOther:
+		return reason
+	default:
+		return failureReasonOther
+	}
+}
+
+func recordReconcile(controller, result string, duration time.Duration) {
+	r := normalizeResult(result)
+	reconcileTotal.WithLabelValues(controller, r).Inc()
+	reconcileDuration.WithLabelValues(controller, r).Observe(duration.Seconds())
+}
+
+func recordReconcileError(controller string, err error) {
+	reconcileErrors.WithLabelValues(controller, classifyError(err)).Inc()
 }
 
 func setManagedInstances(controller string, count float64) {
@@ -92,7 +111,7 @@ func setManagedInstances(controller string, count float64) {
 }
 
 func recordJobFailureEvent(controller, reason string) {
-	jobFailureEvents.WithLabelValues(controller, reason).Inc()
+	jobFailureEvents.WithLabelValues(controller, normalizeFailureReason(reason)).Inc()
 }
 
 // classifyError maps an error to a fixed enum to prevent unbounded label cardinality.

--- a/controllers/evalhub/metrics.go
+++ b/controllers/evalhub/metrics.go
@@ -1,0 +1,117 @@
+package evalhub
+
+import (
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const (
+	resultSuccess = "success"
+	resultRequeue = "requeue"
+	resultError   = "error"
+
+	errorTypeNotFound           = "not_found"
+	errorTypeUpdateFailed       = "update_failed"
+	errorTypeStatusUpdateFailed = "status_update_failed"
+	errorTypeConfigInvalid      = "config_invalid"
+	errorTypeOther              = "other"
+
+	failureReasonRuntimeFailure = "runtime_failure"
+	failureReasonQueueError     = "queue_error"
+	failureReasonOther          = "other"
+)
+
+var (
+	reconcileDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "evalhub_controller_reconcile_duration_seconds",
+			Help:    "Duration in seconds of EvalHub controller reconciliation cycles.",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"controller", "result"},
+	)
+
+	reconcileTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "evalhub_controller_reconcile_total",
+			Help: "Total number of EvalHub controller reconciliations by result.",
+		},
+		[]string{"controller", "result"},
+	)
+
+	reconcileErrors = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "evalhub_controller_reconcile_errors_total",
+			Help: "Total number of EvalHub controller reconciliation errors by error type.",
+		},
+		[]string{"controller", "error_type"},
+	)
+
+	managedInstances = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "evalhub_controller_managed_instances",
+			Help: "Current number of EvalHub instances managed by the controller.",
+		},
+		[]string{"controller"},
+	)
+
+	jobFailureEvents = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "evalhub_evaluation_job_failure_events_total",
+			Help: "Total number of evaluation job failure events recorded by the EvalHub controller.",
+		},
+		[]string{"controller", "failure_reason"},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(
+		reconcileDuration,
+		reconcileTotal,
+		reconcileErrors,
+		managedInstances,
+		jobFailureEvents,
+	)
+}
+
+func recordReconcile(controller, result string, duration time.Duration) {
+	reconcileTotal.WithLabelValues(controller, result).Inc()
+	reconcileDuration.WithLabelValues(controller, result).Observe(duration.Seconds())
+}
+
+func recordReconcileError(controller, errorType string) {
+	reconcileErrors.WithLabelValues(controller, errorType).Inc()
+}
+
+func setManagedInstances(controller string, count float64) {
+	managedInstances.WithLabelValues(controller).Set(count)
+}
+
+func recordJobFailureEvent(controller, reason string) {
+	jobFailureEvents.WithLabelValues(controller, reason).Inc()
+}
+
+// classifyError maps an error to a fixed enum to prevent unbounded label cardinality.
+func classifyError(err error) string {
+	if err == nil {
+		return errorTypeOther
+	}
+	if k8serrors.IsNotFound(err) {
+		return errorTypeNotFound
+	}
+	msg := strings.ToLower(err.Error())
+	if strings.Contains(msg, "status") {
+		return errorTypeStatusUpdateFailed
+	}
+	if strings.Contains(msg, "update") || strings.Contains(msg, "patch") {
+		return errorTypeUpdateFailed
+	}
+	if strings.Contains(msg, "config") || strings.Contains(msg, "invalid") || strings.Contains(msg, "missing") {
+		return errorTypeConfigInvalid
+	}
+	return errorTypeOther
+}


### PR DESCRIPTION
Adds controllers/evalhub/metrics.go with all five metric definitions,
init() registration against the controller-runtime shared registry,
recording helpers, and classifyError() with a fixed enum to prevent
unbounded label cardinality. Prerequisite for reconcile instrumentation
([RHAI-240](https://redhat.atlassian.net/browse/RHAI-240)).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics for EvalHub reconciliation duration and results.
  * Added monitoring for reconciliation errors, managed instance counts, and evaluation job failures.
  * Added categorized error reporting for clearer operational insights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->