### PR TITLE
feat(evalhub): update managed instances gauge after each full reconcile cycle

### DIFF
--- a/controllers/evalhub/evalhub_controller.go
+++ b/controllers/evalhub/evalhub_controller.go
@@ -334,12 +334,22 @@ func (r *EvalHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		return RequeueWithError(err)
 	}
 
+	setManagedInstances("evalhub", r.countManagedInstances(ctx))
+
 	// If everything is ready, requeue after a longer delay for periodic checks
 	if instance.IsReady() {
 		return RequeueWithDelay(time.Minute * 5)
 	}
 
 	return RequeueWithDelay(time.Second * 30)
+}
+
+func (r *EvalHubReconciler) countManagedInstances(ctx context.Context) float64 {
+	list := &evalhubv1.EvalHubList{}
+	if err := r.List(ctx, list); err != nil {
+		return 0
+	}
+	return float64(len(list.Items))
 }
 
 // SetupWithManager registers the EvalHub CR reconciler, the evaluation Job failure → EvalHub events controller,


### PR DESCRIPTION
Add countManagedInstances() helper that lists all EvalHub CRs cluster-wide
and call setManagedInstances() after updateStatus() succeeds, so the gauge
reflects the live CR count on both the ready and not-yet-ready requeue paths
while skipping early-exit error paths ([RHAI-240](https://redhat.atlassian.net/browse/RHAI-240)).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>