### PR TITLE
feat(evalhub): add EvalHub controller distributed tracing (RHAI-241)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	kservev1alpha1 "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
@@ -119,7 +120,9 @@ func run() int {
 		return 1
 	}
 	defer func() {
-		if err := traceShutdown(context.Background()); err != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := traceShutdown(ctx); err != nil {
 			setupLog.Error(err, "problem shutting down OpenTelemetry tracing")
 		}
 	}()

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -89,6 +89,10 @@ func init() {
 }
 
 func main() {
+	os.Exit(run())
+}
+
+func run() int {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
@@ -112,7 +116,7 @@ func main() {
 	traceShutdown, err := tracing.Setup(context.Background())
 	if err != nil {
 		setupLog.Error(err, "unable to set up OpenTelemetry tracing")
-		os.Exit(1)
+		return 1
 	}
 	defer func() {
 		if err := traceShutdown(context.Background()); err != nil {
@@ -122,14 +126,14 @@ func main() {
 
 	if enabledServices.Empty() {
 		setupLog.Error(fmt.Errorf("no service is specified"), "please specify at least one service")
-		os.Exit(1)
+		return 1
 	}
 
 	cfg := ctrl.GetConfigOrDie()
 	tlsResult, err := pkgtls.Resolve(context.Background(), cfg)
 	if err != nil {
 		setupLog.Error(err, "unable to resolve TLS configuration")
-		os.Exit(1)
+		return 1
 	}
 	tlsOpts := tlsResult.TLSOpts
 
@@ -168,20 +172,20 @@ func main() {
 	mgr, err := ctrl.NewManager(cfg, mgrOpts)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
-		os.Exit(1)
+		return 1
 	}
 
 	if slices.Contains(enabledServices, serviceEvalHub) {
 		if err := ctrl.NewWebhookManagedBy(mgr).For(&evalhubv1.EvalHub{}).Complete(); err != nil {
 			setupLog.Error(err, "unable to create EvalHub conversion webhook")
-			os.Exit(1)
+			return 1
 		}
 	}
 
 	if slices.Contains(enabledServices, serviceTAS) {
 		if err := ctrl.NewWebhookManagedBy(mgr).For(&tasv1.TrustyAIService{}).Complete(); err != nil {
 			setupLog.Error(err, "unable to create TrustyAIService conversion webhook")
-			os.Exit(1)
+			return 1
 		}
 	}
 
@@ -194,22 +198,24 @@ func main() {
 
 	if err := controllers.SetupControllers(enabledServices, mgr, ns, configMap, recorder); err != nil {
 		setupLog.Error(err, "unable to initialize controller(s)")
-		os.Exit(1)
+		return 1
 	}
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")
-		os.Exit(1)
+		return 1
 	}
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
-		os.Exit(1)
+		return 1
 	}
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
-		os.Exit(1)
+		return 1
 	}
+
+	return 0
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -55,6 +55,7 @@ import (
 	"github.com/trustyai-explainability/trustyai-service-operator/controllers"
 	"github.com/trustyai-explainability/trustyai-service-operator/controllers/constants"
 	"github.com/trustyai-explainability/trustyai-service-operator/controllers/utils"
+	"github.com/trustyai-explainability/trustyai-service-operator/pkg/tracing"
 	kueuev1beta1 "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	//+kubebuilder:scaffold:imports
 )
@@ -107,6 +108,17 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	traceShutdown, err := tracing.Setup(context.Background())
+	if err != nil {
+		setupLog.Error(err, "unable to set up OpenTelemetry tracing")
+		os.Exit(1)
+	}
+	defer func() {
+		if err := traceShutdown(context.Background()); err != nil {
+			setupLog.Error(err, "problem shutting down OpenTelemetry tracing")
+		}
+	}()
 
 	if enabledServices.Empty() {
 		setupLog.Error(fmt.Errorf("no service is specified"), "please specify at least one service")

--- a/controllers/evalhub/OTEL_TRACING.md
+++ b/controllers/evalhub/OTEL_TRACING.md
@@ -1,0 +1,188 @@
+# EvalHub controller distributed tracing
+
+This document describes how to enable OpenTelemetry (OTEL) tracing for the **TrustyAI Service Operator** when running the EvalHub controller, and how the instrumentation is implemented.
+
+**Related work:** [RHAI-241](https://redhat.atlassian.net/browse/RHAI-241) (controller tracing), sibling [RHAI-240](https://redhat.atlassian.net/browse/RHAI-240) (Prometheus metrics).
+
+---
+
+## Operator tracing vs EvalHub workload tracing
+
+These are separate concerns:
+
+| Layer | What it traces | How it is configured |
+| ----- | -------------- | -------------------- |
+| **Operator controller** (this document) | EvalHub reconcile loops and evaluation job failure handling in the operator process | Environment variables on the **operator Deployment** (`controller-manager`) |
+| **EvalHub server** (managed workload) | EvalHub API, jobs, sidecars | `spec.otel` on the **EvalHub CR** → rendered into the instance `config.yaml` |
+
+Configuring `spec.otel` on an EvalHub instance does **not** enable operator reconcile tracing. Both can be enabled independently.
+
+---
+
+## Enabling operator tracing
+
+Tracing is **opt-in**. By default the operator uses a noop tracer and exports nothing. No new ports are opened on the operator pod; spans are pushed outbound to an OTLP collector.
+
+### Required configuration
+
+Set at least one of these on the operator manager container:
+
+| Variable | Required | Description |
+| -------- | -------- | ----------- |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Yes* | OTLP collector host:port (e.g. `otel-collector.openshift-operators.svc:4317`) |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Yes* | Trace-specific endpoint; takes precedence over `OTEL_EXPORTER_OTLP_ENDPOINT` when set |
+
+\*Tracing stays disabled when neither endpoint variable is set.
+
+### Optional configuration
+
+| Variable | Default | Description |
+| -------- | ------- | ----------- |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc` | Use `http/protobuf` or `http` for OTLP/HTTP |
+| `OTEL_SERVICE_NAME` | `trustyai-service-operator` | `service.name` resource attribute in exported traces |
+| `OTEL_SDK_DISABLED` | unset | Set to `true` or `1` to force tracing off even when an endpoint is configured |
+
+Standard [OTEL SDK environment variables](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/) for headers, TLS, and timeouts are also respected by the OTLP exporters.
+
+### Example: patch the operator Deployment
+
+After deploying the operator (for example into `opendatahub`):
+
+```bash
+kubectl patch deployment trustyai-service-operator-controller-manager -n opendatahub --type='json' -p='[
+  {"op": "add", "path": "/spec/template/spec/containers/0/env/-", "value": {
+    "name": "OTEL_EXPORTER_OTLP_ENDPOINT",
+    "value": "otel-collector.openshift-operators.svc:4317"
+  }},
+  {"op": "add", "path": "/spec/template/spec/containers/0/env/-", "value": {
+    "name": "OTEL_SERVICE_NAME",
+    "value": "trustyai-service-operator"
+  }}
+]'
+```
+
+The deployment restarts automatically. Adjust the collector address and namespace for your cluster (Tempo, Jaeger, SigNoz, OpenShift cluster monitoring, etc.).
+
+### Example: kustomize overlay snippet
+
+Add to the manager container env in your overlay (do not commit a hardcoded production collector unless that is intentional for your environment):
+
+```yaml
+# config/manager/manager.yaml (or overlay patch)
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          env:
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "otel-collector.example.svc:4317"
+            - name: OTEL_SERVICE_NAME
+              value: "trustyai-service-operator"
+            # For OTLP/HTTP collectors:
+            # - name: OTEL_EXPORTER_OTLP_PROTOCOL
+            #   value: "http/protobuf"
+```
+
+### Verifying traces
+
+1. Ensure the operator pod has the env vars: `kubectl describe pod -l control-plane=trustyai-service-operator -n <namespace>`.
+2. Create or update an EvalHub CR to trigger reconciliation.
+3. In your trace backend, search for spans named `evalhub.reconcile` with `service.name=trustyai-service-operator` (or your `OTEL_SERVICE_NAME` override).
+4. To confirm the noop path, remove the endpoint env vars and verify the operator still runs normally.
+
+---
+
+## What gets traced
+
+### EvalHub reconciler (`EvalHubReconciler`)
+
+**Parent spans**
+
+| Span name | When |
+| --------- | ---- |
+| `evalhub.reconcile` | Normal reconcile after the EvalHub CR is fetched |
+| `evalhub.reconcile.deletion` | Finalizer cleanup when `deletionTimestamp` is set |
+
+**Parent attributes**
+
+- `k8s.namespace` — EvalHub instance namespace
+- `evalhub.name` — EvalHub CR name
+- `reconcile.generation` — CR `metadata.generation`
+- `reconcile.outcome` — `success`, `error`, `requeue`, `validation_error`, or `invalid_placement`
+- `reconcile.requeue_after` — present when the reconcile requeues with a delay
+
+**Child phase spans** (under `evalhub.reconcile`)
+
+| Span name | Reconcile phase |
+| --------- | --------------- |
+| `evalhub.reconcile.rbac` | ServiceAccounts, tenant namespace bindings, single-tenancy roles |
+| `evalhub.reconcile.configmap` | Instance ConfigMap, service CA, provider/collection ConfigMaps |
+| `evalhub.reconcile.deployment` | EvalHub Deployment |
+| `evalhub.reconcile.service` | Service, metrics Service, ServiceMonitor |
+| `evalhub.reconcile.route` | OpenShift Route (errors are logged; span does not fail the reconcile) |
+| `evalhub.reconcile.mcp` | MCP server resources (only when MCP is enabled) |
+| `evalhub.reconcile.status` | Status update from deployment readiness |
+
+A failing phase span is marked with OTEL error status and `RecordError` so SREs can see which sub-reconciler failed without reading controller logs.
+
+### Evaluation job failure reconciler (`EvalHubEvaluationJobFailureReconciler`)
+
+| Span name | `evalhub.job_failure_reconcile` |
+| --------- | ------------------------------- |
+
+**Attributes**
+
+- `k8s.namespace` — job namespace
+- `evalhub.job.name` — Kubernetes Job name
+- `evalhub.job.failure_reason` — operator-detected failure message (truncated to 512 characters)
+- `evalhub.job.exit_code` — first non-zero exit code from init/adapter/sidecar containers, when available
+- `evalhub.job_failure.action` — `skip`, `post`, or `delete`
+
+---
+
+## Technical implementation
+
+### Architecture
+
+```golang
+cmd/main.go
+  └── tracing.Setup()          # global TracerProvider (OTLP or noop)
+        └── EvalHub controllers
+              ├── evalhub_controller.go     # parent + phase spans via tracing.WithPhase
+              └── evaluation_job_failure_reconciler.go
+```
+
+### Key packages and files
+
+| File | Role |
+| ---- | ---- |
+| [`pkg/tracing/tracing.go`](../../pkg/tracing/tracing.go) | Shared OTEL bootstrap, `StartReconcileSpan`, `WithPhase`, outcome helpers |
+| [`cmd/main.go`](../../cmd/main.go) | Calls `tracing.Setup()` at startup; `Shutdown` on exit |
+| [`controllers/evalhub/tracing.go`](tracing.go) | EvalHub span name constants and reconcile attribute helpers |
+| [`controllers/evalhub/evalhub_controller.go`](evalhub_controller.go) | Phase instrumentation in `Reconcile()` |
+| [`controllers/evalhub/evaluation_job_failure_reconciler.go`](evaluation_job_failure_reconciler.go) | Job failure span and exit-code extraction |
+
+### Bootstrap behaviour
+
+1. On startup, `tracing.Setup()` checks `OTEL_SDK_DISABLED` and whether an OTLP endpoint env var is set.
+2. If disabled or unset → installs `noop.NewTracerProvider()` (negligible overhead per reconcile).
+3. If enabled → creates an OTLP trace exporter (gRPC by default, HTTP when `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`), batches spans, and sets resource attributes (`service.name`, `service.version` from operator build constants).
+4. Instrumentation scope for EvalHub spans: `evalhub-controller`.
+
+### Design notes
+
+- **No new CLI flags** — configuration follows the standard OTEL environment-variable pattern used by other platform components.
+- **No new exposed ports** — traces egress to the collector; nothing listens for trace ingestion on the operator pod.
+- **Reusable for other controllers** — `pkg/tracing` is controller-agnostic; TAS/LMES can adopt the same helpers in future work.
+- **Distinct from `spec.otel`** — workload OTEL remains configured per EvalHub instance via the CR and [`configmap.go`](configmap.go).
+
+### Tests
+
+Unit tests (no cluster required):
+
+```bash
+go test ./pkg/tracing/... ./controllers/evalhub/... -run 'Tracing|TestEvalHubReconcile|TestExitCode|TestTruncate|TestJobFailure|TestSetup|TestWithPhase|TestSetReconcile'
+```
+
+Tests use an in-memory `tracetest` exporter to assert span names, attributes, and error propagation on failed phases.

--- a/controllers/evalhub/evalhub_controller.go
+++ b/controllers/evalhub/evalhub_controller.go
@@ -482,10 +482,6 @@ func RequeueWithDelay(delay time.Duration) (ctrl.Result, error) {
 	return ctrl.Result{RequeueAfter: delay}, nil
 }
 
-func Requeue() (ctrl.Result, error) {
-	return ctrl.Result{Requeue: true}, nil
-}
-
 // handleDeletion handles the deletion of EvalHub resources
 func (r *EvalHubReconciler) handleDeletion(ctx context.Context, instance *evalhubv1.EvalHub) (ctrl.Result, error) {
 	log := log.FromContext(ctx)

--- a/controllers/evalhub/evalhub_controller.go
+++ b/controllers/evalhub/evalhub_controller.go
@@ -7,6 +7,7 @@ import (
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	evalhubv1 "github.com/trustyai-explainability/trustyai-service-operator/api/evalhub/v1"
+	"github.com/trustyai-explainability/trustyai-service-operator/pkg/tracing"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -73,12 +74,12 @@ type EvalHubReconciler struct {
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
-func (r *EvalHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *EvalHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	log := log.FromContext(ctx)
 
 	// Fetch the EvalHub instance
 	instance := &evalhubv1.EvalHub{}
-	err := r.Get(ctx, req.NamespacedName, instance)
+	err = r.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -94,8 +95,19 @@ func (r *EvalHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	// Handle deletion first to avoid blocking removal with status init.
 	if instance.DeletionTimestamp != nil {
+		ctx, span := startEvalHubReconcileSpan(ctx, spanReconcileDeletion, instance.Namespace, instance.Name, int64(instance.Generation))
+		defer func() {
+			finishEvalHubReconcileSpan(span, result, err)
+			span.End()
+		}()
 		return r.handleDeletion(ctx, instance)
 	}
+
+	ctx, span := startEvalHubReconcileSpan(ctx, spanReconcile, instance.Namespace, instance.Name, int64(instance.Generation))
+	defer func() {
+		finishEvalHubReconcileSpan(span, result, err)
+		span.End()
+	}()
 
 	// Set initial status if not set
 	if instance.Status.Phase == "" {
@@ -130,6 +142,7 @@ func (r *EvalHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		r.Status().Update(ctx, instance)
 		r.EventRecorder.Event(instance, corev1.EventTypeWarning, "DatabaseConfigMissing",
 			"Database configuration is required but not provided in spec.database")
+		tracing.SetSpanOutcome(span, "validation_error")
 		return RequeueWithError(fmt.Errorf("spec.database is required: the operator does not assume a default database"))
 	}
 
@@ -143,6 +156,7 @@ func (r *EvalHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		r.Status().Update(ctx, instance)
 		r.EventRecorder.Event(instance, corev1.EventTypeWarning, "DatabaseConfigInvalid",
 			"PostgreSQL database type requires spec.database.secret to reference a Secret with a db-url key")
+		tracing.SetSpanOutcome(span, "validation_error")
 		return RequeueWithError(fmt.Errorf("spec.database.secret is required for postgresql"))
 	}
 
@@ -168,157 +182,159 @@ func (r *EvalHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			}
 			r.EventRecorder.Event(instance, corev1.EventTypeWarning, invalidPlacementReason,
 				"multi-tenant EvalHub placed in a tenant namespace; deployment halted")
+			tracing.SetSpanOutcome(span, "invalid_placement")
 			return DoNotRequeue()
 		}
 	}
 
-	// Create ServiceAccount for EvalHub
-	err = r.createServiceAccount(ctx, instance)
-	if err != nil {
-		log.Error(err, "Failed to create ServiceAccount")
-		instance.SetStatus("Ready", "Error", fmt.Sprintf("Failed to create ServiceAccount: %v", err), corev1.ConditionFalse)
-		r.Status().Update(ctx, instance)
-		return RequeueWithError(err)
-	}
+	var providerCMNames, collectionCMNames, tenantProviderCMNames, tenantCollectionCMNames []string
 
-	// Create ServiceAccount for jobs in the instance namespace.
-	err = r.createJobsServiceAccount(ctx, instance, instance.Namespace)
-	if err != nil {
-		log.Error(err, "Failed to create job ServiceAccount")
-		instance.SetStatus("Ready", "Error", fmt.Sprintf("Failed to create job ServiceAccount: %v", err), corev1.ConditionFalse)
-		r.Status().Update(ctx, instance)
-		return RequeueWithError(err)
-	}
-
-	// Reconcile tenant namespaces: create job SAs and API SA bindings in any
-	// namespace labelled with evalhub.trustyai.opendatahub.io/tenant.
-	// In single mode this is a no-op except for cleaning up any stale cross-ns resources.
-	if err := r.reconcileTenantNamespaces(ctx, instance); err != nil {
-		log.Error(err, "Failed to reconcile tenant namespaces")
-		instance.SetStatus("Ready", "Error", fmt.Sprintf("Failed to reconcile tenant namespaces: %v", err), corev1.ConditionFalse)
-		r.Status().Update(ctx, instance)
-		return RequeueWithError(err)
-	}
-
-	// Reconcile single-tenancy convenience Roles (create in single mode, clean up in multi mode).
-	if err := r.reconcileSingleTenancyRoles(ctx, instance); err != nil {
-		log.Error(err, "Failed to reconcile single-tenancy roles")
-		instance.SetStatus("Ready", "Error", fmt.Sprintf("Failed to reconcile single-tenancy roles: %v", err), corev1.ConditionFalse)
-		r.Status().Update(ctx, instance)
-		return RequeueWithError(err)
-	}
-
-	// Reconcile ConfigMap
-	if err := r.reconcileConfigMap(ctx, instance); err != nil {
-		log.Error(err, "Failed to reconcile ConfigMap")
-		instance.SetStatus("Ready", "Error", fmt.Sprintf("Failed to reconcile ConfigMap: %v", err), corev1.ConditionFalse)
-		r.Status().Update(ctx, instance)
-		return RequeueWithError(err)
-	}
-
-	// Reconcile Service CA ConfigMap (for jobs to mount service CA certificate)
-	if err := r.reconcileServiceCAConfigMap(ctx, instance); err != nil {
-		log.Error(err, "Failed to reconcile Service CA ConfigMap")
-		instance.SetStatus("Ready", "Error", fmt.Sprintf("Failed to reconcile Service CA ConfigMap: %v", err), corev1.ConditionFalse)
-		r.Status().Update(ctx, instance)
-		return RequeueWithError(err)
-	}
-
-	// Reconcile Provider ConfigMaps (copy system CMs from operator namespace to instance namespace)
-	providerCMNames, err := r.reconcileProviderConfigMaps(ctx, instance)
-	if err != nil {
-		log.Error(err, "Failed to reconcile Provider ConfigMaps")
-		instance.SetStatus("Ready", "Error", fmt.Sprintf("Failed to reconcile Provider ConfigMaps: %v", err), corev1.ConditionFalse)
-		r.Status().Update(ctx, instance)
-		return RequeueWithError(err)
-	}
-	instance.Status.ActiveProviders = instance.Spec.Providers
-
-	// Reconcile Collection ConfigMaps (copy system CMs from operator namespace to instance namespace)
-	collectionCMNames, err := r.reconcileCollectionConfigMaps(ctx, instance)
-	if err != nil {
-		log.Error(err, "Failed to reconcile Collection ConfigMaps")
-		instance.SetStatus("Ready", "Error", fmt.Sprintf("Failed to reconcile Collection ConfigMaps: %v", err), corev1.ConditionFalse)
-		r.Status().Update(ctx, instance)
-		return RequeueWithError(err)
-	}
-	instance.Status.ActiveCollections = instance.Spec.Collections
-
-	// Discover tenant-labeled provider/collection ConfigMaps in the instance namespace.
-	// These are additional CMs provided by the namespace admin and mount at /providers/tenant/ and /collections/tenant/.
-	tenantProviderCMNames, err := r.reconcileTenantProviderConfigMaps(ctx, instance)
-	if err != nil {
-		log.Error(err, "Failed to reconcile tenant Provider ConfigMaps")
-		instance.SetStatus("Ready", "Error", fmt.Sprintf("Failed to reconcile tenant Provider ConfigMaps: %v", err), corev1.ConditionFalse)
-		r.Status().Update(ctx, instance)
-		return RequeueWithError(err)
-	}
-	tenantCollectionCMNames, err := r.reconcileTenantCollectionConfigMaps(ctx, instance)
-	if err != nil {
-		log.Error(err, "Failed to reconcile tenant Collection ConfigMaps")
-		instance.SetStatus("Ready", "Error", fmt.Sprintf("Failed to reconcile tenant Collection ConfigMaps: %v", err), corev1.ConditionFalse)
-		r.Status().Update(ctx, instance)
-		return RequeueWithError(err)
-	}
-
-	// Reconcile Deployment
-	if err := r.reconcileDeployment(ctx, instance, providerCMNames, collectionCMNames, tenantProviderCMNames, tenantCollectionCMNames); err != nil {
-		log.Error(err, "Failed to reconcile Deployment")
-		instance.SetStatus("Ready", "Error", fmt.Sprintf("Failed to reconcile Deployment: %v", err), corev1.ConditionFalse)
-		r.Status().Update(ctx, instance)
-		return RequeueWithError(err)
-	}
-
-	// Reconcile Service
-	if err := r.reconcileService(ctx, instance); err != nil {
-		log.Error(err, "Failed to reconcile Service")
-		instance.SetStatus("Ready", "Error", fmt.Sprintf("Failed to reconcile Service: %v", err), corev1.ConditionFalse)
-		r.Status().Update(ctx, instance)
-		return RequeueWithError(err)
-	}
-
-	// Reconcile metrics Service (dedicated ClusterIP for Prometheus scraping on metricsPort)
-	if err := r.reconcileMetricsService(ctx, instance); err != nil {
-		log.Error(err, "Failed to reconcile metrics Service")
-		instance.SetStatus("Ready", "Error", fmt.Sprintf("Failed to reconcile metrics Service: %v", err), corev1.ConditionFalse)
-		r.Status().Update(ctx, instance)
-		return RequeueWithError(err)
-	}
-
-	// Reconcile monitoring resources (ServiceMonitor).
-	// Monitoring failures are non-fatal: log, set a degraded condition, and continue.
-	// The condition is set in memory only — updateStatus() at the end of the loop
-	// persists the full status in a single write, avoiding mid-reconcile status
-	// updates that would trigger unnecessary re-reconciles.
-	if r.isServiceMonitorSupported() {
-		if err := r.reconcileServiceMonitor(ctx, instance); err != nil {
-			log.Error(err, "Failed to reconcile ServiceMonitor")
-			instance.SetStatus("MonitoringDegraded", "ServiceMonitorFailed", fmt.Sprintf("Failed to reconcile ServiceMonitor: %v", err), corev1.ConditionTrue)
-		} else {
-			instance.SetStatus("MonitoringDegraded", "MonitoringReady", "", corev1.ConditionFalse)
+	err = tracing.WithPhase(ctx, spanReconcileRBAC, func(ctx context.Context) error {
+		if err := r.createServiceAccount(ctx, instance); err != nil {
+			log.Error(err, "Failed to create ServiceAccount")
+			instance.SetStatus("Ready", "Error", fmt.Sprintf("Failed to create ServiceAccount: %v", err), corev1.ConditionFalse)
+			r.Status().Update(ctx, instance)
+			return err
 		}
-	} else {
-		log.Info("ServiceMonitor CRD not available on this cluster, skipping monitoring reconciliation")
+		if err := r.createJobsServiceAccount(ctx, instance, instance.Namespace); err != nil {
+			log.Error(err, "Failed to create job ServiceAccount")
+			instance.SetStatus("Ready", "Error", fmt.Sprintf("Failed to create job ServiceAccount: %v", err), corev1.ConditionFalse)
+			r.Status().Update(ctx, instance)
+			return err
+		}
+		if err := r.reconcileTenantNamespaces(ctx, instance); err != nil {
+			log.Error(err, "Failed to reconcile tenant namespaces")
+			instance.SetStatus("Ready", "Error", fmt.Sprintf("Failed to reconcile tenant namespaces: %v", err), corev1.ConditionFalse)
+			r.Status().Update(ctx, instance)
+			return err
+		}
+		if err := r.reconcileSingleTenancyRoles(ctx, instance); err != nil {
+			log.Error(err, "Failed to reconcile single-tenancy roles")
+			instance.SetStatus("Ready", "Error", fmt.Sprintf("Failed to reconcile single-tenancy roles: %v", err), corev1.ConditionFalse)
+			r.Status().Update(ctx, instance)
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return RequeueWithError(err)
 	}
 
-	// Reconcile Route (if on OpenShift and enabled)
-	if err := r.reconcileRoute(ctx, instance); err != nil {
-		log.Error(err, "Failed to reconcile Route")
-		// Log warning but don't update status - Route is optional (OpenShift only)
-		// The Ready status will be determined by updateStatus based on deployment readiness
-		// Route errors are not fatal, continue
+	err = tracing.WithPhase(ctx, spanReconcileConfigMap, func(ctx context.Context) error {
+		if err := r.reconcileConfigMap(ctx, instance); err != nil {
+			log.Error(err, "Failed to reconcile ConfigMap")
+			instance.SetStatus("Ready", "Error", fmt.Sprintf("Failed to reconcile ConfigMap: %v", err), corev1.ConditionFalse)
+			r.Status().Update(ctx, instance)
+			return err
+		}
+		if err := r.reconcileServiceCAConfigMap(ctx, instance); err != nil {
+			log.Error(err, "Failed to reconcile Service CA ConfigMap")
+			instance.SetStatus("Ready", "Error", fmt.Sprintf("Failed to reconcile Service CA ConfigMap: %v", err), corev1.ConditionFalse)
+			r.Status().Update(ctx, instance)
+			return err
+		}
+		var reconcileErr error
+		providerCMNames, reconcileErr = r.reconcileProviderConfigMaps(ctx, instance)
+		if reconcileErr != nil {
+			log.Error(reconcileErr, "Failed to reconcile Provider ConfigMaps")
+			instance.SetStatus("Ready", "Error", fmt.Sprintf("Failed to reconcile Provider ConfigMaps: %v", reconcileErr), corev1.ConditionFalse)
+			r.Status().Update(ctx, instance)
+			return reconcileErr
+		}
+		instance.Status.ActiveProviders = instance.Spec.Providers
+		collectionCMNames, reconcileErr = r.reconcileCollectionConfigMaps(ctx, instance)
+		if reconcileErr != nil {
+			log.Error(reconcileErr, "Failed to reconcile Collection ConfigMaps")
+			instance.SetStatus("Ready", "Error", fmt.Sprintf("Failed to reconcile Collection ConfigMaps: %v", reconcileErr), corev1.ConditionFalse)
+			r.Status().Update(ctx, instance)
+			return reconcileErr
+		}
+		instance.Status.ActiveCollections = instance.Spec.Collections
+		tenantProviderCMNames, reconcileErr = r.reconcileTenantProviderConfigMaps(ctx, instance)
+		if reconcileErr != nil {
+			log.Error(reconcileErr, "Failed to reconcile tenant Provider ConfigMaps")
+			instance.SetStatus("Ready", "Error", fmt.Sprintf("Failed to reconcile tenant Provider ConfigMaps: %v", reconcileErr), corev1.ConditionFalse)
+			r.Status().Update(ctx, instance)
+			return reconcileErr
+		}
+		tenantCollectionCMNames, reconcileErr = r.reconcileTenantCollectionConfigMaps(ctx, instance)
+		if reconcileErr != nil {
+			log.Error(reconcileErr, "Failed to reconcile tenant Collection ConfigMaps")
+			instance.SetStatus("Ready", "Error", fmt.Sprintf("Failed to reconcile tenant Collection ConfigMaps: %v", reconcileErr), corev1.ConditionFalse)
+			r.Status().Update(ctx, instance)
+			return reconcileErr
+		}
+		return nil
+	})
+	if err != nil {
+		return RequeueWithError(err)
 	}
 
-	// Reconcile optional MCP resources. Failures are recorded on status.mcp only; EvalHub API
-	// readiness is determined from the main deployment in updateStatus.
+	err = tracing.WithPhase(ctx, spanReconcileDeployment, func(ctx context.Context) error {
+		if err := r.reconcileDeployment(ctx, instance, providerCMNames, collectionCMNames, tenantProviderCMNames, tenantCollectionCMNames); err != nil {
+			log.Error(err, "Failed to reconcile Deployment")
+			instance.SetStatus("Ready", "Error", fmt.Sprintf("Failed to reconcile Deployment: %v", err), corev1.ConditionFalse)
+			r.Status().Update(ctx, instance)
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return RequeueWithError(err)
+	}
+
+	err = tracing.WithPhase(ctx, spanReconcileService, func(ctx context.Context) error {
+		if err := r.reconcileService(ctx, instance); err != nil {
+			log.Error(err, "Failed to reconcile Service")
+			instance.SetStatus("Ready", "Error", fmt.Sprintf("Failed to reconcile Service: %v", err), corev1.ConditionFalse)
+			r.Status().Update(ctx, instance)
+			return err
+		}
+		if err := r.reconcileMetricsService(ctx, instance); err != nil {
+			log.Error(err, "Failed to reconcile metrics Service")
+			instance.SetStatus("Ready", "Error", fmt.Sprintf("Failed to reconcile metrics Service: %v", err), corev1.ConditionFalse)
+			r.Status().Update(ctx, instance)
+			return err
+		}
+		if r.isServiceMonitorSupported() {
+			if err := r.reconcileServiceMonitor(ctx, instance); err != nil {
+				log.Error(err, "Failed to reconcile ServiceMonitor")
+				instance.SetStatus("MonitoringDegraded", "ServiceMonitorFailed", fmt.Sprintf("Failed to reconcile ServiceMonitor: %v", err), corev1.ConditionTrue)
+			} else {
+				instance.SetStatus("MonitoringDegraded", "MonitoringReady", "", corev1.ConditionFalse)
+			}
+		} else {
+			log.Info("ServiceMonitor CRD not available on this cluster, skipping monitoring reconciliation")
+		}
+		return nil
+	})
+	if err != nil {
+		return RequeueWithError(err)
+	}
+
+	_ = tracing.WithPhase(ctx, spanReconcileRoute, func(ctx context.Context) error {
+		if err := r.reconcileRoute(ctx, instance); err != nil {
+			log.Error(err, "Failed to reconcile Route")
+		}
+		return nil
+	})
+
 	mcpReconcileOK := true
 	if instance.Spec.IsMCPEnabled() {
-		mcpReconcileOK = r.reconcileMCPServer(ctx, instance)
+		_ = tracing.WithPhase(ctx, spanReconcileMCP, func(ctx context.Context) error {
+			mcpReconcileOK = r.reconcileMCPServer(ctx, instance)
+			return nil
+		})
 	}
 
-	// Check deployment status and update EvalHub status
-	if err := r.updateStatus(ctx, instance, mcpReconcileOK); err != nil {
-		log.Error(err, "Failed to update EvalHub status")
+	err = tracing.WithPhase(ctx, spanReconcileStatus, func(ctx context.Context) error {
+		if err := r.updateStatus(ctx, instance, mcpReconcileOK); err != nil {
+			log.Error(err, "Failed to update EvalHub status")
+			return err
+		}
+		return nil
+	})
+	if err != nil {
 		return RequeueWithError(err)
 	}
 

--- a/controllers/evalhub/evaluation_job_failure_reconciler.go
+++ b/controllers/evalhub/evaluation_job_failure_reconciler.go
@@ -21,6 +21,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/trustyai-explainability/trustyai-service-operator/pkg/tracing"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -77,9 +80,9 @@ const (
 // Job lifecycle label and annotation stamped by the operator on infrastructure failures.
 // The same label is also set by the EvalHub server; the operator checks it to prevent duplicate Events.
 const (
-	labelEvaluationPhase        = "trustyai.opendatahub.io/evaluation-phase"
-	labelEvaluationPhaseFailed  = "Failed"
-	annotationEvaluationStatus  = "trustyai.opendatahub.io/evaluation-status"
+	labelEvaluationPhase       = "trustyai.opendatahub.io/evaluation-phase"
+	labelEvaluationPhaseFailed = "Failed"
+	annotationEvaluationStatus = "trustyai.opendatahub.io/evaluation-status"
 	// eventReasonEvaluationFailed matches the reason used by server-emitted Events; source.component
 	// distinguishes operator vs server (set automatically by the EventRecorder).
 	eventReasonEvaluationFailed = "EvaluationFailed"
@@ -321,7 +324,7 @@ func podOwnedByJob(pod *corev1.Pod) bool {
 	return jobNameFromPodOwner(pod) != ""
 }
 
-func (r *EvalHubEvaluationJobFailureReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *EvalHubEvaluationJobFailureReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	log := log.FromContext(ctx)
 	log.Info("reconcile start",
 		append(failureWatcherLogFields(), "action", "reconcile", "namespace", req.Namespace, "name", req.Name)...)
@@ -336,8 +339,22 @@ func (r *EvalHubEvaluationJobFailureReconciler) Reconcile(ctx context.Context, r
 	if !r.tenantNS.IsTenant(job.Namespace) {
 		return ctrl.Result{}, nil
 	}
+
+	ctx, span := tracing.StartReconcileSpan(ctx, evalHubTracerName, spanJobFailureReconcile,
+		attribute.String("k8s.namespace", job.Namespace),
+		attribute.String("evalhub.job.name", job.Name),
+	)
+	defer func() {
+		finishEvalHubReconcileSpan(span, result, err)
+		span.End()
+	}()
+
+	setJobFailureAction := func(action string) {
+		span.SetAttributes(attribute.String("evalhub.job_failure.action", action))
+	}
+
 	if failureAlreadyReported(&job) {
-		// POST succeeded in a prior reconcile; ensure the Job is removed (delete may have failed after patch).
+		setJobFailureAction("delete")
 		if err := r.deleteEvalHubFailureSyncedJob(ctx, &job); err != nil {
 			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 		}
@@ -347,6 +364,7 @@ func (r *EvalHubEvaluationJobFailureReconciler) Reconcile(ctx context.Context, r
 		log.Info("skip: EvalHub server already set failure label",
 			append(failureWatcherLogFields(), "action", "skip_server_handled",
 				"job", job.Name, "namespace", job.Namespace)...)
+		setJobFailureAction("delete")
 		if err := r.deleteEvalHubFailureSyncedJob(ctx, &job); err != nil {
 			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 		}
@@ -360,6 +378,7 @@ func (r *EvalHubEvaluationJobFailureReconciler) Reconcile(ctx context.Context, r
 	if !failed {
 		log.Info("skip EvalHub POST: no operator-only container failure",
 			append(failureWatcherLogFields(), "action", "skip_no_operator_failure", "job", job.Name, "namespace", job.Namespace)...)
+		setJobFailureAction("skip")
 		if requeue := r.pendingSchedulingRequeueAfter(ctx, &job); requeue > 0 {
 			log.Info("pod unschedulable within grace period — requeuing",
 				append(failureWatcherLogFields(), "action", "requeue_scheduling_grace", "job", job.Name, "namespace", job.Namespace, "requeueAfter", requeue)...)
@@ -367,6 +386,14 @@ func (r *EvalHubEvaluationJobFailureReconciler) Reconcile(ctx context.Context, r
 		}
 		return ctrl.Result{}, nil
 	}
+
+	span.SetAttributes(
+		attribute.String("evalhub.job.failure_reason", truncateFailureReason(msg)),
+	)
+	if exitCode, ok := r.exitCodeFromJobPods(ctx, &job); ok {
+		span.SetAttributes(attribute.Int("evalhub.job.exit_code", int(exitCode)))
+	}
+
 	detailForLog := msg
 	if len(detailForLog) > 512 {
 		detailForLog = detailForLog[:512] + "…"
@@ -380,11 +407,13 @@ func (r *EvalHubEvaluationJobFailureReconciler) Reconcile(ctx context.Context, r
 			log.Info("cannot resolve EvalHub URL from job",
 				append(failureWatcherLogFields(), "action", "skip_no_evalhub_url",
 					"job", job.Name, "namespace", job.Namespace, "error", err.Error())...)
+			setJobFailureAction("skip")
 			return ctrl.Result{}, nil
 		}
 		log.Info("cannot resolve EvalHub URL from job",
 			append(failureWatcherLogFields(), "action", "skip_no_evalhub_url",
 				"job", job.Name, "namespace", job.Namespace, "error", err.Error())...)
+		setJobFailureAction("skip")
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
@@ -392,6 +421,7 @@ func (r *EvalHubEvaluationJobFailureReconciler) Reconcile(ctx context.Context, r
 	if jobID == "" {
 		log.Info("skip EvalHub POST: missing job_id label",
 			append(failureWatcherLogFields(), "action", "skip_missing_label", "job", job.Name, "namespace", job.Namespace, "label", evalHubJobIDLabel)...)
+		setJobFailureAction("skip")
 		return ctrl.Result{}, nil
 	}
 
@@ -400,10 +430,13 @@ func (r *EvalHubEvaluationJobFailureReconciler) Reconcile(ctx context.Context, r
 	if providerID == "" || benchmarkID == "" {
 		log.Info("skip EvalHub POST: missing provider_id or benchmark_id label",
 			append(failureWatcherLogFields(), "action", "skip_missing_label", "job", job.Name, "namespace", job.Namespace)...)
+		setJobFailureAction("skip")
 		return ctrl.Result{}, nil
 	}
 
 	benchmarkIndex := benchmarkIndexFromJob(&job)
+
+	setJobFailureAction("post")
 
 	// If failure-pending is already set, the POST succeeded in a prior reconcile but the
 	// promote patch failed. Skip the POST and go straight to the promote patch.
@@ -416,12 +449,15 @@ func (r *EvalHubEvaluationJobFailureReconciler) Reconcile(ctx context.Context, r
 		if err := r.Patch(ctx, &job, pendingPatch); err != nil {
 			log.Error(err, "failed to annotate job pending EvalHub failure sync",
 				append(failureWatcherLogFields(), "action", "patch_pending_failed", "job", job.Name)...)
+			span.SetStatus(codes.Error, err.Error())
 			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 		}
 
 		if err := postEvalHubBenchmarkFailed(ctx, r.RESTConfig, baseURL, job.Namespace, jobID, providerID, benchmarkID, benchmarkIndex, msg, ""); err != nil {
 			log.Error(err, "failed to post EvalHub benchmark failure event",
 				append(failureWatcherLogFields(), "action", "post_events_failed", "job", job.Name, "evalJobID", jobID)...)
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
 			revert := client.MergeFrom(job.DeepCopy())
 			delete(job.Annotations, annotationFailurePending)
 			if len(job.Annotations) == 0 {
@@ -449,11 +485,14 @@ func (r *EvalHubEvaluationJobFailureReconciler) Reconcile(ctx context.Context, r
 	if err := r.Patch(ctx, &job, promotePatch); err != nil {
 		log.Error(err, "failed to promote failure-reported annotation after successful POST",
 			append(failureWatcherLogFields(), "action", "promote_reported_failed", "job", job.Name)...)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	r.EventRecorder.Eventf(&job, corev1.EventTypeWarning, eventReasonEvaluationFailed, "%s", msg)
 
+	setJobFailureAction("delete")
 	if err := r.deleteEvalHubFailureSyncedJob(ctx, &job); err != nil {
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
@@ -496,6 +535,62 @@ func (r *EvalHubEvaluationJobFailureReconciler) detectFailure(ctx context.Contex
 		return true, msg, nil
 	}
 	return false, "", nil
+}
+
+func (r *EvalHubEvaluationJobFailureReconciler) exitCodeFromJobPods(ctx context.Context, job *batchv1.Job) (int32, bool) {
+	list := &corev1.PodList{}
+	if err := r.List(ctx, list, client.InNamespace(job.Namespace), client.MatchingLabels{
+		"batch.kubernetes.io/job-name": job.Name,
+	}); err != nil {
+		return 0, false
+	}
+	for i := range list.Items {
+		pod := &list.Items[i]
+		ownedByJob := false
+		for _, ref := range pod.OwnerReferences {
+			if ref.Kind == "Job" && ref.UID == job.UID {
+				ownedByJob = true
+				break
+			}
+		}
+		if !ownedByJob {
+			continue
+		}
+		if code, ok := exitCodeFromPod(pod); ok {
+			return code, true
+		}
+	}
+	return 0, false
+}
+
+func exitCodeFromPod(pod *corev1.Pod) (int32, bool) {
+	if code, ok := terminatedExitCodeFromContainerStatuses(pod.Status.InitContainerStatuses, initContainerName, true); ok {
+		return code, true
+	}
+	if code, ok := terminatedExitCodeFromContainerStatuses(pod.Status.ContainerStatuses, adapterContainerName, false); ok {
+		return code, true
+	}
+	if code, ok := terminatedExitCodeFromContainerStatuses(pod.Status.ContainerStatuses, sidecarContainerName, true); ok {
+		return code, true
+	}
+	return 0, false
+}
+
+func terminatedExitCodeFromContainerStatuses(statuses []corev1.ContainerStatus, containerName string, initOrSidecar bool) (int32, bool) {
+	for _, cs := range statuses {
+		if cs.Name != containerName || cs.State.Terminated == nil {
+			continue
+		}
+		t := cs.State.Terminated
+		needReport := terminatedInitOrSidecarNeedsOperatorReport(t)
+		if !initOrSidecar {
+			needReport = terminatedAdapterNeedsOperatorReport(t)
+		}
+		if needReport && t.ExitCode != 0 {
+			return t.ExitCode, true
+		}
+	}
+	return 0, false
 }
 
 func (r *EvalHubEvaluationJobFailureReconciler) operatorOnlyFailureFromPods(ctx context.Context, job *batchv1.Job) (string, bool, error) {

--- a/controllers/evalhub/evaluation_job_failure_reconciler.go
+++ b/controllers/evalhub/evaluation_job_failure_reconciler.go
@@ -449,6 +449,7 @@ func (r *EvalHubEvaluationJobFailureReconciler) Reconcile(ctx context.Context, r
 		if err := r.Patch(ctx, &job, pendingPatch); err != nil {
 			log.Error(err, "failed to annotate job pending EvalHub failure sync",
 				append(failureWatcherLogFields(), "action", "patch_pending_failed", "job", job.Name)...)
+			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
 			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 		}

--- a/controllers/evalhub/tracing.go
+++ b/controllers/evalhub/tracing.go
@@ -1,0 +1,48 @@
+package evalhub
+
+import (
+	"context"
+
+	"github.com/trustyai-explainability/trustyai-service-operator/pkg/tracing"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+const evalHubTracerName = "evalhub-controller"
+
+const (
+	spanReconcile           = "evalhub.reconcile"
+	spanReconcileDeletion   = "evalhub.reconcile.deletion"
+	spanReconcileRBAC       = "evalhub.reconcile.rbac"
+	spanReconcileConfigMap  = "evalhub.reconcile.configmap"
+	spanReconcileDeployment = "evalhub.reconcile.deployment"
+	spanReconcileService    = "evalhub.reconcile.service"
+	spanReconcileRoute      = "evalhub.reconcile.route"
+	spanReconcileMCP        = "evalhub.reconcile.mcp"
+	spanReconcileStatus     = "evalhub.reconcile.status"
+	spanJobFailureReconcile = "evalhub.job_failure_reconcile"
+)
+
+func evalHubReconcileAttrs(namespace, name string, generation int64) []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String("k8s.namespace", namespace),
+		attribute.String("evalhub.name", name),
+		attribute.Int64("reconcile.generation", generation),
+	}
+}
+
+func startEvalHubReconcileSpan(ctx context.Context, spanName, namespace, name string, generation int64) (context.Context, trace.Span) {
+	return tracing.StartReconcileSpan(ctx, evalHubTracerName, spanName, evalHubReconcileAttrs(namespace, name, generation)...)
+}
+
+func finishEvalHubReconcileSpan(span trace.Span, result ctrl.Result, err error) {
+	tracing.SetReconcileOutcome(span, result.Requeue, result.RequeueAfter, err)
+}
+
+func truncateFailureReason(msg string) string {
+	if len(msg) <= 512 {
+		return msg
+	}
+	return msg[:512] + "…"
+}

--- a/controllers/evalhub/tracing.go
+++ b/controllers/evalhub/tracing.go
@@ -37,12 +37,15 @@ func startEvalHubReconcileSpan(ctx context.Context, spanName, namespace, name st
 }
 
 func finishEvalHubReconcileSpan(span trace.Span, result ctrl.Result, err error) {
-	tracing.SetReconcileOutcome(span, result.Requeue, result.RequeueAfter, err)
+	tracing.FinishReconcileOutcome(span, !result.IsZero(), result.RequeueAfter, err)
 }
 
+const maxFailureReasonRunes = 512
+
 func truncateFailureReason(msg string) string {
-	if len(msg) <= 512 {
+	runes := []rune(msg)
+	if len(runes) <= maxFailureReasonRunes {
 		return msg
 	}
-	return msg[:512] + "…"
+	return string(runes[:maxFailureReasonRunes]) + "…"
 }

--- a/controllers/evalhub/tracing_test.go
+++ b/controllers/evalhub/tracing_test.go
@@ -1,0 +1,153 @@
+package evalhub
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/trustyai-explainability/trustyai-service-operator/pkg/tracing"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestEvalHubReconcileSpanAttributes(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	ctx, span := startEvalHubReconcileSpan(context.Background(), spanReconcile, "ns-1", "hub-1", 7)
+	span.End()
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+	assert.Equal(t, spanReconcile, spans[0].Name)
+	assert.Equal(t, "ns-1", attrString(spans[0].Attributes, "k8s.namespace"))
+	assert.Equal(t, "hub-1", attrString(spans[0].Attributes, "evalhub.name"))
+	assert.Equal(t, int64(7), attrInt64(spans[0].Attributes, "reconcile.generation"))
+
+	_ = ctx
+}
+
+func TestEvalHubReconcilePhaseSpanOnFailure(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	ctx, parent := startEvalHubReconcileSpan(context.Background(), spanReconcile, "ns-1", "hub-1", 1)
+	phaseErr := errors.New("deployment unavailable")
+	err := tracing.WithPhase(ctx, spanReconcileDeployment, func(context.Context) error {
+		return phaseErr
+	})
+	require.ErrorIs(t, err, phaseErr)
+	parent.End()
+
+	names := spanNames(exporter.GetSpans())
+	assert.Contains(t, names, spanReconcile)
+	assert.Contains(t, names, spanReconcileDeployment)
+}
+
+func TestExitCodeFromPod(t *testing.T) {
+	pod := &corev1.Pod{
+		Status: corev1.PodStatus{
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: initContainerName,
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							Reason:   "Error",
+							ExitCode: 42,
+						},
+					},
+				},
+			},
+		},
+	}
+	code, ok := exitCodeFromPod(pod)
+	require.True(t, ok)
+	assert.Equal(t, int32(42), code)
+}
+
+func TestTruncateFailureReason(t *testing.T) {
+	long := strings.Repeat("a", 600)
+	truncated := truncateFailureReason(long)
+	assert.LessOrEqual(t, len(truncated), 515)
+	assert.True(t, strings.HasSuffix(truncated, "…"))
+}
+
+func attrString(attrs []attribute.KeyValue, key string) string {
+	for _, a := range attrs {
+		if string(a.Key) == key {
+			return a.Value.AsString()
+		}
+	}
+	return ""
+}
+
+func attrInt64(attrs []attribute.KeyValue, key string) int64 {
+	for _, a := range attrs {
+		if string(a.Key) == key {
+			return a.Value.AsInt64()
+		}
+	}
+	return 0
+}
+
+func spanNames(spans tracetest.SpanStubs) []string {
+	names := make([]string, len(spans))
+	for i := range spans {
+		names[i] = spans[i].Name
+	}
+	return names
+}
+
+func TestJobFailureSpanExitCodeAttribute(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-1"},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: sidecarContainerName,
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							Reason:   "Error",
+							ExitCode: 13,
+						},
+					},
+				},
+			},
+		},
+	}
+	code, ok := exitCodeFromPod(pod)
+	require.True(t, ok)
+	assert.Equal(t, int32(13), code)
+
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	_, span := tracing.StartReconcileSpan(context.Background(), evalHubTracerName, spanJobFailureReconcile,
+		attribute.String("k8s.namespace", "tenant-ns"),
+		attribute.String("evalhub.job.name", "job-1"),
+		attribute.String("evalhub.job.failure_reason", "sidecar failed"),
+		attribute.Int("evalhub.job.exit_code", int(code)),
+	)
+	span.End()
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+	assert.Equal(t, spanJobFailureReconcile, spans[0].Name)
+	assert.Equal(t, int64(13), attrInt64(spans[0].Attributes, "evalhub.job.exit_code"))
+
+	_ = batchv1.Job{}
+}

--- a/controllers/evalhub/tracing_test.go
+++ b/controllers/evalhub/tracing_test.go
@@ -11,18 +11,24 @@ import (
 	"github.com/trustyai-explainability/trustyai-service-operator/pkg/tracing"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace/noop"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 func TestEvalHubReconcileSpanAttributes(t *testing.T) {
 	exporter := tracetest.NewInMemoryExporter()
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
 	otel.SetTracerProvider(tp)
-	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	t.Cleanup(func() {
+		otel.SetTracerProvider(noop.NewTracerProvider())
+		_ = tp.Shutdown(context.Background())
+	})
 
 	ctx, span := startEvalHubReconcileSpan(context.Background(), spanReconcile, "ns-1", "hub-1", 7)
 	span.End()
@@ -41,7 +47,10 @@ func TestEvalHubReconcilePhaseSpanOnFailure(t *testing.T) {
 	exporter := tracetest.NewInMemoryExporter()
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
 	otel.SetTracerProvider(tp)
-	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	t.Cleanup(func() {
+		otel.SetTracerProvider(noop.NewTracerProvider())
+		_ = tp.Shutdown(context.Background())
+	})
 
 	ctx, parent := startEvalHubReconcileSpan(context.Background(), spanReconcile, "ns-1", "hub-1", 1)
 	phaseErr := errors.New("deployment unavailable")
@@ -80,8 +89,35 @@ func TestExitCodeFromPod(t *testing.T) {
 func TestTruncateFailureReason(t *testing.T) {
 	long := strings.Repeat("a", 600)
 	truncated := truncateFailureReason(long)
-	assert.LessOrEqual(t, len(truncated), 515)
+	assert.LessOrEqual(t, len([]rune(truncated)), maxFailureReasonRunes+1)
 	assert.True(t, strings.HasSuffix(truncated, "…"))
+
+	unicodeLong := strings.Repeat("é", 600)
+	truncatedUnicode := truncateFailureReason(unicodeLong)
+	assert.Equal(t, maxFailureReasonRunes+1, len([]rune(truncatedUnicode)))
+	assert.True(t, strings.HasSuffix(truncatedUnicode, "…"))
+	withinLimit := strings.Repeat("é", maxFailureReasonRunes)
+	assert.Equal(t, withinLimit, truncateFailureReason(withinLimit))
+}
+
+func TestFinishEvalHubReconcileSpanPreservesExplicitOutcome(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(noop.NewTracerProvider())
+		_ = tp.Shutdown(context.Background())
+	})
+
+	_, span := startEvalHubReconcileSpan(context.Background(), spanReconcile, "ns-1", "hub-1", 1)
+	tracing.SetSpanOutcome(span, "validation_error")
+	finishEvalHubReconcileSpan(span, ctrl.Result{}, errors.New("ignored"))
+	span.End()
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+	assert.Equal(t, "validation_error", attrString(spans[0].Attributes, "reconcile.outcome"))
+	assert.Equal(t, codes.Ok, spans[0].Status.Code)
 }
 
 func attrString(attrs []attribute.KeyValue, key string) string {
@@ -134,7 +170,10 @@ func TestJobFailureSpanExitCodeAttribute(t *testing.T) {
 	exporter := tracetest.NewInMemoryExporter()
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
 	otel.SetTracerProvider(tp)
-	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	t.Cleanup(func() {
+		otel.SetTracerProvider(noop.NewTracerProvider())
+		_ = tp.Shutdown(context.Background())
+	})
 
 	_, span := tracing.StartReconcileSpan(context.Background(), evalHubTracerName, spanJobFailureReconcile,
 		attribute.String("k8s.namespace", "tenant-ns"),

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,15 @@ require (
 )
 
 require (
+	go.opentelemetry.io/otel v1.43.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0
+	go.opentelemetry.io/otel/sdk v1.43.0
+	go.opentelemetry.io/otel/trace v1.43.0
+)
+
+require (
 	cel.dev/expr v0.25.1 // indirect
 	cloud.google.com/go/auth v0.20.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
@@ -34,6 +43,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
+	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
@@ -61,6 +71,7 @@ require (
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/hashicorp/hcl v1.0.1-vault-7 // indirect
 	github.com/kedacore/keda/v2 v2.18.3 // indirect
 	github.com/kubeflow/mpi-operator v0.7.0 // indirect
@@ -91,11 +102,9 @@ require (
 	go.opentelemetry.io/contrib/detectors/gcp v1.43.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 // indirect
-	go.opentelemetry.io/otel v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
-	go.opentelemetry.io/otel/trace v1.43.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a // indirect

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/blendle/zapdriver v1.3.1 h1:C3dydBOWYRiOk+B8X9IVZ5IOe+7cl+tGOexN4QqHfpE=
 github.com/blendle/zapdriver v1.3.1/go.mod h1:mdXfREi6u5MArG4j9fewC+FGnXaBR+T4Ox4J2u4eHCc=
+github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
+github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -209,6 +211,8 @@ github.com/googleapis/google-cloud-go-testing v0.0.0-20210719221736-1c9a4c676720
 github.com/googleapis/google-cloud-go-testing v0.0.0-20210719221736-1c9a4c676720/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz+PMpZ14Jynv3O2Zs=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.1-vault-7 h1:ag5OxFVy3QYTFTJODRzTKVZ6xvdfLLCA1cy/Y6xGI0I=
@@ -352,6 +356,12 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 h1:Oyrsyzu
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0/go.mod h1:C2NGBr+kAB4bk3xtMXfZ94gqFDtg/GkI7e9zqGh5Beg=
 go.opentelemetry.io/otel v1.43.0 h1:mYIM03dnh5zfN7HautFE4ieIig9amkNANT+xcVxAj9I=
 go.opentelemetry.io/otel v1.43.0/go.mod h1:JuG+u74mvjvcm8vj8pI5XiHy1zDeoCS2LB1spIq7Ay0=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 h1:88Y4s2C8oTui1LGM6bTWkw0ICGcOLCAI5l6zsD1j20k=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0/go.mod h1:Vl1/iaggsuRlrHf/hfPJPvVag77kKyvrLeD10kpMl+A=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0 h1:RAE+JPfvEmvy+0LzyUA25/SGawPwIUbZ6u0Wug54sLc=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0/go.mod h1:AGmbycVGEsRx9mXMZ75CsOyhSP6MFIcj/6dnG+vhVjk=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0 h1:3iZJKlCZufyRzPzlQhUIWVmfltrXuGyfjREgGP3UUjc=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0/go.mod h1:/G+nUPfhq2e+qiXMGxMwumDrP5jtzU+mWN7/sjT2rak=
 go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.43.0 h1:TC+BewnDpeiAmcscXbGMfxkO+mwYUwE/VySwvw88PfA=
 go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.43.0/go.mod h1:J/ZyF4vfPwsSr9xJSPyQ4LqtcTPULFR64KwTikGLe+A=
 go.opentelemetry.io/otel/metric v1.43.0 h1:d7638QeInOnuwOONPp4JAOGfbCEpYb+K6DVWvdxGzgM=
@@ -362,6 +372,8 @@ go.opentelemetry.io/otel/sdk/metric v1.43.0 h1:S88dyqXjJkuBNLeMcVPRFXpRw2fuwdvfC
 go.opentelemetry.io/otel/sdk/metric v1.43.0/go.mod h1:C/RJtwSEJ5hzTiUz5pXF1kILHStzb9zFlIEe85bhj6A=
 go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09nk+3A=
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
+go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
+go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/trustyai-explainability/trustyai-service-operator/controllers/constants"
@@ -30,6 +31,8 @@ import (
 const defaultServiceName = "trustyai-service-operator"
 
 type tracerScopeKey struct{}
+
+var explicitReconcileOutcomes sync.Map
 
 // Setup initializes the global TracerProvider. When OTLP is not configured, a noop provider is used.
 func Setup(ctx context.Context) (func(context.Context) error, error) {
@@ -111,6 +114,23 @@ func SetReconcileOutcome(span trace.Span, requeue bool, requeueAfter time.Durati
 func SetSpanOutcome(span trace.Span, outcome string) {
 	span.SetAttributes(attribute.String("reconcile.outcome", outcome))
 	span.SetStatus(codes.Ok, "")
+	if sc := span.SpanContext(); sc.IsValid() {
+		explicitReconcileOutcomes.Store(spanContextKey(sc), struct{}{})
+	}
+}
+
+// FinishReconcileOutcome records reconcile result unless SetSpanOutcome already set an explicit outcome.
+func FinishReconcileOutcome(span trace.Span, requeue bool, requeueAfter time.Duration, err error) {
+	if sc := span.SpanContext(); sc.IsValid() {
+		if _, explicit := explicitReconcileOutcomes.LoadAndDelete(spanContextKey(sc)); explicit {
+			return
+		}
+	}
+	SetReconcileOutcome(span, requeue, requeueAfter, err)
+}
+
+func spanContextKey(sc trace.SpanContext) string {
+	return sc.TraceID().String() + "\x00" + sc.SpanID().String()
 }
 
 func tracerFromContext(ctx context.Context) trace.Tracer {
@@ -147,8 +167,15 @@ func serviceName() string {
 	return defaultServiceName
 }
 
+func otlpProtocol() string {
+	if protocol := strings.TrimSpace(strings.ToLower(os.Getenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"))); protocol != "" {
+		return protocol
+	}
+	return strings.TrimSpace(strings.ToLower(os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL")))
+}
+
 func newOTLPExporter(ctx context.Context) (sdktrace.SpanExporter, error) {
-	protocol := strings.TrimSpace(strings.ToLower(os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL")))
+	protocol := otlpProtocol()
 	if protocol == "http/protobuf" || protocol == "http" {
 		return otlptracehttp.New(ctx)
 	}

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -1,0 +1,156 @@
+// Package tracing provides opt-in OpenTelemetry tracing for the TrustyAI Service Operator.
+//
+// Tracing is disabled unless OTLP export is configured via environment variables:
+//   - OTEL_EXPORTER_OTLP_ENDPOINT (or OTEL_EXPORTER_OTLP_TRACES_ENDPOINT)
+//   - OTEL_EXPORTER_OTLP_PROTOCOL (optional: grpc default, or http/protobuf)
+//   - OTEL_SERVICE_NAME (optional, default: trustyai-service-operator)
+//   - OTEL_SDK_DISABLED=true disables tracing even when an endpoint is set
+package tracing
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/trustyai-explainability/trustyai-service-operator/controllers/constants"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+const defaultServiceName = "trustyai-service-operator"
+
+type tracerScopeKey struct{}
+
+// Setup initializes the global TracerProvider. When OTLP is not configured, a noop provider is used.
+func Setup(ctx context.Context) (func(context.Context) error, error) {
+	if !tracingEnabled() {
+		otel.SetTracerProvider(noop.NewTracerProvider())
+		return func(context.Context) error { return nil }, nil
+	}
+
+	exporter, err := newOTLPExporter(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("create OTLP trace exporter: %w", err)
+	}
+
+	res, err := resource.Merge(
+		resource.Default(),
+		resource.NewWithAttributes(
+			semconv.SchemaURL,
+			semconv.ServiceName(serviceName()),
+			semconv.ServiceVersion(constants.Version),
+		),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create trace resource: %w", err)
+	}
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exporter),
+		sdktrace.WithResource(res),
+	)
+	otel.SetTracerProvider(tp)
+	return tp.Shutdown, nil
+}
+
+// Tracer returns a named tracer from the global TracerProvider.
+func Tracer(name string) trace.Tracer {
+	return otel.Tracer(name)
+}
+
+// StartReconcileSpan starts a parent reconcile span and stores the tracer scope in ctx.
+func StartReconcileSpan(ctx context.Context, tracerName, spanName string, attrs ...attribute.KeyValue) (context.Context, trace.Span) {
+	ctx = context.WithValue(ctx, tracerScopeKey{}, tracerName)
+	tracer := otel.Tracer(tracerName)
+	return tracer.Start(ctx, spanName, trace.WithAttributes(attrs...))
+}
+
+// WithPhase runs fn inside a child span using the tracer scope from ctx.
+func WithPhase(ctx context.Context, spanName string, fn func(context.Context) error) error {
+	tracer := tracerFromContext(ctx)
+	ctx, span := tracer.Start(ctx, spanName)
+	defer span.End()
+
+	if err := fn(ctx); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	return nil
+}
+
+// SetReconcileOutcome records the reconcile result on the parent span.
+func SetReconcileOutcome(span trace.Span, requeue bool, requeueAfter time.Duration, err error) {
+	outcome := "success"
+	if err != nil {
+		outcome = "error"
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	} else if requeue || requeueAfter > 0 {
+		outcome = "requeue"
+		if requeueAfter > 0 {
+			span.SetAttributes(attribute.String("reconcile.requeue_after", requeueAfter.String()))
+		}
+	} else {
+		span.SetStatus(codes.Ok, "")
+	}
+	span.SetAttributes(attribute.String("reconcile.outcome", outcome))
+}
+
+// SetSpanOutcome sets reconcile.outcome without treating the span as an error (e.g. validation halt).
+func SetSpanOutcome(span trace.Span, outcome string) {
+	span.SetAttributes(attribute.String("reconcile.outcome", outcome))
+	span.SetStatus(codes.Ok, "")
+}
+
+func tracerFromContext(ctx context.Context) trace.Tracer {
+	name, _ := ctx.Value(tracerScopeKey{}).(string)
+	if name == "" {
+		name = defaultServiceName
+	}
+	return otel.Tracer(name)
+}
+
+func tracingEnabled() bool {
+	if sdkDisabled() {
+		return false
+	}
+	return otlpEndpoint() != ""
+}
+
+func sdkDisabled() bool {
+	v := strings.TrimSpace(strings.ToLower(os.Getenv("OTEL_SDK_DISABLED")))
+	return v == "true" || v == "1"
+}
+
+func otlpEndpoint() string {
+	if ep := strings.TrimSpace(os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")); ep != "" {
+		return ep
+	}
+	return strings.TrimSpace(os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"))
+}
+
+func serviceName() string {
+	if name := strings.TrimSpace(os.Getenv("OTEL_SERVICE_NAME")); name != "" {
+		return name
+	}
+	return defaultServiceName
+}
+
+func newOTLPExporter(ctx context.Context) (sdktrace.SpanExporter, error) {
+	protocol := strings.TrimSpace(strings.ToLower(os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL")))
+	if protocol == "http/protobuf" || protocol == "http" {
+		return otlptracehttp.New(ctx)
+	}
+	return otlptracegrpc.New(ctx)
+}

--- a/pkg/tracing/tracing_test.go
+++ b/pkg/tracing/tracing_test.go
@@ -76,6 +76,29 @@ func TestSetReconcileOutcome(t *testing.T) {
 	assert.Equal(t, "30s", attrValue(spans[0].Attributes, "reconcile.requeue_after"))
 }
 
+func TestOtlpProtocolTraceSpecificWins(t *testing.T) {
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "http/protobuf")
+	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+	assert.Equal(t, "http/protobuf", otlpProtocol())
+}
+
+func TestFinishReconcileOutcomePreservesExplicitOutcome(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	_, span := Tracer("test").Start(context.Background(), "reconcile")
+	SetSpanOutcome(span, "invalid_placement")
+	FinishReconcileOutcome(span, true, 0, errors.New("ignored"))
+	span.End()
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+	assert.Equal(t, "invalid_placement", attrValue(spans[0].Attributes, "reconcile.outcome"))
+	assert.Equal(t, codes.Ok, spans[0].Status.Code)
+}
+
 func attrValue(attrs []attribute.KeyValue, key string) string {
 	for _, a := range attrs {
 		if string(a.Key) == key {

--- a/pkg/tracing/tracing_test.go
+++ b/pkg/tracing/tracing_test.go
@@ -1,0 +1,86 @@
+package tracing
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestSetupWithoutEndpointUsesNoopProvider(t *testing.T) {
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+	t.Setenv("OTEL_SDK_DISABLED", "")
+
+	shutdown, err := Setup(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = shutdown(context.Background()) })
+
+	_, span := Tracer("test").Start(context.Background(), "noop-span")
+	span.End()
+	assert.False(t, span.SpanContext().IsValid())
+}
+
+func TestWithPhaseRecordsErrorStatus(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	const tracerName = "test-controller"
+	ctx, parent := StartReconcileSpan(context.Background(), tracerName, "parent")
+
+	phaseErr := errors.New("deployment failed")
+	err := WithPhase(ctx, "child.phase", func(context.Context) error {
+		return phaseErr
+	})
+	require.ErrorIs(t, err, phaseErr)
+	parent.End()
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 2)
+
+	var child *tracetest.SpanStub
+	for i := range spans {
+		if spans[i].Name == "child.phase" {
+			child = &spans[i]
+			break
+		}
+	}
+	require.NotNil(t, child)
+	assert.Equal(t, codes.Error, child.Status.Code)
+	assert.Contains(t, child.Status.Description, "deployment failed")
+}
+
+func TestSetReconcileOutcome(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	_, span := Tracer("test").Start(context.Background(), "reconcile")
+	SetReconcileOutcome(span, false, 30*time.Second, nil)
+	span.End()
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+	assert.Equal(t, "requeue", attrValue(spans[0].Attributes, "reconcile.outcome"))
+	assert.Equal(t, "30s", attrValue(spans[0].Attributes, "reconcile.requeue_after"))
+}
+
+func attrValue(attrs []attribute.KeyValue, key string) string {
+	for _, a := range attrs {
+		if string(a.Key) == key {
+			return a.Value.AsString()
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary

- Add opt-in OpenTelemetry tracing for the EvalHub operator controller via standard `OTEL_*` environment variables (no manifest or CLI changes).
- Introduce `pkg/tracing` bootstrap with noop provider when OTLP is not configured, and instrument `EvalHubReconciler` with parent/child reconcile spans (`evalhub.reconcile` + phase children per [RHAISTRAT-1606](https://redhat.atlassian.net/browse/RHAISTRAT-1606)).
- Instrument `EvalHubEvaluationJobFailureReconciler` with `evalhub.job_failure_reconcile` spans and document operator vs workload OTEL in `controllers/evalhub/OTEL_TRACING.md`.

Closes [RHAI-241](https://redhat.atlassian.net/browse/RHAI-241).

## Changes to `cmd/main.go`

This PR wires operator-wide tracing bootstrap into the manager entrypoint and adjusts startup flow so tracing can shut down cleanly on every exit path.

### OpenTelemetry bootstrap

After logger setup and flag parsing, `run()` calls `tracing.Setup(context.Background())` from `pkg/tracing`. That function:

- Installs a **noop** `TracerProvider` when OTLP is not configured (no endpoint env vars, or `OTEL_SDK_DISABLED=true`), so there is no runtime overhead when tracing is off.
- Creates an OTLP trace exporter and batching `TracerProvider` when `OTEL_EXPORTER_OTLP_ENDPOINT` or `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` is set.

On success, `run()` registers a deferred shutdown callback:

```go
defer func() {
    if err := traceShutdown(context.Background()); err != nil {
        setupLog.Error(err, "problem shutting down OpenTelemetry tracing")
    }
}()
```

This flushes and shuts down the SDK exporter when the process exits normally or after a startup failure.

### `main()` / `run()` refactor

Startup logic was moved from `main()` into `run() int`, with `main()` reduced to:

```go
func main() {
    os.Exit(run())
}
```

All previous `os.Exit(1)` calls inside startup (missing services, TLS resolution failure, manager/webhook/controller setup errors, health check registration, manager start failure) now `return 1` instead.

**Why:** Calling `os.Exit` directly skips deferred functions in the current goroutine. Returning an exit code to `main()` ensures the `traceShutdown` defer runs on every failure path after tracing has been initialized, while preserving existing log messages and exit semantics.

Tracing setup failure itself returns `1` before the defer is registered (no provider was installed), matching prior behavior.

### Operational impact

- No new CLI flags or Deployment manifest changes are required for tracing; configuration remains env-var driven (`OTEL_*`).
- When OTLP is not configured, operator behavior is unchanged aside from the noop provider registration at startup.
- Tracing is process-global: the bootstrap in `cmd/main.go` enables any controller using `pkg/tracing`, not only EvalHub (though only EvalHub is instrumented in this PR).

## Test plan

- [x] `go test ./pkg/tracing/... ./controllers/evalhub/... -run 'Tracing|TestEvalHubReconcile|TestExitCode|TestTruncate|TestJobFailure|TestSetup|TestWithPhase|TestSetReconcile'`
- [ ] Deploy operator with `OTEL_EXPORTER_OTLP_ENDPOINT` set and confirm spans appear in OTLP backend
- [ ] Confirm noop behavior when OTLP env vars are unset


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in OpenTelemetry tracing for application startup and EvalHub reconciliation.
  * Added support for tracing reconciliation phases, failures, actions, outcomes, and relevant job or pod details.
  * Supports OTLP exporters over gRPC or HTTP, service-name overrides, and configurable tracing behavior.

* **Documentation**
  * Added setup, configuration, deployment, verification, and troubleshooting guidance for tracing.

* **Tests**
  * Added coverage for tracing setup, span attributes, failure reporting, outcomes, and exit-code detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->