### PR TITLE
test(evalhub): add unit tests for Prometheus metrics package

### DIFF
--- a/controllers/evalhub/metrics_test.go
+++ b/controllers/evalhub/metrics_test.go
@@ -1,0 +1,130 @@
+package evalhub
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// histogramCount extracts the sample count from a prometheus.Observer by type-asserting
+// to prometheus.Histogram (always valid for metrics returned by HistogramVec.WithLabelValues).
+func histogramCount(t *testing.T, obs prometheus.Observer) uint64 {
+	t.Helper()
+	h, ok := obs.(prometheus.Histogram)
+	require.True(t, ok, "observer must implement prometheus.Histogram")
+	var m dto.Metric
+	require.NoError(t, h.Write(&m))
+	return m.GetHistogram().GetSampleCount()
+}
+
+func TestClassifyError(t *testing.T) {
+	gr := schema.GroupResource{Group: "trustyai.opendatahub.io", Resource: "evalhubs"}
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"nil", nil, errorTypeOther},
+		{"not_found", k8serrors.NewNotFound(gr, "test"), errorTypeNotFound},
+		{"status_update", errors.New("failed to update status for resource"), errorTypeStatusUpdateFailed},
+		{"update", errors.New("failed to update resource"), errorTypeUpdateFailed},
+		{"patch", errors.New("failed to patch object"), errorTypeUpdateFailed},
+		{"config", errors.New("database config is wrong"), errorTypeConfigInvalid},
+		{"invalid", errors.New("spec is invalid"), errorTypeConfigInvalid},
+		{"missing", errors.New("secret is missing"), errorTypeConfigInvalid},
+		{"other", errors.New("some unexpected error"), errorTypeOther},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, classifyError(tt.err))
+		})
+	}
+}
+
+func TestRecordReconcile_AllResultLabels(t *testing.T) {
+	results := []string{resultSuccess, resultRequeue, resultError}
+	for i, result := range results {
+		ctrl := fmt.Sprintf("test-reconcile-result-%d", i)
+		result := result
+		t.Run(result, func(t *testing.T) {
+			recordReconcile(ctrl, result, 42*time.Millisecond)
+
+			assert.Equal(t, float64(1),
+				testutil.ToFloat64(reconcileTotal.WithLabelValues(ctrl, result)),
+				"reconcile_total counter should be 1 after one call")
+
+			assert.Equal(t, uint64(1),
+				histogramCount(t, reconcileDuration.WithLabelValues(ctrl, result)),
+				"reconcile_duration histogram should have sample count 1 after one observation")
+		})
+	}
+}
+
+func TestRecordReconcile_DurationObserved(t *testing.T) {
+	ctrl := "test-reconcile-duration"
+	recordReconcile(ctrl, resultSuccess, 100*time.Millisecond)
+
+	var m dto.Metric
+	h := reconcileDuration.WithLabelValues(ctrl, resultSuccess).(prometheus.Histogram)
+	require.NoError(t, h.Write(&m))
+	// 100 ms = 0.1 s; sum must be at least that
+	assert.GreaterOrEqual(t, m.GetHistogram().GetSampleSum(), 0.09,
+		"histogram sum should reflect the observed duration")
+}
+
+func TestRecordReconcileError_AllErrorTypes(t *testing.T) {
+	errorTypes := []string{
+		errorTypeNotFound,
+		errorTypeUpdateFailed,
+		errorTypeStatusUpdateFailed,
+		errorTypeConfigInvalid,
+		errorTypeOther,
+	}
+	for i, errType := range errorTypes {
+		ctrl := fmt.Sprintf("test-reconcile-error-%d", i)
+		errType := errType
+		t.Run(errType, func(t *testing.T) {
+			recordReconcileError(ctrl, errType)
+			assert.Equal(t, float64(1),
+				testutil.ToFloat64(reconcileErrors.WithLabelValues(ctrl, errType)),
+				"reconcile_errors_total counter should be 1 after one call")
+		})
+	}
+}
+
+func TestSetManagedInstances(t *testing.T) {
+	ctrl := "test-gauge"
+
+	setManagedInstances(ctrl, 3)
+	assert.Equal(t, float64(3),
+		testutil.ToFloat64(managedInstances.WithLabelValues(ctrl)),
+		"gauge should reflect the set value")
+
+	setManagedInstances(ctrl, 7)
+	assert.Equal(t, float64(7),
+		testutil.ToFloat64(managedInstances.WithLabelValues(ctrl)),
+		"gauge should update to the new value")
+}
+
+func TestRecordJobFailureEvent_AllReasons(t *testing.T) {
+	reasons := []string{failureReasonRuntimeFailure, failureReasonQueueError, failureReasonOther}
+	for i, reason := range reasons {
+		ctrl := fmt.Sprintf("test-failure-%d", i)
+		reason := reason
+		t.Run(reason, func(t *testing.T) {
+			recordJobFailureEvent(ctrl, reason)
+			assert.Equal(t, float64(1),
+				testutil.ToFloat64(jobFailureEvents.WithLabelValues(ctrl, reason)),
+				"failure_events_total counter should be 1 after one call")
+		})
+	}
+}

--- a/controllers/evalhub/metrics_test.go
+++ b/controllers/evalhub/metrics_test.go
@@ -82,20 +82,23 @@ func TestRecordReconcile_DurationObserved(t *testing.T) {
 }
 
 func TestRecordReconcileError_AllErrorTypes(t *testing.T) {
-	errorTypes := []string{
-		errorTypeNotFound,
-		errorTypeUpdateFailed,
-		errorTypeStatusUpdateFailed,
-		errorTypeConfigInvalid,
-		errorTypeOther,
+	cases := []struct {
+		err           error
+		expectedLabel string
+	}{
+		{k8serrors.NewNotFound(schema.GroupResource{}, "test"), errorTypeNotFound},
+		{errors.New("status update failed"), errorTypeStatusUpdateFailed},
+		{errors.New("update failed"), errorTypeUpdateFailed},
+		{errors.New("config invalid"), errorTypeConfigInvalid},
+		{errors.New("unknown"), errorTypeOther},
 	}
-	for i, errType := range errorTypes {
+	for i, tc := range cases {
 		ctrl := fmt.Sprintf("test-reconcile-error-%d", i)
-		errType := errType
-		t.Run(errType, func(t *testing.T) {
-			recordReconcileError(ctrl, errType)
+		tc := tc
+		t.Run(tc.expectedLabel, func(t *testing.T) {
+			recordReconcileError(ctrl, tc.err)
 			assert.Equal(t, float64(1),
-				testutil.ToFloat64(reconcileErrors.WithLabelValues(ctrl, errType)),
+				testutil.ToFloat64(reconcileErrors.WithLabelValues(ctrl, tc.expectedLabel)),
 				"reconcile_errors_total counter should be 1 after one call")
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -147,7 +147,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.23.2
-	github.com/prometheus/client_model v0.6.2 // indirect
+	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect


### PR DESCRIPTION
Table-driven tests covering classifyError() enum mapping (all 5 types
+ nil), each result label for reconcile counter and histogram count,
all error type labels, gauge set/update behaviour, and all failure
reason labels. Uses unique controller names per test to avoid
cross-test counter interference ([RHAI-240](https://redhat.atlassian.net/browse/RHAI-240)).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>