### PR TITLE
feat(evalhub): add EvalHub controller OTLP metrics (stacked on RHAI-241)

### DIFF
--- a/controllers/evalhub/OTEL_METRICS.md
+++ b/controllers/evalhub/OTEL_METRICS.md
@@ -1,0 +1,117 @@
+# EvalHub controller OTLP metrics
+
+This document describes how to enable OpenTelemetry (OTEL) **metrics** export for the **TrustyAI Service Operator** when running the EvalHub controller.
+
+**Related work:** [RHAI-241](https://redhat.atlassian.net/browse/RHAI-241) (controller tracing, PR #877), [RHAI-240](https://redhat.atlassian.net/browse/RHAI-240) (Prometheus metrics on `:8080` — separate delivery path).
+
+---
+
+## Operator OTLP metrics vs other observability signals
+
+| Layer | Signal | Delivery | Configuration |
+| ----- | ------ | -------- | ------------- |
+| **Operator controller** (this document) | OTLP metrics | Push to OTLP collector | `OTEL_EXPORTER_OTLP_METRICS_*` env vars on operator Deployment |
+| **Operator controller** | OTLP traces | Push to OTLP collector | `OTEL_EXPORTER_OTLP_TRACES_*` env vars — see [OTEL_TRACING.md](OTEL_TRACING.md) |
+| **Operator controller** | Prometheus metrics | Scrape `:8080/metrics` | controller-runtime defaults (RHAI-240 scope) |
+| **EvalHub server** (workload) | OTLP traces/metrics/logs | Push from EvalHub process | `spec.otel` on EvalHub CR |
+
+Traces and OTLP metrics can be enabled independently. Configuring `spec.otel` on an EvalHub instance does **not** enable operator controller metrics.
+
+---
+
+## Enabling operator OTLP metrics
+
+Metrics export is **opt-in**. By default the operator uses a noop meter and exports nothing. Metrics are pushed outbound to an OTLP collector; no new ports are opened on the operator pod.
+
+### Required configuration
+
+Set at least one of these on the operator manager container:
+
+| Variable | Required | Description |
+| -------- | -------- | ----------- |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Yes* | Shared OTLP collector host:port (e.g. `otel-collector.openshift-operators.svc:4317`) |
+| `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | Yes* | Metrics-specific endpoint; takes precedence over `OTEL_EXPORTER_OTLP_ENDPOINT` when set |
+
+\*Metrics export stays disabled when neither endpoint variable is set.
+
+### Optional configuration
+
+| Variable | Default | Description |
+| -------- | ------- | ----------- |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc` | Default protocol for OTLP exporters |
+| `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL` | falls back to `OTEL_EXPORTER_OTLP_PROTOCOL` | Metrics-specific protocol (`grpc` or `http/protobuf`) |
+| `OTEL_SERVICE_NAME` | `trustyai-service-operator` | `service.name` resource attribute |
+| `OTEL_SDK_DISABLED` | unset | Set to `true` or `1` to disable metrics and traces |
+
+### Example: patch the operator Deployment
+
+```bash
+kubectl patch deployment trustyai-service-operator-controller-manager -n opendatahub --type='json' -p='[
+  {"op": "add", "path": "/spec/template/spec/containers/0/env/-", "value": {
+    "name": "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+    "value": "otel-collector.openshift-operators.svc:4317"
+  }},
+  {"op": "add", "path": "/spec/template/spec/containers/0/env/-", "value": {
+    "name": "OTEL_SERVICE_NAME",
+    "value": "trustyai-service-operator"
+  }}
+]'
+```
+
+To export both traces and metrics to the same collector, set `OTEL_EXPORTER_OTLP_ENDPOINT` once (or set trace- and metrics-specific endpoints separately).
+
+---
+
+## Exported metrics
+
+Instrumentation scope: `evalhub-controller`.
+
+| Instrument | Type | Attributes | When recorded |
+| ---------- | ---- | ---------- | ------------- |
+| `evalhub.controller.reconcile.duration` | Histogram (seconds) | `controller`, `result` | End of each reconcile cycle |
+| `evalhub.controller.reconcile.total` | Counter | `controller`, `result` | End of each reconcile cycle |
+| `evalhub.controller.reconcile.errors` | Counter | `controller`, `error_type` | Reconcile cycles with `result=error` |
+| `evalhub.controller.managed_instances` | UpDownCounter | — | Finalizer added (+1) / removed on successful deletion (-1) |
+| `evalhub.controller.job_failure.events` | Counter | `failure_reason` | After successful EvalHub failure POST |
+
+### Controller labels
+
+| `controller` value | Source |
+| ------------------ | ------ |
+| `evalhub` | Main `EvalHubReconciler` reconcile loop |
+| `evalhub_deletion` | EvalHub finalizer cleanup |
+| `job_failure` | `EvalHubEvaluationJobFailureReconciler` |
+
+### Result labels
+
+`success`, `requeue`, `error`, `validation_error`, `invalid_placement` (explicit outcomes preserved from tracing).
+
+### Error type labels (fixed enum)
+
+`get`, `validation`, `placement`, `rbac`, `configmap`, `deployment`, `service`, `route`, `status`, `job_failure`, `not_found`, `conflict`, `timeout`, `other`.
+
+### Failure reason labels (bounded)
+
+`init`, `adapter`, `sidecar`, `scheduling`, `other`.
+
+---
+
+## Technical implementation
+
+| File | Role |
+| ---- | ---- |
+| [`pkg/tracing/tracing.go`](../../pkg/tracing/tracing.go) | Shared OTEL bootstrap for traces and metrics |
+| [`controllers/evalhub/metrics.go`](metrics.go) | EvalHub OTEL instruments and recording helpers |
+| [`controllers/evalhub/tracing.go`](tracing.go) | Shared reconcile completion (`finishEvalHubReconcileSpan`) |
+| [`controllers/evalhub/evalhub_controller.go`](evalhub_controller.go) | Reconcile timing and managed-instance tracking |
+| [`controllers/evalhub/evaluation_job_failure_reconciler.go`](evaluation_job_failure_reconciler.go) | Job failure event counter |
+
+### Managed instances counter
+
+The managed-instances UpDownCounter increments when the EvalHub finalizer is first added and decrements after successful finalizer removal. It may reset to zero on operator restart until reconciles run again; use cluster-level EvalHub CR counts for authoritative inventory if needed.
+
+### Tests
+
+```bash
+go test ./pkg/tracing/... ./controllers/evalhub/... -run 'Metric|Tracing|Reconcile|Record|Classify'
+```

--- a/controllers/evalhub/OTEL_METRICS.md
+++ b/controllers/evalhub/OTEL_METRICS.md
@@ -68,8 +68,8 @@ Instrumentation scope: `evalhub-controller`.
 
 | Instrument | Type | Attributes | When recorded |
 | ---------- | ---- | ---------- | ------------- |
-| `evalhub.controller.reconcile.duration` | Histogram (seconds) | `controller`, `result` | End of each reconcile cycle |
-| `evalhub.controller.reconcile.total` | Counter | `controller`, `result` | End of each reconcile cycle |
+| `evalhub.controller.reconcile.duration` | Histogram (seconds) | `controller`, `result` | End of each reconcile cycle (includes initial resource fetch) |
+| `evalhub.controller.reconcile.total` | Counter | `controller`, `result` | End of each reconcile cycle (includes initial resource fetch) |
 | `evalhub.controller.reconcile.errors` | Counter | `controller`, `error_type` | Reconcile cycles with `result=error` |
 | `evalhub.controller.managed_instances` | UpDownCounter | — | Finalizer added (+1) / removed on successful deletion (-1) |
 | `evalhub.controller.job_failure.events` | Counter | `failure_reason` | After successful EvalHub failure POST |
@@ -108,7 +108,7 @@ Instrumentation scope: `evalhub-controller`.
 
 ### Managed instances counter
 
-The managed-instances UpDownCounter increments when the EvalHub finalizer is first added and decrements after successful finalizer removal. It may reset to zero on operator restart until reconciles run again; use cluster-level EvalHub CR counts for authoritative inventory if needed.
+The managed-instances UpDownCounter increments when the EvalHub finalizer is first added and decrements only after successful finalizer removal (guarded by `res.IsZero()` and absence of the finalizer to prevent double-decrement on multi-step deletion). It may reset to zero on operator restart until reconciles run again; use cluster-level EvalHub CR counts for authoritative inventory if needed.
 
 ### Tests
 

--- a/controllers/evalhub/OTEL_METRICS.md
+++ b/controllers/evalhub/OTEL_METRICS.md
@@ -71,7 +71,7 @@ Instrumentation scope: `evalhub-controller`.
 | `evalhub.controller.reconcile.duration` | Histogram (seconds) | `controller`, `result` | End of each reconcile cycle (includes initial resource fetch) |
 | `evalhub.controller.reconcile.total` | Counter | `controller`, `result` | End of each reconcile cycle (includes initial resource fetch) |
 | `evalhub.controller.reconcile.errors` | Counter | `controller`, `error_type` | Reconcile cycles with `result=error` |
-| `evalhub.controller.managed_instances` | UpDownCounter | — | Finalizer added (+1) / removed on successful deletion (-1) |
+| `evalhub.controller.managed_instances` | Gauge | — | Each metrics collection (lists EvalHub CRs with active finalizers) |
 | `evalhub.controller.job_failure.events` | Counter | `failure_reason` | After successful EvalHub failure POST |
 
 ### Controller labels
@@ -108,7 +108,7 @@ Instrumentation scope: `evalhub-controller`.
 
 ### Managed instances counter
 
-The managed-instances UpDownCounter increments when the EvalHub finalizer is first added and decrements only after successful finalizer removal (guarded by `res.IsZero()` and absence of the finalizer to prevent double-decrement on multi-step deletion). It may reset to zero on operator restart until reconciles run again; use cluster-level EvalHub CR counts for authoritative inventory if needed.
+The managed-instances gauge uses an observable callback that lists EvalHub CRs with the finalizer present on each metrics collection interval. This always reports the accurate current count regardless of operator restarts — no delta tracking or baseline initialization required.
 
 ### Tests
 

--- a/controllers/evalhub/OTEL_TRACING.md
+++ b/controllers/evalhub/OTEL_TRACING.md
@@ -29,8 +29,8 @@ Set at least one of these on the operator manager container:
 
 | Variable | Required | Description |
 | -------- | -------- | ----------- |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | Yes* | OTLP collector host:port (e.g. `otel-collector.openshift-operators.svc:4317`) |
-| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Yes* | Trace-specific endpoint; takes precedence over `OTEL_EXPORTER_OTLP_ENDPOINT` when set |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Yes* | OTLP collector URL (e.g. `http://otel-collector.openshift-operators.svc:4317` for in-cluster plaintext gRPC; use `https://` for TLS — see below) |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Yes* | Trace-specific endpoint; takes precedence over `OTEL_EXPORTER_OTLP_ENDPOINT` when set (for OTLP/HTTP use the full path, e.g. `http://otel-collector.openshift-operators.svc:4318/v1/traces`) |
 
 \*Tracing stays disabled when neither endpoint variable is set.
 
@@ -44,6 +44,8 @@ Set at least one of these on the operator manager container:
 
 Standard [OTEL SDK environment variables](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/) for headers, TLS, and timeouts are also respected by the OTLP exporters.
 
+**TLS endpoints:** When the collector requires TLS, use `https://` in the endpoint URL and set `OTEL_EXPORTER_OTLP_CERTIFICATE` to the path of the CA bundle (e.g. a mounted Secret or the OpenShift service-CA). For mTLS, also set `OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE` and `OTEL_EXPORTER_OTLP_CLIENT_KEY`.
+
 ### Example: patch the operator Deployment
 
 After deploying the operator (for example into `opendatahub`):
@@ -52,7 +54,7 @@ After deploying the operator (for example into `opendatahub`):
 kubectl patch deployment trustyai-service-operator-controller-manager -n opendatahub --type='json' -p='[
   {"op": "add", "path": "/spec/template/spec/containers/0/env/-", "value": {
     "name": "OTEL_EXPORTER_OTLP_ENDPOINT",
-    "value": "otel-collector.openshift-operators.svc:4317"
+    "value": "http://otel-collector.openshift-operators.svc:4317"
   }},
   {"op": "add", "path": "/spec/template/spec/containers/0/env/-", "value": {
     "name": "OTEL_SERVICE_NAME",
@@ -76,12 +78,19 @@ spec:
         - name: manager
           env:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: "otel-collector.example.svc:4317"
+              value: "http://otel-collector.example.svc:4317"
             - name: OTEL_SERVICE_NAME
               value: "trustyai-service-operator"
             # For OTLP/HTTP collectors:
             # - name: OTEL_EXPORTER_OTLP_PROTOCOL
             #   value: "http/protobuf"
+            # - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            #   value: "http://otel-collector.example.svc:4318"
+            # For TLS (https://) collectors, configure certificate trust:
+            # - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            #   value: "https://otel-collector.example.svc:4317"
+            # - name: OTEL_EXPORTER_OTLP_CERTIFICATE
+            #   value: "/var/run/secrets/otel/ca.crt"
 ```
 
 ### Verifying traces

--- a/controllers/evalhub/OTEL_TRACING.md
+++ b/controllers/evalhub/OTEL_TRACING.md
@@ -2,7 +2,7 @@
 
 This document describes how to enable OpenTelemetry (OTEL) tracing for the **TrustyAI Service Operator** when running the EvalHub controller, and how the instrumentation is implemented.
 
-**Related work:** [RHAI-241](https://redhat.atlassian.net/browse/RHAI-241) (controller tracing), sibling [RHAI-240](https://redhat.atlassian.net/browse/RHAI-240) (Prometheus metrics).
+**Related work:** [RHAI-241](https://redhat.atlassian.net/browse/RHAI-241) (controller tracing), [OTEL_METRICS.md](OTEL_METRICS.md) (controller OTLP metrics), sibling [RHAI-240](https://redhat.atlassian.net/browse/RHAI-240) (Prometheus metrics on `:8080`).
 
 ---
 

--- a/controllers/evalhub/evalhub_controller.go
+++ b/controllers/evalhub/evalhub_controller.go
@@ -100,12 +100,7 @@ func (r *EvalHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 			finishEvalHubReconcileSpan(span, metricControllerDeletion, reconcileStart, result, err)
 			span.End()
 		}()
-		res, delErr := r.handleDeletion(ctx, instance)
-		if delErr == nil && res.IsZero() &&
-			!controllerutil.ContainsFinalizer(instance, evalhubv1.FinalizerName) {
-			recordManagedInstanceDelta(-1)
-		}
-		return res, delErr
+		return r.handleDeletion(ctx, instance)
 	}
 
 	ctx, span := startEvalHubReconcileSpan(ctx, spanReconcile, instance.Namespace, instance.Name, int64(instance.Generation))
@@ -133,7 +128,6 @@ func (r *EvalHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 			log.Error(err, "Failed to add finalizer")
 			return RequeueWithError(err)
 		}
-		recordManagedInstanceDelta(1)
 		return RequeueWithDelay(time.Second * 5)
 	}
 
@@ -374,6 +368,11 @@ func (r *EvalHubReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if err := b.Complete(r); err != nil {
 		return err
 	}
+
+	if err := registerManagedInstancesGauge(r.countManagedInstances); err != nil {
+		return fmt.Errorf("evalhub: register managed_instances gauge: %w", err)
+	}
+
 	tenantNS := newEvalHubTenantNamespaces()
 	if err := tenantNS.bootstrap(context.Background(), mgr.GetAPIReader()); err != nil {
 		return fmt.Errorf("evalhub: bootstrap tenant namespaces: %w", err)
@@ -486,6 +485,20 @@ func RequeueWithError(err error) (ctrl.Result, error) {
 
 func RequeueWithDelay(delay time.Duration) (ctrl.Result, error) {
 	return ctrl.Result{RequeueAfter: delay}, nil
+}
+
+func (r *EvalHubReconciler) countManagedInstances(ctx context.Context) (int64, error) {
+	list := &evalhubv1.EvalHubList{}
+	if err := r.List(ctx, list); err != nil {
+		return 0, err
+	}
+	var count int64
+	for i := range list.Items {
+		if controllerutil.ContainsFinalizer(&list.Items[i], evalhubv1.FinalizerName) {
+			count++
+		}
+	}
+	return count, nil
 }
 
 // handleDeletion handles the deletion of EvalHub resources

--- a/controllers/evalhub/evalhub_controller.go
+++ b/controllers/evalhub/evalhub_controller.go
@@ -95,17 +95,23 @@ func (r *EvalHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 
 	// Handle deletion first to avoid blocking removal with status init.
 	if instance.DeletionTimestamp != nil {
+		reconcileStart := time.Now()
 		ctx, span := startEvalHubReconcileSpan(ctx, spanReconcileDeletion, instance.Namespace, instance.Name, int64(instance.Generation))
 		defer func() {
-			finishEvalHubReconcileSpan(span, result, err)
+			finishEvalHubReconcileSpan(span, metricControllerDeletion, reconcileStart, result, err)
 			span.End()
 		}()
-		return r.handleDeletion(ctx, instance)
+		res, delErr := r.handleDeletion(ctx, instance)
+		if delErr == nil {
+			recordManagedInstanceDelta(-1)
+		}
+		return res, delErr
 	}
 
+	reconcileStart := time.Now()
 	ctx, span := startEvalHubReconcileSpan(ctx, spanReconcile, instance.Namespace, instance.Name, int64(instance.Generation))
 	defer func() {
-		finishEvalHubReconcileSpan(span, result, err)
+		finishEvalHubReconcileSpan(span, metricControllerEvalHub, reconcileStart, result, err)
 		span.End()
 	}()
 
@@ -128,6 +134,7 @@ func (r *EvalHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 			log.Error(err, "Failed to add finalizer")
 			return RequeueWithError(err)
 		}
+		recordManagedInstanceDelta(1)
 		return RequeueWithDelay(time.Second * 5)
 	}
 

--- a/controllers/evalhub/evalhub_controller.go
+++ b/controllers/evalhub/evalhub_controller.go
@@ -76,18 +76,18 @@ type EvalHubReconciler struct {
 // move the current state of the cluster closer to the desired state.
 func (r *EvalHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	log := log.FromContext(ctx)
+	reconcileStart := time.Now()
 
 	// Fetch the EvalHub instance
 	instance := &evalhubv1.EvalHub{}
 	err = r.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			// Request object not found, could have been deleted after reconcile request.
 			log.Info("EvalHub resource not found. Ignoring since object must be deleted")
 			return DoNotRequeue()
 		}
-		// Error reading the object - requeue the request.
 		log.Error(err, "Failed to get EvalHub")
+		recordEvalHubReconcileMetrics(metricControllerEvalHub, "error", err, time.Since(reconcileStart))
 		return RequeueWithError(err)
 	}
 
@@ -95,20 +95,19 @@ func (r *EvalHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 
 	// Handle deletion first to avoid blocking removal with status init.
 	if instance.DeletionTimestamp != nil {
-		reconcileStart := time.Now()
 		ctx, span := startEvalHubReconcileSpan(ctx, spanReconcileDeletion, instance.Namespace, instance.Name, int64(instance.Generation))
 		defer func() {
 			finishEvalHubReconcileSpan(span, metricControllerDeletion, reconcileStart, result, err)
 			span.End()
 		}()
 		res, delErr := r.handleDeletion(ctx, instance)
-		if delErr == nil {
+		if delErr == nil && res.IsZero() &&
+			!controllerutil.ContainsFinalizer(instance, evalhubv1.FinalizerName) {
 			recordManagedInstanceDelta(-1)
 		}
 		return res, delErr
 	}
 
-	reconcileStart := time.Now()
 	ctx, span := startEvalHubReconcileSpan(ctx, spanReconcile, instance.Namespace, instance.Name, int64(instance.Generation))
 	defer func() {
 		finishEvalHubReconcileSpan(span, metricControllerEvalHub, reconcileStart, result, err)

--- a/controllers/evalhub/evaluation_job_failure_reconciler.go
+++ b/controllers/evalhub/evaluation_job_failure_reconciler.go
@@ -344,8 +344,9 @@ func (r *EvalHubEvaluationJobFailureReconciler) Reconcile(ctx context.Context, r
 		attribute.String("k8s.namespace", job.Namespace),
 		attribute.String("evalhub.job.name", job.Name),
 	)
+	reconcileStart := time.Now()
 	defer func() {
-		finishEvalHubReconcileSpan(span, result, err)
+		finishEvalHubReconcileSpan(span, metricControllerJobFailure, reconcileStart, result, err)
 		span.End()
 	}()
 
@@ -470,6 +471,7 @@ func (r *EvalHubEvaluationJobFailureReconciler) Reconcile(ctx context.Context, r
 			}
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
+		recordJobFailureEvent(msg)
 	}
 
 	promotePatch := client.MergeFrom(job.DeepCopy())

--- a/controllers/evalhub/metrics.go
+++ b/controllers/evalhub/metrics.go
@@ -161,7 +161,7 @@ func classifyReconcileError(err error) string {
 	if apierrors.IsConflict(err) {
 		return errorTypeConflict
 	}
-	if apierrors.IsTimeout(err) {
+	if apierrors.IsTimeout(err) || apierrors.IsServerTimeout(err) || apierrors.IsTooManyRequests(err) {
 		return errorTypeTimeout
 	}
 

--- a/controllers/evalhub/metrics.go
+++ b/controllers/evalhub/metrics.go
@@ -51,7 +51,6 @@ type evalHubOTelMetrics struct {
 	reconcileDuration metric.Float64Histogram
 	reconcileTotal    metric.Int64Counter
 	reconcileErrors   metric.Int64Counter
-	managedInstances  metric.Int64UpDownCounter
 	jobFailureEvents  metric.Int64Counter
 }
 
@@ -85,14 +84,6 @@ func getEvalHubMetrics() (evalHubOTelMetrics, error) {
 		evalHubMetrics.reconcileErrors, evalHubMetricsErr = meter.Int64Counter(
 			metricReconcileErrors,
 			metric.WithDescription("Total EvalHub controller reconcile errors by type"),
-		)
-		if evalHubMetricsErr != nil {
-			return
-		}
-
-		evalHubMetrics.managedInstances, evalHubMetricsErr = meter.Int64UpDownCounter(
-			metricManagedInstances,
-			metric.WithDescription("Number of EvalHub custom resources managed by the operator"),
 		)
 		if evalHubMetricsErr != nil {
 			return
@@ -133,12 +124,28 @@ func recordEvalHubReconcileMetrics(controller, outcome string, reconcileErr erro
 	}
 }
 
-func recordManagedInstanceDelta(delta int64) {
-	metrics, err := getEvalHubMetrics()
-	if err != nil {
-		return
-	}
-	metrics.managedInstances.Add(context.Background(), delta)
+// ManagedInstanceCounter is a function that returns the current count of managed EvalHub instances.
+type ManagedInstanceCounter func(ctx context.Context) (int64, error)
+
+// registerManagedInstancesGauge registers an observable gauge that reports the
+// current number of managed EvalHub CRs. The callback queries the cluster on
+// each metrics collection, so the value is always accurate regardless of
+// operator restarts.
+func registerManagedInstancesGauge(counter ManagedInstanceCounter) error {
+	meter := tracing.Meter(evalHubTracerName)
+	_, err := meter.Int64ObservableGauge(
+		metricManagedInstances,
+		metric.WithDescription("Current number of EvalHub custom resources managed by the operator"),
+		metric.WithInt64Callback(func(ctx context.Context, o metric.Int64Observer) error {
+			count, err := counter(ctx)
+			if err != nil {
+				return nil
+			}
+			o.Observe(count)
+			return nil
+		}),
+	)
+	return err
 }
 
 func recordJobFailureEvent(failureReason string) {

--- a/controllers/evalhub/metrics.go
+++ b/controllers/evalhub/metrics.go
@@ -1,0 +1,209 @@
+package evalhub
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/trustyai-explainability/trustyai-service-operator/pkg/tracing"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+const (
+	metricControllerEvalHub    = "evalhub"
+	metricControllerDeletion   = "evalhub_deletion"
+	metricControllerJobFailure = "job_failure"
+
+	metricReconcileDuration = "evalhub.controller.reconcile.duration"
+	metricReconcileTotal    = "evalhub.controller.reconcile.total"
+	metricReconcileErrors   = "evalhub.controller.reconcile.errors"
+	metricManagedInstances  = "evalhub.controller.managed_instances"
+	metricJobFailureEvents  = "evalhub.controller.job_failure.events"
+
+	errorTypeOther      = "other"
+	errorTypeGet        = "get"
+	errorTypeValidation = "validation"
+	errorTypePlacement  = "placement"
+	errorTypeRBAC       = "rbac"
+	errorTypeConfigMap  = "configmap"
+	errorTypeDeployment = "deployment"
+	errorTypeService    = "service"
+	errorTypeRoute      = "route"
+	errorTypeStatus     = "status"
+	errorTypeJobFailure = "job_failure"
+	errorTypeNotFound   = "not_found"
+	errorTypeConflict   = "conflict"
+	errorTypeTimeout    = "timeout"
+
+	failureReasonOther      = "other"
+	failureReasonSidecar    = "sidecar"
+	failureReasonInit       = "init"
+	failureReasonAdapter    = "adapter"
+	failureReasonScheduling = "scheduling"
+)
+
+type evalHubOTelMetrics struct {
+	reconcileDuration metric.Float64Histogram
+	reconcileTotal    metric.Int64Counter
+	reconcileErrors   metric.Int64Counter
+	managedInstances  metric.Int64UpDownCounter
+	jobFailureEvents  metric.Int64Counter
+}
+
+var (
+	evalHubMetrics     evalHubOTelMetrics
+	evalHubMetricsOnce sync.Once
+	evalHubMetricsErr  error
+)
+
+func getEvalHubMetrics() (evalHubOTelMetrics, error) {
+	evalHubMetricsOnce.Do(func() {
+		meter := tracing.Meter(evalHubTracerName)
+
+		evalHubMetrics.reconcileDuration, evalHubMetricsErr = meter.Float64Histogram(
+			metricReconcileDuration,
+			metric.WithDescription("Wall-clock duration of EvalHub controller reconcile cycles in seconds"),
+			metric.WithUnit("s"),
+		)
+		if evalHubMetricsErr != nil {
+			return
+		}
+
+		evalHubMetrics.reconcileTotal, evalHubMetricsErr = meter.Int64Counter(
+			metricReconcileTotal,
+			metric.WithDescription("Total EvalHub controller reconcile cycles"),
+		)
+		if evalHubMetricsErr != nil {
+			return
+		}
+
+		evalHubMetrics.reconcileErrors, evalHubMetricsErr = meter.Int64Counter(
+			metricReconcileErrors,
+			metric.WithDescription("Total EvalHub controller reconcile errors by type"),
+		)
+		if evalHubMetricsErr != nil {
+			return
+		}
+
+		evalHubMetrics.managedInstances, evalHubMetricsErr = meter.Int64UpDownCounter(
+			metricManagedInstances,
+			metric.WithDescription("Number of EvalHub custom resources managed by the operator"),
+		)
+		if evalHubMetricsErr != nil {
+			return
+		}
+
+		evalHubMetrics.jobFailureEvents, evalHubMetricsErr = meter.Int64Counter(
+			metricJobFailureEvents,
+			metric.WithDescription("Evaluation job failure events handled by the operator"),
+		)
+	})
+	return evalHubMetrics, evalHubMetricsErr
+}
+
+func finishEvalHubReconcile(span trace.Span, controller string, start time.Time, result ctrl.Result, err error) {
+	outcome := tracing.FinishReconcileOutcome(span, !result.IsZero(), result.RequeueAfter, err)
+	recordEvalHubReconcileMetrics(controller, outcome, err, time.Since(start))
+}
+
+func recordEvalHubReconcileMetrics(controller, outcome string, reconcileErr error, duration time.Duration) {
+	metrics, err := getEvalHubMetrics()
+	if err != nil {
+		return
+	}
+
+	ctx := context.Background()
+	resultAttrs := metric.WithAttributes(
+		attribute.String("controller", controller),
+		attribute.String("result", outcome),
+	)
+	metrics.reconcileDuration.Record(ctx, duration.Seconds(), resultAttrs)
+	metrics.reconcileTotal.Add(ctx, 1, resultAttrs)
+
+	if reconcileErr != nil && outcome == "error" {
+		metrics.reconcileErrors.Add(ctx, 1, metric.WithAttributes(
+			attribute.String("controller", controller),
+			attribute.String("error_type", classifyReconcileError(reconcileErr)),
+		))
+	}
+}
+
+func recordManagedInstanceDelta(delta int64) {
+	metrics, err := getEvalHubMetrics()
+	if err != nil {
+		return
+	}
+	metrics.managedInstances.Add(context.Background(), delta)
+}
+
+func recordJobFailureEvent(failureReason string) {
+	metrics, err := getEvalHubMetrics()
+	if err != nil {
+		return
+	}
+	metrics.jobFailureEvents.Add(context.Background(), 1, metric.WithAttributes(
+		attribute.String("failure_reason", classifyFailureReason(failureReason)),
+	))
+}
+
+func classifyReconcileError(err error) string {
+	if err == nil {
+		return errorTypeOther
+	}
+	if apierrors.IsNotFound(err) {
+		return errorTypeNotFound
+	}
+	if apierrors.IsConflict(err) {
+		return errorTypeConflict
+	}
+	if apierrors.IsTimeout(err) {
+		return errorTypeTimeout
+	}
+
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "rbac"), strings.Contains(msg, "serviceaccount"), strings.Contains(msg, "rolebinding"), strings.Contains(msg, "clusterrole"):
+		return errorTypeRBAC
+	case strings.Contains(msg, "configmap"):
+		return errorTypeConfigMap
+	case strings.Contains(msg, "deployment"):
+		return errorTypeDeployment
+	case strings.Contains(msg, "service"):
+		return errorTypeService
+	case strings.Contains(msg, "route"):
+		return errorTypeRoute
+	case strings.Contains(msg, "status"):
+		return errorTypeStatus
+	case strings.Contains(msg, "database"), strings.Contains(msg, "validation"), strings.Contains(msg, "spec."):
+		return errorTypeValidation
+	case strings.Contains(msg, "placement"), strings.Contains(msg, "tenant namespace"):
+		return errorTypePlacement
+	case strings.Contains(msg, "job"):
+		return errorTypeJobFailure
+	case strings.Contains(msg, "get "):
+		return errorTypeGet
+	default:
+		return errorTypeOther
+	}
+}
+
+func classifyFailureReason(reason string) string {
+	lower := strings.ToLower(reason)
+	switch {
+	case strings.Contains(lower, initContainerName):
+		return failureReasonInit
+	case strings.Contains(lower, adapterContainerName):
+		return failureReasonAdapter
+	case strings.Contains(lower, sidecarContainerName):
+		return failureReasonSidecar
+	case strings.Contains(lower, "unschedulable"), strings.Contains(lower, "scheduling"):
+		return failureReasonScheduling
+	default:
+		return failureReasonOther
+	}
+}

--- a/controllers/evalhub/metrics_test.go
+++ b/controllers/evalhub/metrics_test.go
@@ -103,17 +103,21 @@ func TestRecordJobFailureEvent(t *testing.T) {
 	assert.Equal(t, failureReasonSidecar, attributeValue(sum.DataPoints[0].Attributes, "failure_reason"))
 }
 
-func TestRecordManagedInstanceDelta(t *testing.T) {
+func TestManagedInstancesGauge(t *testing.T) {
 	reader := setupEvalHubMetricsTest(t)
 
-	recordManagedInstanceDelta(1)
-	recordManagedInstanceDelta(-1)
+	instanceCount := int64(3)
+	err := registerManagedInstancesGauge(func(_ context.Context) (int64, error) {
+		return instanceCount, nil
+	})
+	require.NoError(t, err)
 
 	metrics := collectMetrics(t, reader)
-	sum, ok := metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64])
+	gaugeMetric := findMetricByName(t, metrics.ScopeMetrics[0].Metrics, metricManagedInstances)
+	gauge, ok := gaugeMetric.Data.(metricdata.Gauge[int64])
 	require.True(t, ok)
-	require.Len(t, sum.DataPoints, 1)
-	assert.Equal(t, int64(0), sum.DataPoints[0].Value)
+	require.Len(t, gauge.DataPoints, 1)
+	assert.Equal(t, int64(3), gauge.DataPoints[0].Value)
 }
 
 func findMetricByName(t *testing.T, scopeMetrics []metricdata.Metrics, name string) metricdata.Metrics {

--- a/controllers/evalhub/metrics_test.go
+++ b/controllers/evalhub/metrics_test.go
@@ -1,0 +1,125 @@
+package evalhub
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func resetEvalHubMetricsForTest() {
+	evalHubMetricsOnce = sync.Once{}
+	evalHubMetricsErr = nil
+}
+
+func setupEvalHubMetricsTest(t *testing.T) *sdkmetric.ManualReader {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	otel.SetMeterProvider(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+	resetEvalHubMetricsForTest()
+	t.Cleanup(func() {
+		resetEvalHubMetricsForTest()
+	})
+	return reader
+}
+
+func collectMetrics(t *testing.T, reader *sdkmetric.ManualReader) metricdata.ResourceMetrics {
+	t.Helper()
+	var metrics metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &metrics))
+	return metrics
+}
+
+func TestRecordEvalHubReconcileMetrics(t *testing.T) {
+	reader := setupEvalHubMetricsTest(t)
+
+	recordEvalHubReconcileMetrics(metricControllerEvalHub, "success", nil, 250*time.Millisecond)
+
+	metrics := collectMetrics(t, reader)
+	require.Len(t, metrics.ScopeMetrics, 1)
+	scopeMetrics := metrics.ScopeMetrics[0].Metrics
+	require.Len(t, scopeMetrics, 2)
+
+	assert.Equal(t, metricReconcileDuration, scopeMetrics[0].Name)
+	histogram, ok := scopeMetrics[0].Data.(metricdata.Histogram[float64])
+	require.True(t, ok)
+	require.Len(t, histogram.DataPoints, 1)
+	attrs := histogram.DataPoints[0].Attributes
+	assert.Equal(t, metricControllerEvalHub, attributeValue(attrs, "controller"))
+	assert.Equal(t, "success", attributeValue(attrs, "result"))
+	assert.Equal(t, uint64(1), histogram.DataPoints[0].Count)
+
+	assert.Equal(t, metricReconcileTotal, scopeMetrics[1].Name)
+	total, ok := scopeMetrics[1].Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+	require.Len(t, total.DataPoints, 1)
+	assert.Equal(t, int64(1), total.DataPoints[0].Value)
+}
+
+func TestRecordEvalHubReconcileErrorMetrics(t *testing.T) {
+	reader := setupEvalHubMetricsTest(t)
+
+	recordEvalHubReconcileMetrics(metricControllerEvalHub, "error", assert.AnError, time.Second)
+
+	metrics := collectMetrics(t, reader)
+	scopeMetrics := metrics.ScopeMetrics[0].Metrics
+	require.Len(t, scopeMetrics, 3)
+
+	assert.Equal(t, metricReconcileErrors, scopeMetrics[2].Name)
+	errorsSum, ok := scopeMetrics[2].Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+	require.Len(t, errorsSum.DataPoints, 1)
+	assert.Equal(t, errorTypeOther, attributeValue(errorsSum.DataPoints[0].Attributes, "error_type"))
+}
+
+func TestClassifyFailureReason(t *testing.T) {
+	assert.Equal(t, failureReasonInit, classifyFailureReason("init container failed"))
+	assert.Equal(t, failureReasonAdapter, classifyFailureReason("adapter exited with code 1"))
+	assert.Equal(t, failureReasonSidecar, classifyFailureReason("sidecar crash loop"))
+	assert.Equal(t, failureReasonScheduling, classifyFailureReason("pod unschedulable"))
+	assert.Equal(t, failureReasonOther, classifyFailureReason("unknown failure"))
+}
+
+func TestRecordJobFailureEvent(t *testing.T) {
+	reader := setupEvalHubMetricsTest(t)
+
+	recordJobFailureEvent("sidecar container failed")
+
+	metrics := collectMetrics(t, reader)
+	scopeMetrics := metrics.ScopeMetrics[0].Metrics
+	require.Len(t, scopeMetrics, 1)
+	assert.Equal(t, metricJobFailureEvents, scopeMetrics[0].Name)
+
+	sum, ok := scopeMetrics[0].Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+	require.Len(t, sum.DataPoints, 1)
+	assert.Equal(t, failureReasonSidecar, attributeValue(sum.DataPoints[0].Attributes, "failure_reason"))
+}
+
+func TestRecordManagedInstanceDelta(t *testing.T) {
+	reader := setupEvalHubMetricsTest(t)
+
+	recordManagedInstanceDelta(1)
+	recordManagedInstanceDelta(-1)
+
+	metrics := collectMetrics(t, reader)
+	sum, ok := metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+	require.Len(t, sum.DataPoints, 1)
+	assert.Equal(t, int64(0), sum.DataPoints[0].Value)
+}
+
+func attributeValue(attrs attribute.Set, key string) string {
+	value, ok := attrs.Value(attribute.Key(key))
+	if !ok {
+		return ""
+	}
+	return value.AsString()
+}

--- a/controllers/evalhub/metrics_test.go
+++ b/controllers/evalhub/metrics_test.go
@@ -47,8 +47,8 @@ func TestRecordEvalHubReconcileMetrics(t *testing.T) {
 	scopeMetrics := metrics.ScopeMetrics[0].Metrics
 	require.Len(t, scopeMetrics, 2)
 
-	assert.Equal(t, metricReconcileDuration, scopeMetrics[0].Name)
-	histogram, ok := scopeMetrics[0].Data.(metricdata.Histogram[float64])
+	durationMetric := findMetricByName(t, scopeMetrics, metricReconcileDuration)
+	histogram, ok := durationMetric.Data.(metricdata.Histogram[float64])
 	require.True(t, ok)
 	require.Len(t, histogram.DataPoints, 1)
 	attrs := histogram.DataPoints[0].Attributes
@@ -56,8 +56,8 @@ func TestRecordEvalHubReconcileMetrics(t *testing.T) {
 	assert.Equal(t, "success", attributeValue(attrs, "result"))
 	assert.Equal(t, uint64(1), histogram.DataPoints[0].Count)
 
-	assert.Equal(t, metricReconcileTotal, scopeMetrics[1].Name)
-	total, ok := scopeMetrics[1].Data.(metricdata.Sum[int64])
+	totalMetric := findMetricByName(t, scopeMetrics, metricReconcileTotal)
+	total, ok := totalMetric.Data.(metricdata.Sum[int64])
 	require.True(t, ok)
 	require.Len(t, total.DataPoints, 1)
 	assert.Equal(t, int64(1), total.DataPoints[0].Value)
@@ -72,8 +72,8 @@ func TestRecordEvalHubReconcileErrorMetrics(t *testing.T) {
 	scopeMetrics := metrics.ScopeMetrics[0].Metrics
 	require.Len(t, scopeMetrics, 3)
 
-	assert.Equal(t, metricReconcileErrors, scopeMetrics[2].Name)
-	errorsSum, ok := scopeMetrics[2].Data.(metricdata.Sum[int64])
+	errorsMetric := findMetricByName(t, scopeMetrics, metricReconcileErrors)
+	errorsSum, ok := errorsMetric.Data.(metricdata.Sum[int64])
 	require.True(t, ok)
 	require.Len(t, errorsSum.DataPoints, 1)
 	assert.Equal(t, errorTypeOther, attributeValue(errorsSum.DataPoints[0].Attributes, "error_type"))
@@ -114,6 +114,17 @@ func TestRecordManagedInstanceDelta(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, sum.DataPoints, 1)
 	assert.Equal(t, int64(0), sum.DataPoints[0].Value)
+}
+
+func findMetricByName(t *testing.T, scopeMetrics []metricdata.Metrics, name string) metricdata.Metrics {
+	t.Helper()
+	for _, m := range scopeMetrics {
+		if m.Name == name {
+			return m
+		}
+	}
+	t.Fatalf("metric %q not found in scope metrics", name)
+	return metricdata.Metrics{}
 }
 
 func attributeValue(attrs attribute.Set, key string) string {

--- a/controllers/evalhub/tracing.go
+++ b/controllers/evalhub/tracing.go
@@ -2,6 +2,7 @@ package evalhub
 
 import (
 	"context"
+	"time"
 
 	"github.com/trustyai-explainability/trustyai-service-operator/pkg/tracing"
 	"go.opentelemetry.io/otel/attribute"
@@ -36,8 +37,8 @@ func startEvalHubReconcileSpan(ctx context.Context, spanName, namespace, name st
 	return tracing.StartReconcileSpan(ctx, evalHubTracerName, spanName, evalHubReconcileAttrs(namespace, name, generation)...)
 }
 
-func finishEvalHubReconcileSpan(span trace.Span, result ctrl.Result, err error) {
-	tracing.FinishReconcileOutcome(span, !result.IsZero(), result.RequeueAfter, err)
+func finishEvalHubReconcileSpan(span trace.Span, controller string, start time.Time, result ctrl.Result, err error) {
+	finishEvalHubReconcile(span, controller, start, result, err)
 }
 
 const maxFailureReasonRunes = 512

--- a/controllers/evalhub/tracing_test.go
+++ b/controllers/evalhub/tracing_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -111,7 +112,7 @@ func TestFinishEvalHubReconcileSpanPreservesExplicitOutcome(t *testing.T) {
 
 	_, span := startEvalHubReconcileSpan(context.Background(), spanReconcile, "ns-1", "hub-1", 1)
 	tracing.SetSpanOutcome(span, "validation_error")
-	finishEvalHubReconcileSpan(span, ctrl.Result{}, errors.New("ignored"))
+	finishEvalHubReconcileSpan(span, metricControllerEvalHub, time.Now(), ctrl.Result{}, errors.New("ignored"))
 	span.End()
 
 	spans := exporter.GetSpans()

--- a/go.mod
+++ b/go.mod
@@ -21,10 +21,13 @@ require (
 
 require (
 	go.opentelemetry.io/otel v1.43.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0
+	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
+	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 )
 
@@ -102,8 +105,7 @@ require (
 	go.opentelemetry.io/contrib/detectors/gcp v1.43.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 // indirect
-	go.opentelemetry.io/otel/metric v1.43.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -356,6 +356,10 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 h1:Oyrsyzu
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0/go.mod h1:C2NGBr+kAB4bk3xtMXfZ94gqFDtg/GkI7e9zqGh5Beg=
 go.opentelemetry.io/otel v1.43.0 h1:mYIM03dnh5zfN7HautFE4ieIig9amkNANT+xcVxAj9I=
 go.opentelemetry.io/otel v1.43.0/go.mod h1:JuG+u74mvjvcm8vj8pI5XiHy1zDeoCS2LB1spIq7Ay0=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0 h1:8UQVDcZxOJLtX6gxtDt3vY2WTgvZqMQRzjsqiIHQdkc=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0/go.mod h1:2lmweYCiHYpEjQ/lSJBYhj9jP1zvCvQW4BqL9dnT7FQ=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0 h1:w1K+pCJoPpQifuVpsKamUdn9U0zM3xUziVOqsGksUrY=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0/go.mod h1:HBy4BjzgVE8139ieRI75oXm3EcDN+6GhD88JT1Kjvxg=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 h1:88Y4s2C8oTui1LGM6bTWkw0ICGcOLCAI5l6zsD1j20k=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0/go.mod h1:Vl1/iaggsuRlrHf/hfPJPvVag77kKyvrLeD10kpMl+A=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0 h1:RAE+JPfvEmvy+0LzyUA25/SGawPwIUbZ6u0Wug54sLc=

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -1,14 +1,23 @@
-// Package tracing provides opt-in OpenTelemetry tracing for the TrustyAI Service Operator.
+// Package tracing provides opt-in OpenTelemetry tracing and metrics for the TrustyAI Service Operator.
 //
-// Tracing is disabled unless OTLP export is configured via environment variables:
+// Tracing is disabled unless OTLP trace export is configured via environment variables:
 //   - OTEL_EXPORTER_OTLP_ENDPOINT (or OTEL_EXPORTER_OTLP_TRACES_ENDPOINT)
 //   - OTEL_EXPORTER_OTLP_PROTOCOL (optional: grpc default, or http/protobuf)
+//   - OTEL_EXPORTER_OTLP_TRACES_PROTOCOL (optional, overrides OTEL_EXPORTER_OTLP_PROTOCOL for traces)
+//
+// Metrics are disabled unless OTLP metrics export is configured via:
+//   - OTEL_EXPORTER_OTLP_ENDPOINT (or OTEL_EXPORTER_OTLP_METRICS_ENDPOINT)
+//   - OTEL_EXPORTER_OTLP_PROTOCOL (optional)
+//   - OTEL_EXPORTER_OTLP_METRICS_PROTOCOL (optional, overrides OTEL_EXPORTER_OTLP_PROTOCOL for metrics)
+//
+// Shared configuration:
 //   - OTEL_SERVICE_NAME (optional, default: trustyai-service-operator)
-//   - OTEL_SDK_DISABLED=true disables tracing even when an endpoint is set
+//   - OTEL_SDK_DISABLED=true disables tracing and metrics even when endpoints are set
 package tracing
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -19,9 +28,14 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/metric"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/sdk/resource"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 	"go.opentelemetry.io/otel/trace"
@@ -34,41 +48,50 @@ type tracerScopeKey struct{}
 
 var explicitReconcileOutcomes sync.Map
 
-// Setup initializes the global TracerProvider. When OTLP is not configured, a noop provider is used.
+// Setup initializes global TracerProvider and MeterProvider.
+// When OTLP is not configured for a signal, a noop provider is used for that signal.
 func Setup(ctx context.Context) (func(context.Context) error, error) {
-	if !tracingEnabled() {
+	var shutdowns []func(context.Context) error
+
+	if tracingEnabled() {
+		traceShutdown, err := setupTracing(ctx)
+		if err != nil {
+			return nil, err
+		}
+		shutdowns = append(shutdowns, traceShutdown)
+	} else {
 		otel.SetTracerProvider(noop.NewTracerProvider())
-		return func(context.Context) error { return nil }, nil
 	}
 
-	exporter, err := newOTLPExporter(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("create OTLP trace exporter: %w", err)
+	if metricsEnabled() {
+		metricsShutdown, err := setupMetrics(ctx)
+		if err != nil {
+			return nil, err
+		}
+		shutdowns = append(shutdowns, metricsShutdown)
+	} else {
+		otel.SetMeterProvider(metricnoop.NewMeterProvider())
 	}
 
-	res, err := resource.Merge(
-		resource.Default(),
-		resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceName(serviceName()),
-			semconv.ServiceVersion(constants.Version),
-		),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("create trace resource: %w", err)
-	}
-
-	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithBatcher(exporter),
-		sdktrace.WithResource(res),
-	)
-	otel.SetTracerProvider(tp)
-	return tp.Shutdown, nil
+	return func(ctx context.Context) error {
+		var errs []error
+		for _, shutdown := range shutdowns {
+			if err := shutdown(ctx); err != nil {
+				errs = append(errs, err)
+			}
+		}
+		return errors.Join(errs...)
+	}, nil
 }
 
 // Tracer returns a named tracer from the global TracerProvider.
 func Tracer(name string) trace.Tracer {
 	return otel.Tracer(name)
+}
+
+// Meter returns a named meter from the global MeterProvider.
+func Meter(name string) metric.Meter {
+	return otel.Meter(name)
 }
 
 // StartReconcileSpan starts a parent reconcile span and stores the tracer scope in ctx.
@@ -92,15 +115,24 @@ func WithPhase(ctx context.Context, spanName string, fn func(context.Context) er
 	return nil
 }
 
+// ReconcileOutcome derives the reconcile result label from controller-runtime result and error.
+func ReconcileOutcome(requeue bool, requeueAfter time.Duration, err error) string {
+	if err != nil {
+		return "error"
+	}
+	if requeue || requeueAfter > 0 {
+		return "requeue"
+	}
+	return "success"
+}
+
 // SetReconcileOutcome records the reconcile result on the parent span.
 func SetReconcileOutcome(span trace.Span, requeue bool, requeueAfter time.Duration, err error) {
-	outcome := "success"
+	outcome := ReconcileOutcome(requeue, requeueAfter, err)
 	if err != nil {
-		outcome = "error"
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 	} else if requeue || requeueAfter > 0 {
-		outcome = "requeue"
 		if requeueAfter > 0 {
 			span.SetAttributes(attribute.String("reconcile.requeue_after", requeueAfter.String()))
 		}
@@ -115,18 +147,19 @@ func SetSpanOutcome(span trace.Span, outcome string) {
 	span.SetAttributes(attribute.String("reconcile.outcome", outcome))
 	span.SetStatus(codes.Ok, "")
 	if sc := span.SpanContext(); sc.IsValid() {
-		explicitReconcileOutcomes.Store(spanContextKey(sc), struct{}{})
+		explicitReconcileOutcomes.Store(spanContextKey(sc), outcome)
 	}
 }
 
 // FinishReconcileOutcome records reconcile result unless SetSpanOutcome already set an explicit outcome.
-func FinishReconcileOutcome(span trace.Span, requeue bool, requeueAfter time.Duration, err error) {
+func FinishReconcileOutcome(span trace.Span, requeue bool, requeueAfter time.Duration, err error) string {
 	if sc := span.SpanContext(); sc.IsValid() {
-		if _, explicit := explicitReconcileOutcomes.LoadAndDelete(spanContextKey(sc)); explicit {
-			return
+		if outcome, explicit := explicitReconcileOutcomes.LoadAndDelete(spanContextKey(sc)); explicit {
+			return outcome.(string)
 		}
 	}
 	SetReconcileOutcome(span, requeue, requeueAfter, err)
+	return ReconcileOutcome(requeue, requeueAfter, err)
 }
 
 func spanContextKey(sc trace.SpanContext) string {
@@ -141,11 +174,71 @@ func tracerFromContext(ctx context.Context) trace.Tracer {
 	return otel.Tracer(name)
 }
 
+func setupTracing(ctx context.Context) (func(context.Context) error, error) {
+	exporter, err := newOTLPTraceExporter(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("create OTLP trace exporter: %w", err)
+	}
+
+	res, err := otelResource()
+	if err != nil {
+		return nil, err
+	}
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exporter),
+		sdktrace.WithResource(res),
+	)
+	otel.SetTracerProvider(tp)
+	return tp.Shutdown, nil
+}
+
+func setupMetrics(ctx context.Context) (func(context.Context) error, error) {
+	exporter, err := newOTLPMetricExporter(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("create OTLP metric exporter: %w", err)
+	}
+
+	res, err := otelResource()
+	if err != nil {
+		return nil, err
+	}
+
+	mp := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exporter)),
+		sdkmetric.WithResource(res),
+	)
+	otel.SetMeterProvider(mp)
+	return mp.Shutdown, nil
+}
+
+func otelResource() (*resource.Resource, error) {
+	res, err := resource.Merge(
+		resource.Default(),
+		resource.NewWithAttributes(
+			semconv.SchemaURL,
+			semconv.ServiceName(serviceName()),
+			semconv.ServiceVersion(constants.Version),
+		),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create otel resource: %w", err)
+	}
+	return res, nil
+}
+
 func tracingEnabled() bool {
 	if sdkDisabled() {
 		return false
 	}
-	return otlpEndpoint() != ""
+	return otlpTraceEndpoint() != ""
+}
+
+func metricsEnabled() bool {
+	if sdkDisabled() {
+		return false
+	}
+	return otlpMetricsEndpoint() != ""
 }
 
 func sdkDisabled() bool {
@@ -153,8 +246,15 @@ func sdkDisabled() bool {
 	return v == "true" || v == "1"
 }
 
-func otlpEndpoint() string {
+func otlpTraceEndpoint() string {
 	if ep := strings.TrimSpace(os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")); ep != "" {
+		return ep
+	}
+	return strings.TrimSpace(os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"))
+}
+
+func otlpMetricsEndpoint() string {
+	if ep := strings.TrimSpace(os.Getenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT")); ep != "" {
 		return ep
 	}
 	return strings.TrimSpace(os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"))
@@ -167,17 +267,32 @@ func serviceName() string {
 	return defaultServiceName
 }
 
-func otlpProtocol() string {
+func otlpTraceProtocol() string {
 	if protocol := strings.TrimSpace(strings.ToLower(os.Getenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"))); protocol != "" {
 		return protocol
 	}
 	return strings.TrimSpace(strings.ToLower(os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL")))
 }
 
-func newOTLPExporter(ctx context.Context) (sdktrace.SpanExporter, error) {
-	protocol := otlpProtocol()
+func otlpMetricsProtocol() string {
+	if protocol := strings.TrimSpace(strings.ToLower(os.Getenv("OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"))); protocol != "" {
+		return protocol
+	}
+	return strings.TrimSpace(strings.ToLower(os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL")))
+}
+
+func newOTLPTraceExporter(ctx context.Context) (sdktrace.SpanExporter, error) {
+	protocol := otlpTraceProtocol()
 	if protocol == "http/protobuf" || protocol == "http" {
 		return otlptracehttp.New(ctx)
 	}
 	return otlptracegrpc.New(ctx)
+}
+
+func newOTLPMetricExporter(ctx context.Context) (sdkmetric.Exporter, error) {
+	protocol := otlpMetricsProtocol()
+	if protocol == "http/protobuf" || protocol == "http" {
+		return otlpmetrichttp.New(ctx)
+	}
+	return otlpmetricgrpc.New(ctx)
 }

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -66,6 +66,11 @@ func Setup(ctx context.Context) (func(context.Context) error, error) {
 	if metricsEnabled() {
 		metricsShutdown, err := setupMetrics(ctx)
 		if err != nil {
+			for _, shutdown := range shutdowns {
+				if shutdownErr := shutdown(ctx); shutdownErr != nil {
+					err = errors.Join(err, shutdownErr)
+				}
+			}
 			return nil, err
 		}
 		shutdowns = append(shutdowns, metricsShutdown)

--- a/pkg/tracing/tracing_test.go
+++ b/pkg/tracing/tracing_test.go
@@ -18,6 +18,7 @@ import (
 func TestSetupWithoutEndpointUsesNoopProvider(t *testing.T) {
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
 	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "")
 	t.Setenv("OTEL_SDK_DISABLED", "")
 
 	shutdown, err := Setup(context.Background())
@@ -27,6 +28,29 @@ func TestSetupWithoutEndpointUsesNoopProvider(t *testing.T) {
 	_, span := Tracer("test").Start(context.Background(), "noop-span")
 	span.End()
 	assert.False(t, span.SpanContext().IsValid())
+
+	counter, err := Meter("test").Int64Counter("noop.counter")
+	require.NoError(t, err)
+	counter.Add(context.Background(), 1)
+}
+
+func TestReconcileOutcome(t *testing.T) {
+	assert.Equal(t, "success", ReconcileOutcome(false, 0, nil))
+	assert.Equal(t, "requeue", ReconcileOutcome(true, 0, nil))
+	assert.Equal(t, "requeue", ReconcileOutcome(false, time.Second, nil))
+	assert.Equal(t, "error", ReconcileOutcome(false, 0, errors.New("boom")))
+}
+
+func TestOtlpMetricsProtocolSpecificWins(t *testing.T) {
+	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_PROTOCOL", "http/protobuf")
+	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+	assert.Equal(t, "http/protobuf", otlpMetricsProtocol())
+}
+
+func TestOtlpTraceProtocolSpecificWins(t *testing.T) {
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "http/protobuf")
+	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+	assert.Equal(t, "http/protobuf", otlpTraceProtocol())
 }
 
 func TestWithPhaseRecordsErrorStatus(t *testing.T) {
@@ -79,7 +103,7 @@ func TestSetReconcileOutcome(t *testing.T) {
 func TestOtlpProtocolTraceSpecificWins(t *testing.T) {
 	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "http/protobuf")
 	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
-	assert.Equal(t, "http/protobuf", otlpProtocol())
+	assert.Equal(t, "http/protobuf", otlpTraceProtocol())
 }
 
 func TestFinishReconcileOutcomePreservesExplicitOutcome(t *testing.T) {
@@ -90,8 +114,10 @@ func TestFinishReconcileOutcomePreservesExplicitOutcome(t *testing.T) {
 
 	_, span := Tracer("test").Start(context.Background(), "reconcile")
 	SetSpanOutcome(span, "invalid_placement")
-	FinishReconcileOutcome(span, true, 0, errors.New("ignored"))
+	outcome := FinishReconcileOutcome(span, true, 0, errors.New("ignored"))
 	span.End()
+
+	assert.Equal(t, "invalid_placement", outcome)
 
 	spans := exporter.GetSpans()
 	require.Len(t, spans, 1)


### PR DESCRIPTION
## Summary

Stacked on #877 ([RHAI-241](https://redhat.atlassian.net/browse/RHAI-241) tracing). Adds opt-in OpenTelemetry **metrics** export for the EvalHub operator controller via standard `OTEL_EXPORTER_OTLP_METRICS_*` environment variables.

- Extend `pkg/tracing.Setup()` with a noop or OTLP `MeterProvider`, combined shutdown with traces, and `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL` precedence.
- Add EvalHub OTLP instruments: reconcile duration histogram, reconcile total counter, reconcile errors counter (bounded `error_type` enum), managed instances up/down counter, and job failure events counter.
- Record metrics at existing reconcile defer/outcome points shared with tracing (`finishEvalHubReconcileSpan`), preserving explicit outcomes (`validation_error`, `invalid_placement`).
- Document configuration and metric inventory in `controllers/evalhub/OTEL_METRICS.md`.

**Note:** This delivers OTLP metrics push, not Prometheus scrape on `:8080` ([RHAI-240](https://redhat.atlassian.net/browse/RHAI-240) scope). Traces and OTLP metrics can be enabled independently.

## Depends on

- #877

## Test plan

- [x] `go test ./pkg/tracing/... ./controllers/evalhub/... -run 'Metric|Tracing|Reconcile|Record|Classify|Otlp|Outcome'`
- [x] `go build ./cmd/...`
- [ ] Deploy operator with `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` set and confirm metrics appear in OTLP backend alongside traces
- [ ] Confirm noop behavior when OTLP metrics env vars are unset


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in OpenTelemetry metrics export for EvalHub controllers.
  * Added metrics for reconciliation duration, outcomes, errors, managed instances, and job-failure events.
  * Enabled independent configuration of OTLP tracing and metrics endpoints and protocols.
  * Improved reconciliation telemetry for cleanup and resource management activity.

* **Documentation**
  * Added setup guidance covering configuration, deployment changes, exported metrics, and interactions with tracing and Prometheus monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->