### PR TITLE
feat(module): MC-12 move user-configurable settings from ConfigMap to spec

### DIFF
--- a/trustyai-operator-module/manifests-template/base/operator-configmap.yaml
+++ b/trustyai-operator-module/manifests-template/base/operator-configmap.yaml
@@ -3,21 +3,16 @@ kind: ConfigMap
 metadata:
   name: trustyai-service-operator-config
 data:
+  # Image overrides — managed by the Kustomize overlay (replacements from params.env).
+  # User-configurable settings (batch sizes, code-execution policy, etc.) are written
+  # by the module operator into this ConfigMap from the TrustyAI CR spec at runtime.
   trustyaiServiceImage: quay.io/trustyai/trustyai-service:latest
   trustyaiOperatorImage: quay.io/trustyai/trustyai-service-operator:latest
   evalHubImage: quay.io/evalhub/evalhub:latest
   evalHubMCPImage: quay.io/evalhub/evalhub:latest
   kube-rbac-proxy: quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable
-  kServeServerless: enabled
   lmes-driver-image: quay.io/trustyai/ta-lmes-driver:latest
   lmes-pod-image: quay.io/opendatahub/ta-lmes-job:odh-3.4-final
-  lmes-pod-checking-interval: 10s
-  lmes-image-pull-policy: Always
-  lmes-max-batch-size: "24"
-  lmes-default-batch-size: "8"
-  lmes-detect-device: "true"
-  lmes-allow-online: "true"
-  lmes-allow-code-execution: "true"
   guardrails-orchestrator-image: quay.io/trustyai/ta-guardrails-orchestrator:latest
   guardrails-built-in-detector-image: quay.io/trustyai/guardrails-detector-built-in:latest
   guardrails-sidecar-gateway-image: quay.io/trustyai/guardrails-sidecar-gateway:latest
@@ -29,3 +24,5 @@ data:
   evalhub-provider-deepeval-image: quay.io/evalhub/community-deepeval:latest
   evalhub-provider-ragas-image: quay.io/evalhub/community-ragas:latest
   evalhub-provider-inspect-image: quay.io/evalhub/community-inspect:latest
+  # Internal controller flag — operator polling interval, not user-configurable.
+  lmes-pod-checking-interval: 10s

--- a/trustyai-operator-module/pkg/apis/v1alpha1/trustyai_types.go
+++ b/trustyai-operator-module/pkg/apis/v1alpha1/trustyai_types.go
@@ -21,12 +21,33 @@ type EnabledServices struct {
 
 // LMEvalConfig defines LMEval-specific configuration
 type LMEvalConfig struct {
+	// PermitCodeExecution controls whether code execution is allowed during evaluations.
 	// +kubebuilder:default=false
 	// +optional
 	PermitCodeExecution bool `json:"permitCodeExecution,omitempty"`
+	// PermitOnline controls whether online access is allowed during evaluations.
 	// +kubebuilder:default=false
 	// +optional
 	PermitOnline bool `json:"permitOnline,omitempty"`
+	// MaxBatchSize is the maximum number of evaluation requests processed in a single batch.
+	// +kubebuilder:default=24
+	// +kubebuilder:validation:Minimum=1
+	// +optional
+	MaxBatchSize int `json:"maxBatchSize,omitempty"`
+	// DefaultBatchSize is the default number of evaluation requests processed in a single batch.
+	// +kubebuilder:default=8
+	// +kubebuilder:validation:Minimum=1
+	// +optional
+	DefaultBatchSize int `json:"defaultBatchSize,omitempty"`
+	// DetectDevice controls whether the evaluation driver auto-detects available compute devices (CPU/GPU).
+	// +kubebuilder:default=true
+	// +optional
+	DetectDevice bool `json:"detectDevice,omitempty"`
+	// ImagePullPolicy is the image pull policy for LMES job pods.
+	// +kubebuilder:default=Always
+	// +kubebuilder:validation:Enum=Always;IfNotPresent;Never
+	// +optional
+	ImagePullPolicy string `json:"imagePullPolicy,omitempty"`
 }
 
 // EvalConfig defines evaluation-related configuration
@@ -42,6 +63,10 @@ type TrustyAICommonSpec struct {
 	EnabledServices EnabledServices `json:"enabledServices,omitempty"`
 	// +optional
 	Eval EvalConfig `json:"eval,omitempty"`
+	// KServeServerless controls whether KServe serverless mode is enabled for TrustyAI services.
+	// +kubebuilder:default=true
+	// +optional
+	KServeServerless bool `json:"kServeServerless,omitempty"`
 	// MCPGuardrailsMode deploys TrustyAI with only the NemoGuardrails service enabled,
 	// using a dedicated Kustomize overlay. Mutually exclusive with other enabledServices flags.
 	// +optional

--- a/trustyai-operator-module/pkg/trustyaimodule/configmap.go
+++ b/trustyai-operator-module/pkg/trustyaimodule/configmap.go
@@ -3,6 +3,7 @@ package trustyaimodule
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strconv"
 
 	platformv1alpha1 "github.com/trustyai-explainability/trustyai-operator-module/pkg/apis/v1alpha1"
@@ -12,6 +13,100 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+// reconcileWorkloadConfigMap creates or updates the trustyai-service-operator-config
+// ConfigMap in the applications namespace with the user-configurable settings from the
+// TrustyAI spec. Image overrides are kept in the static manifests-template ConfigMap;
+// only the operator-behaviour keys are managed here.
+func (r *TrustyAIModuleReconciler) reconcileWorkloadConfigMap(ctx context.Context, module *platformv1alpha1.TrustyAI) error {
+	logger := log.FromContext(ctx)
+
+	desired := r.buildWorkloadConfigMap(module)
+
+	existing := &corev1.ConfigMap{}
+	err := r.Get(ctx, types.NamespacedName{
+		Name:      WorkloadConfigMapName,
+		Namespace: r.ApplicationsNamespace,
+	}, existing)
+
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Info("Creating workload ConfigMap", "name", WorkloadConfigMapName, "namespace", r.ApplicationsNamespace)
+			if createErr := r.Create(ctx, desired); createErr != nil {
+				r.EventRecorder.Event(module, "Warning", "ConfigMapCreateFailed", "Failed to create workload ConfigMap")
+				return fmt.Errorf("failed to create workload ConfigMap: %w", createErr)
+			}
+			r.EventRecorder.Event(module, "Normal", "ConfigMapCreated", "Workload ConfigMap created successfully")
+			return nil
+		}
+		return fmt.Errorf("failed to get workload ConfigMap: %w", err)
+	}
+
+	merged := mergeConfigMapData(existing.Data, desired.Data)
+	if !configMapDataEqual(existing.Data, merged) {
+		logger.Info("Updating workload ConfigMap", "name", WorkloadConfigMapName, "namespace", r.ApplicationsNamespace)
+		existing.Data = merged
+		if updateErr := r.Update(ctx, existing); updateErr != nil {
+			r.EventRecorder.Event(module, "Warning", "ConfigMapUpdateFailed", "Failed to update workload ConfigMap")
+			return fmt.Errorf("failed to update workload ConfigMap: %w", updateErr)
+		}
+		r.EventRecorder.Event(module, "Normal", "ConfigMapUpdated", "Workload ConfigMap updated successfully")
+	}
+
+	return nil
+}
+
+// buildWorkloadConfigMap constructs the user-configurable portion of the workload
+// operator ConfigMap from the TrustyAI CR spec. Image keys are managed by the
+// static manifests-template overlay and must not be overwritten here.
+func (r *TrustyAIModuleReconciler) buildWorkloadConfigMap(module *platformv1alpha1.TrustyAI) *corev1.ConfigMap {
+	lme := module.Spec.Eval.LMEval
+
+	kServeVal := "disabled"
+	if module.Spec.KServeServerless {
+		kServeVal = "enabled"
+	}
+
+	maxBatch := lme.MaxBatchSize
+	if maxBatch == 0 {
+		maxBatch = 24
+	}
+	defaultBatch := lme.DefaultBatchSize
+	if defaultBatch == 0 {
+		defaultBatch = 8
+	}
+	pullPolicy := lme.ImagePullPolicy
+	if pullPolicy == "" {
+		pullPolicy = "Always"
+	}
+
+	data := map[string]string{
+		WorkloadKeyKServeServerless:       kServeVal,
+		WorkloadKeyLMEvalPermitCodeExec:   strconv.FormatBool(lme.PermitCodeExecution),
+		WorkloadKeyLMEvalPermitOnline:     strconv.FormatBool(lme.PermitOnline),
+		WorkloadKeyLMEvalMaxBatchSize:     strconv.Itoa(maxBatch),
+		WorkloadKeyLMEvalDefaultBatchSize: strconv.Itoa(defaultBatch),
+		WorkloadKeyLMEvalDetectDevice:     strconv.FormatBool(lme.DetectDevice),
+		WorkloadKeyLMEvalImagePullPolicy:  pullPolicy,
+	}
+
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      WorkloadConfigMapName,
+			Namespace: r.ApplicationsNamespace,
+		},
+		Data: data,
+	}
+}
+
+// mergeConfigMapData merges spec-derived keys (from desired) into the existing map,
+// leaving image-override keys (managed by the static manifests) untouched.
+func mergeConfigMapData(existing, desired map[string]string) map[string]string {
+	merged := make(map[string]string, len(existing)+len(desired))
+	maps.Copy(merged, existing)
+	maps.Copy(merged, desired)
+	return merged
+}
 
 func (r *TrustyAIModuleReconciler) reconcileConfigMap(ctx context.Context, module *platformv1alpha1.TrustyAI) error {
 	logger := log.FromContext(ctx)

--- a/trustyai-operator-module/pkg/trustyaimodule/constants.go
+++ b/trustyai-operator-module/pkg/trustyaimodule/constants.go
@@ -23,9 +23,19 @@ const (
 	EventReasonStatusUpdated = "StatusUpdated"
 
 	// ConfigMap names
-	DSCConfigMapName = "trustyai-dsc-config"
+	DSCConfigMapName      = "trustyai-dsc-config"
+	WorkloadConfigMapName = "trustyai-service-operator-config"
 
-	// ConfigMap keys
+	// Workload ConfigMap keys — user-configurable settings written from the TrustyAI spec.
+	WorkloadKeyKServeServerless       = "kServeServerless"
+	WorkloadKeyLMEvalPermitCodeExec   = "lmes-allow-code-execution"
+	WorkloadKeyLMEvalPermitOnline     = "lmes-allow-online"
+	WorkloadKeyLMEvalMaxBatchSize     = "lmes-max-batch-size"
+	WorkloadKeyLMEvalDefaultBatchSize = "lmes-default-batch-size"
+	WorkloadKeyLMEvalDetectDevice     = "lmes-detect-device"
+	WorkloadKeyLMEvalImagePullPolicy  = "lmes-image-pull-policy"
+
+	// Legacy ConfigMap keys kept for the module's own DSC ConfigMap.
 	LMEvalPermitCodeExecutionKey = "eval.lmeval.permitCodeExecution"
 	LMEvalPermitOnlineKey        = "eval.lmeval.permitOnline"
 

--- a/trustyai-operator-module/pkg/trustyaimodule/reconciler.go
+++ b/trustyai-operator-module/pkg/trustyaimodule/reconciler.go
@@ -174,6 +174,11 @@ func (r *TrustyAIModuleReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, err
 	}
 
+	if err := r.reconcileWorkloadConfigMap(ctx, module); err != nil {
+		logger.Error(err, "Failed to reconcile workload ConfigMap")
+		return ctrl.Result{}, err
+	}
+
 	r.updateHealthStatus(ctx, module, condMgr)
 	r.updateReleases(module)
 


### PR DESCRIPTION
The operator-configmap.yaml stub contained user-configurable settings
(batch sizes, device detection, image pull policy, KServe serverless mode,
code execution and online access policy) hardcoded in YAML. These violated
MC-12 which requires ConfigMaps to hold only image overrides and internal
controller flags.

Changes:
- Extend LMEvalConfig with MaxBatchSize, DefaultBatchSize, DetectDevice,
  and ImagePullPolicy spec fields (with kubebuilder defaults matching the
  previous hardcoded values).
- Add KServeServerless bool to TrustyAICommonSpec (default true).
- Add reconcileWorkloadConfigMap which creates/updates the workload operator's
  trustyai-service-operator-config ConfigMap in the applications namespace,
  writing all user-configurable keys from the TrustyAI spec. Image-override
  keys already present in the ConfigMap (set by the Kustomize overlay) are
  preserved via mergeConfigMapData.
- Strip operator-configmap.yaml to image overrides and the internal
  lmes-pod-checking-interval flag only.
- Add WorkloadConfigMapName and WorkloadKey* constants; keep existing
  DSCConfigMapName / LMEvalPermit* constants for the module's own namespace CM.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>