### PR TITLE
feat(module): MC-14 add GC collector as last action after deploy

### DIFF
--- a/trustyai-operator-module/cmd/trustyai-operator-module/main.go
+++ b/trustyai-operator-module/cmd/trustyai-operator-module/main.go
@@ -10,12 +10,15 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/controller/gc"
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/deploy"
 	platformv1alpha1 "github.com/trustyai-explainability/trustyai-operator-module/pkg/apis/v1alpha1"
 	"github.com/trustyai-explainability/trustyai-operator-module/pkg/trustyaimodule"
@@ -74,7 +77,9 @@ func main() {
 		applicationsNamespace:  {},
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	restConfig := ctrl.GetConfigOrDie()
+
+	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme:                  scheme,
 		Metrics:                 metricsserver.Options{BindAddress: metricsAddr},
 		LeaderElection:          enableLeaderElection,
@@ -88,9 +93,25 @@ func main() {
 		os.Exit(1)
 	}
 
+	dynamicCli, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		setupLog.Error(err, "unable to create dynamic client")
+		os.Exit(1)
+	}
+
+	discoveryCli, err := discovery.NewDiscoveryClientForConfig(restConfig)
+	if err != nil {
+		setupLog.Error(err, "unable to create discovery client")
+		os.Exit(1)
+	}
+
 	deployer := deploy.NewDeployer(
 		deploy.WithFieldOwner(trustyaimodule.FieldManagerModule),
 		deploy.WithApplyOrder(),
+	)
+
+	garbageCollector := gc.New(
+		gc.InNamespace(applicationsNamespace),
 	)
 
 	if err := (&trustyaimodule.TrustyAIModuleReconciler{
@@ -100,6 +121,9 @@ func main() {
 		ApplicationsNamespace: applicationsNamespace,
 		ManifestsTemplatePath: manifestsPath,
 		Deployer:              deployer,
+		DynamicClient:         dynamicCli,
+		DiscoveryClient:       discoveryCli,
+		GarbageCollector:      garbageCollector,
 		EventRecorder:         mgr.GetEventRecorderFor("trustyai-module"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "TrustyAI")

--- a/trustyai-operator-module/pkg/trustyaimodule/reconciler.go
+++ b/trustyai-operator-module/pkg/trustyaimodule/reconciler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster"
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/controller/action"
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/controller/conditions"
+	odhgc "github.com/opendatahub-io/odh-platform-utilities/pkg/controller/gc"
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/controller/precondition"
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/deploy"
 	statusPkg "github.com/opendatahub-io/odh-platform-utilities/pkg/status"
@@ -18,12 +19,19 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+// gcRunner is the interface satisfied by odhgc.Collector, extracted for testing.
+type gcRunner interface {
+	Run(context.Context, odhgc.RunParams) error
+}
 
 // Version is the operator version, injected at build time via -ldflags.
 var Version = "unknown"
@@ -36,6 +44,9 @@ type TrustyAIModuleReconciler struct {
 	ApplicationsNamespace  string
 	ManifestsTemplatePath  string
 	Deployer               *deploy.Deployer
+	DynamicClient          dynamic.Interface
+	DiscoveryClient        discovery.DiscoveryInterface
+	GarbageCollector       gcRunner
 	EventRecorder          record.EventRecorder
 	SkipDependencyChecks   bool // set to true in tests to skip external dependency checks
 }
@@ -448,7 +459,32 @@ func (r *TrustyAIModuleReconciler) reconcileComponent(
 		return err
 	}
 
+	// GC must be the last action: collect resources that were previously
+	// deployed but are no longer in the current rendered set.
+	if err := r.runGC(ctx, module); err != nil {
+		condMgr.MarkFalse(string(common.ConditionTypeProvisioningSucceeded),
+			conditions.WithReason("GCFailed"),
+			conditions.WithMessage("Garbage collection failed: %v", err),
+			conditions.WithObservedGeneration(module.Generation),
+		)
+		return err
+	}
+
 	return nil
+}
+
+func (r *TrustyAIModuleReconciler) runGC(ctx context.Context, module *platformv1alpha1.TrustyAI) error {
+	if r.GarbageCollector == nil {
+		return nil
+	}
+	return r.GarbageCollector.Run(ctx, odhgc.RunParams{
+		Client:          r.Client,
+		DynamicClient:   r.DynamicClient,
+		DiscoveryClient: r.DiscoveryClient,
+		Owner:           module,
+		Version:         Version,
+		PlatformType:    os.Getenv("ODH_PLATFORM_TYPE"),
+	})
 }
 
 func (r *TrustyAIModuleReconciler) SetupWithManager(mgr ctrl.Manager) error {


### PR DESCRIPTION
Wire the odh-platform-utilities gc.Collector into the reconciler so that
stale resources (deployed in a prior version of the overlay but no longer
rendered) are garbage-collected after every successful deploy cycle.

Changes:
- Add gcRunner interface, DynamicClient, DiscoveryClient, and GarbageCollector
  fields to TrustyAIModuleReconciler.
- Add runGC helper that calls GarbageCollector.Run with the current module as
  owner; nil-safe so tests can leave it unset.
- Call runGC at the end of reconcileComponent, after Deployer.Deploy succeeds,
  making GC the last action in the reconciliation pipeline (MC-14 compliance).
- Initialise dynamic and discovery clients from the kubeconfig in main.go and
  construct a gc.Collector scoped to the applications namespace.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>