### PR TITLE
feat(evalhub): record job failure events counter in failure reconciler

### DIFF
--- a/controllers/evalhub/evaluation_job_failure_reconciler.go
+++ b/controllers/evalhub/evaluation_job_failure_reconciler.go
@@ -460,6 +460,7 @@ func (r *EvalHubEvaluationJobFailureReconciler) Reconcile(ctx context.Context, r
 
 	log.Info("posted EvalHub benchmark failure event",
 		append(failureWatcherLogFields(), "action", "post_events_ok", "evalJobID", jobID, "k8sJob", job.Name, "namespace", job.Namespace)...)
+	recordJobFailureEvent(evalHubEvaluationJobFailureControllerName, failureReasonRuntimeFailure)
 	return ctrl.Result{}, nil
 }
 


### PR DESCRIPTION
Increment evalhub_evaluation_job_failure_events_total at the single
success point where the full pipeline (POST → promote patch → k8s
event → delete) has completed, covering both first-time and retry
paths ([RHAI-240](https://redhat.atlassian.net/browse/RHAI-240)).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>