### PR TITLE
feat(evalhub): instrument EvalHubReconciler.Reconcile() with metrics

### DIFF
--- a/controllers/evalhub/evalhub_controller.go
+++ b/controllers/evalhub/evalhub_controller.go
@@ -73,12 +73,24 @@ type EvalHubReconciler struct {
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
-func (r *EvalHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *EvalHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.Result, err error) {
+	start := time.Now()
+	defer func() {
+		result := resultSuccess
+		if err != nil {
+			result = resultError
+			recordReconcileError("evalhub", classifyError(err))
+		} else if res.Requeue || res.RequeueAfter > 0 {
+			result = resultRequeue
+		}
+		recordReconcile("evalhub", result, time.Since(start))
+	}()
+
 	log := log.FromContext(ctx)
 
 	// Fetch the EvalHub instance
 	instance := &evalhubv1.EvalHub{}
-	err := r.Get(ctx, req.NamespacedName, instance)
+	err = r.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.

--- a/controllers/evalhub/evalhub_controller.go
+++ b/controllers/evalhub/evalhub_controller.go
@@ -79,7 +79,7 @@ func (r *EvalHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		result := resultSuccess
 		if err != nil {
 			result = resultError
-			recordReconcileError("evalhub", classifyError(err))
+			recordReconcileError("evalhub", err)
 		} else if res.Requeue || res.RequeueAfter > 0 {
 			result = resultRequeue
 		}


### PR DESCRIPTION
Use named returns + a single defer to record reconcile duration,
result label (success/requeue/error), and error type on every return
path without modifying individual return sites. Covers all 10+
return paths including handleDeletion and the periodic ready-state
requeue ([RHAI-240](https://redhat.atlassian.net/browse/RHAI-240)).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>