### PR TITLE
feat(module): add MCPGuardrailsMode and mcp-guardrails Kustomize overlay

### DIFF
--- a/trustyai-operator-module/config/crd/bases/components.platform.opendatahub.io_trustyais.yaml
+++ b/trustyai-operator-module/config/crd/bases/components.platform.opendatahub.io_trustyais.yaml
@@ -87,6 +87,12 @@ spec:
                 - Removed
                 - Unmanaged
                 type: string
+              mcpGuardrailsMode:
+                description: |-
+                  MCPGuardrailsMode deploys TrustyAI with only the NemoGuardrails service
+                  enabled, using a dedicated Kustomize overlay. Mutually exclusive with
+                  other enabledServices flags.
+                type: boolean
             type: object
           status:
             description: TrustyAIStatus defines the observed state of TrustyAI module

--- a/trustyai-operator-module/config/manifests-template/overlays/mcp-guardrails/kustomization.yaml
+++ b/trustyai-operator-module/config/manifests-template/overlays/mcp-guardrails/kustomization.yaml
@@ -1,0 +1,30 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# MCP guardrails mode: deploys the trustyai-service-operator configured for
+# NemoGuardrails-only operation (MCPGuardrailsMode=true in the TrustyAI CR).
+# This overlay is selected instead of overlays/odh or overlays/rhoai when the
+# MCPGuardrailsMode flag is set, mirroring the ODH operator's /overlays/mcp-guardrails.
+#
+# TODO: add MCP-specific patches (e.g. --enable-services NEMO_GUARDRAILS arg,
+# resource limits tuned for guardrails-only deployment) once the manifest set
+# is finalised alongside the ODH operator's mcp-guardrails overlay.
+resources:
+  - ../../base
+# Build a ConfigMap from params.env (rewritten by applyParams with platform-injected image env vars).
+configMapGenerator:
+  - name: trustyai-images
+    envs:
+      - params.env
+
+# Inject the operator's own image ref (TRUSTYAI_OPERATOR_IMAGE) directly into the Deployment.
+replacements:
+  - source:
+      kind: ConfigMap
+      name: trustyai-images
+      fieldPath: data.TRUSTYAI_OPERATOR_IMAGE
+    targets:
+      - select:
+          kind: Deployment
+          name: trustyai-service-operator
+        fieldPaths:
+          - spec.template.spec.containers.[name=manager].image

--- a/trustyai-operator-module/config/manifests-template/overlays/mcp-guardrails/params.env
+++ b/trustyai-operator-module/config/manifests-template/overlays/mcp-guardrails/params.env
@@ -1,0 +1,11 @@
+TRUSTYAI_OPERATOR_IMAGE=quay.io/trustyai/trustyai-service-operator:latest
+TRUSTYAI_SERVICE_IMAGE=quay.io/trustyai/trustyai-service:latest
+EVAL_HUB_IMAGE=quay.io/trustyai/evalhub:latest
+KUBE_RBAC_PROXY_IMAGE=registry.redhat.io/openshift4/ose-kube-rbac-proxy:latest
+TA_LMES_JOB_IMAGE=quay.io/trustyai/ta-lmes-job:latest
+TA_LMES_DRIVER_IMAGE=quay.io/trustyai/ta-lmes-driver:latest
+FMS_GUARDRAILS_ORCHESTRATOR_IMAGE=quay.io/trustyai/fms-guardrails-orchestrator:latest
+BUILT_IN_DETECTOR_IMAGE=quay.io/trustyai/built-in-detector:latest
+TRUSTYAI_VLLM_ORCHESTRATOR_GATEWAY_IMAGE=quay.io/trustyai/vllm-orchestrator-gateway:latest
+TRUSTYAI_GARAK_LLS_PROVIDER_DSP_IMAGE=quay.io/trustyai/garak-lls-provider:latest
+TRUSTYAI_NEMO_GUARDRAILS_SERVER_IMAGE=quay.io/trustyai/nemo-guardrails-server:latest

--- a/trustyai-operator-module/pkg/apis/v1alpha1/trustyai_types.go
+++ b/trustyai-operator-module/pkg/apis/v1alpha1/trustyai_types.go
@@ -42,6 +42,10 @@ type TrustyAISpec struct {
 	EnabledServices EnabledServices `json:"enabledServices,omitempty"`
 	// +optional
 	Eval EvalConfig `json:"eval,omitempty"`
+	// MCPGuardrailsMode deploys TrustyAI with only the NemoGuardrails service enabled,
+	// using a dedicated Kustomize overlay. Mutually exclusive with other enabledServices flags.
+	// +optional
+	MCPGuardrailsMode bool `json:"mcpGuardrailsMode,omitempty"`
 }
 
 // DistributionInfo represents distribution information

--- a/trustyai-operator-module/pkg/trustyaimodule/manifests.go
+++ b/trustyai-operator-module/pkg/trustyaimodule/manifests.go
@@ -23,34 +23,29 @@ const (
 )
 
 var (
-	stagingOnce   sync.Once
-	stagingErr    error
-	stagedOverlay string
+	copyOnce sync.Once
+	copyErr  error
 )
 
-// EnsureManifests copies templatePath to a writable location (once per
-// process), selects the overlay directory based on ODH_PLATFORM_TYPE, and
-// rewrites params.env with platform-injected image env vars.
+// EnsureManifests copies templatePath to a writable location (once per process),
+// then selects and prepares the overlay directory for the current platform and mode.
 //
-// Subsequent calls return the cached overlay path without re-running.
-func EnsureManifests(templatePath string) (string, error) {
-	stagingOnce.Do(func() {
-		overlay, err := stageManifests(templatePath, manifestsTarget)
-		stagedOverlay = overlay
-		stagingErr = err
+// The file copy is performed only once; overlay selection and params rewriting
+// happen on every call so that mode changes (e.g. MCPGuardrailsMode toggled on
+// the live CR) take effect without restarting the operator.
+func EnsureManifests(templatePath string, mcpMode bool) (string, error) {
+	copyOnce.Do(func() {
+		if err := os.RemoveAll(manifestsTarget); err != nil && !os.IsNotExist(err) {
+			copyErr = fmt.Errorf("clearing manifests target %s: %w", manifestsTarget, err)
+			return
+		}
+		copyErr = copyDir(templatePath, manifestsTarget)
 	})
-	return stagedOverlay, stagingErr
-}
-
-func stageManifests(src, dst string) (string, error) {
-	if err := os.RemoveAll(dst); err != nil && !os.IsNotExist(err) {
-		return "", fmt.Errorf("clearing manifests target %s: %w", dst, err)
-	}
-	if err := copyDir(src, dst); err != nil {
-		return "", fmt.Errorf("copying manifests from %s to %s: %w", src, dst, err)
+	if copyErr != nil {
+		return "", copyErr
 	}
 
-	overlay := selectOverlay(dst)
+	overlay := selectOverlay(manifestsTarget, mcpMode)
 	if err := applyParams(overlay); err != nil {
 		return "", fmt.Errorf("applying image params to overlay %s: %w", overlay, err)
 	}
@@ -58,9 +53,13 @@ func stageManifests(src, dst string) (string, error) {
 }
 
 // selectOverlay returns the kustomize overlay directory path for the current
-// platform, derived from the ODH_PLATFORM_TYPE environment variable.
-// Defaults to the ODH overlay when the variable is absent or unrecognised.
-func selectOverlay(manifestsDir string) string {
+// platform and mode. MCPGuardrailsMode takes priority over ODH_PLATFORM_TYPE:
+// when true it always selects overlays/mcp-guardrails regardless of platform.
+// Otherwise the platform is derived from ODH_PLATFORM_TYPE; defaults to ODH.
+func selectOverlay(manifestsDir string, mcpMode bool) string {
+	if mcpMode {
+		return filepath.Join(manifestsDir, "overlays/mcp-guardrails")
+	}
 	platform := strings.ToLower(os.Getenv("ODH_PLATFORM_TYPE"))
 	sub := "overlays/odh"
 	if strings.Contains(platform, "rhoai") ||
@@ -107,10 +106,10 @@ func applyParams(overlayDir string) error {
 // RenderManifests stages the manifests (once) and renders the selected
 // Kustomize overlay into a list of unstructured resources, injecting
 // namespace into all namespaced resources.
-func RenderManifests(ctx context.Context, templatePath, namespace string) ([]unstructured.Unstructured, error) {
+func RenderManifests(ctx context.Context, templatePath, namespace string, mcpMode bool) ([]unstructured.Unstructured, error) {
 	logger := log.FromContext(ctx)
 
-	overlay, err := EnsureManifests(templatePath)
+	overlay, err := EnsureManifests(templatePath, mcpMode)
 	if err != nil {
 		return nil, fmt.Errorf("staging manifests: %w", err)
 	}

--- a/trustyai-operator-module/pkg/trustyaimodule/reconciler.go
+++ b/trustyai-operator-module/pkg/trustyaimodule/reconciler.go
@@ -402,7 +402,7 @@ func (r *TrustyAIModuleReconciler) reconcileComponent(
 		return nil
 	}
 
-	objs, err := RenderManifests(ctx, r.ManifestsTemplatePath, r.Namespace)
+	objs, err := RenderManifests(ctx, r.ManifestsTemplatePath, r.Namespace, module.Spec.MCPGuardrailsMode)
 	if err != nil {
 		condMgr.MarkFalse(string(common.ConditionTypeProvisioningSucceeded),
 			conditions.WithReason("RenderFailed"),


### PR DESCRIPTION
Adds MCPGuardrailsMode bool to TrustyAISpec, mirroring the field of the
same name in the ODH operator's TrustyAICommonSpec. When true, the module
operator selects overlays/mcp-guardrails instead of overlays/odh or rhoai.

Refactors EnsureManifests to split the one-time file copy from overlay
selection: the copy still uses sync.Once but overlay selection now runs
on every reconcile so a mode change takes effect without restarting the
operator.

Creates the mcp-guardrails overlay directory with a placeholder
kustomization.yaml and params.env; MCP-specific patches (enabling only
NemoGuardrails) to be added once the ODH operator overlay is finalised.

Updates the CRD YAML to include the new mcpGuardrailsMode field.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>