### PR TITLE
fix(module): rename CR singleton to default-trustyai, populate distribution, scope cache

### DIFF
--- a/trustyai-operator-module/cmd/trustyai-operator-module/main.go
+++ b/trustyai-operator-module/cmd/trustyai-operator-module/main.go
@@ -11,6 +11,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -58,6 +59,21 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Applications namespace is where the workload operator is deployed.
+	// Defaults to the operator namespace when not explicitly set.
+	applicationsNamespace := os.Getenv("APPLICATIONS_NAMESPACE")
+	if applicationsNamespace == "" {
+		applicationsNamespace = namespace
+	}
+
+	// Scope the cache to the namespaces we actually care about. Cluster-scoped
+	// resources (e.g. the TrustyAI CR itself) are always watched cluster-wide
+	// regardless of this setting.
+	watchNamespaces := map[string]cache.Config{
+		namespace:              {},
+		applicationsNamespace:  {},
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                  scheme,
 		Metrics:                 metricsserver.Options{BindAddress: metricsAddr},
@@ -65,6 +81,7 @@ func main() {
 		LeaderElectionID:        "trustyai-operator-module-controller-manager",
 		LeaderElectionNamespace: namespace,
 		HealthProbeBindAddress:  probeAddr,
+		Cache:                   cache.Options{DefaultNamespaces: watchNamespaces},
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/trustyai-operator-module/config/crd/bases/components.platform.opendatahub.io_trustyais.yaml
+++ b/trustyai-operator-module/config/crd/bases/components.platform.opendatahub.io_trustyais.yaml
@@ -183,8 +183,8 @@ spec:
             type: object
         type: object
         x-kubernetes-validations:
-        - message: TrustyAI resource must be named 'default'
-          rule: self.metadata.name == 'default'
+        - message: TrustyAI resource must be named 'default-trustyai'
+          rule: self.metadata.name == 'default-trustyai'
     served: true
     storage: true
     subresources:

--- a/trustyai-operator-module/pkg/apis/v1alpha1/trustyai_types.go
+++ b/trustyai-operator-module/pkg/apis/v1alpha1/trustyai_types.go
@@ -58,12 +58,17 @@ type TrustyAIStatus struct {
 	Distribution DistributionInfo `json:"distribution,omitempty"`
 }
 
+const (
+	// TrustyAIInstanceName is the singleton CR name enforced by the CEL validation rule.
+	TrustyAIInstanceName = "default-trustyai"
+)
+
 // TrustyAI is the Schema for the trustyais API
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,shortName=tai
 // +kubebuilder:storageversion
-// +kubebuilder:validation:XValidation:rule="self.metadata.name == 'default'",message="TrustyAI resource must be named 'default'"
+// +kubebuilder:validation:XValidation:rule="self.metadata.name == 'default-trustyai'",message="TrustyAI resource must be named 'default-trustyai'"
 // +kubebuilder:printcolumn:name="Management State",type=string,JSONPath=`.spec.managementState`
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`

--- a/trustyai-operator-module/pkg/trustyaimodule/reconciler.go
+++ b/trustyai-operator-module/pkg/trustyaimodule/reconciler.go
@@ -111,6 +111,10 @@ func (r *TrustyAIModuleReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return r.handleRemoval(ctx, module)
 	}
 
+	// Populate distribution before any early-exit that persists status, so
+	// status.distribution is always set regardless of which branch returns.
+	r.updateDistribution(module)
+
 	// Build the condition manager for this reconcile cycle.
 	condMgr := r.newConditionManager(module)
 
@@ -168,7 +172,6 @@ func (r *TrustyAIModuleReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	r.updateHealthStatus(ctx, module, condMgr)
 	r.updateReleases(module)
-	r.updateDistribution(module)
 
 	module.Status.ObservedGeneration = module.Generation
 	condMgr.Sort()

--- a/trustyai-operator-module/pkg/trustyaimodule/reconciler.go
+++ b/trustyai-operator-module/pkg/trustyaimodule/reconciler.go
@@ -3,6 +3,7 @@ package trustyaimodule
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -167,6 +168,7 @@ func (r *TrustyAIModuleReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	r.updateHealthStatus(ctx, module, condMgr)
 	r.updateReleases(module)
+	r.updateDistribution(module)
 
 	module.Status.ObservedGeneration = module.Generation
 	condMgr.Sort()
@@ -362,6 +364,23 @@ func (r *TrustyAIModuleReconciler) updateReleases(module *platformv1alpha1.Trust
 		Name:    "trustyai-operator-module",
 		Version: Version,
 	})
+}
+
+// updateDistribution populates status.distribution from platform env vars injected
+// by the ODH operator: ODH_PLATFORM_TYPE (name) and ODH_MODULE_OPERATOR_PLATFORM_VERSION (version).
+func (r *TrustyAIModuleReconciler) updateDistribution(module *platformv1alpha1.TrustyAI) {
+	name := os.Getenv("ODH_PLATFORM_TYPE")
+	if name == "" {
+		name = "OpenDataHub"
+	}
+	version := os.Getenv("ODH_MODULE_OPERATOR_PLATFORM_VERSION")
+	if version == "" {
+		version = "unknown"
+	}
+	module.Status.Distribution = platformv1alpha1.DistributionInfo{
+		Name:    name,
+		Version: version,
+	}
 }
 
 // reconcileComponent renders the Kustomize overlay for the trustyai-service-operator


### PR DESCRIPTION
- Rename CEL singleton constraint from 'default' to 'default-trustyai' to match
  platform naming convention ([GAP-02](https://redhat.atlassian.net/browse/GAP-02)); add TrustyAIInstanceName constant
- Update generated CRD YAML to reflect the new validation rule
- Populate status.distribution from ODH_PLATFORM_TYPE and
  ODH_MODULE_OPERATOR_PLATFORM_VERSION env vars on each reconcile
- Scope controller-runtime cache to operator namespace + applications namespace
  (APPLICATIONS_NAMESPACE, falls back to POD_NAMESPACE); cluster-scoped resources
  such as the TrustyAI CR are unaffected by namespace scoping

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added platform distribution and version details to TrustyAI status information.
  * Limited application resource monitoring to the operator and applications namespaces while retaining cluster-wide monitoring for cluster-scoped resources.

* **Bug Fixes**
  * TrustyAI resources now consistently require the name `default-trustyai`.
  * Added fallback values when platform metadata is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->