### PR TITLE
feat(evalhub): add Open-Telco Inspect benchmarks and fix lighteval TruthfulQA

### DIFF
--- a/config/configmaps/evalhub/collection-open-telco-v1.yaml
+++ b/config/configmaps/evalhub/collection-open-telco-v1.yaml
@@ -27,11 +27,9 @@ data:
       - reasoning
       - inspect
       - vllm
-    agent:
-      result_interpretation:
-        - "Equal-weight average across four Open-Telco benchmarks"
-        - "(0.50 + 0.70 + 0.25 + 0.45) / 4 = 0.475"
     pass_criteria:
+      # Equal-weight average across four Open-Telco benchmarks:
+      # (0.50 + 0.70 + 0.25 + 0.45) / 4 = 0.475
       threshold: 0.475
     benchmarks:
       - id: inspect/telemath
@@ -41,9 +39,8 @@ data:
           metric: telemath_scorer/accuracy
           lower_is_better: false
         pass_criteria:
+          # GSMA leaderboard median ≈ 0.42; GPT-5 ≈ 0.79.
           threshold: 0.50
-        agent:
-          result_interpretation: "GSMA leaderboard median ≈ 0.42; GPT-5 ≈ 0.79."
         parameters:
           full: true
           num_examples: 50
@@ -55,9 +52,8 @@ data:
           metric: choice/accuracy
           lower_is_better: false
         pass_criteria:
+          # GSMA leaderboard median ≈ 0.75; GPT-5 ≈ 0.84.
           threshold: 0.70
-        agent:
-          result_interpretation: "GSMA leaderboard median ≈ 0.75; GPT-5 ≈ 0.84."
         parameters:
           full: true
           subject: full
@@ -70,9 +66,8 @@ data:
           metric: telelogs_scorer/accuracy
           lower_is_better: false
         pass_criteria:
+          # GSMA leaderboard median ≈ 0.23; GPT-5 ≈ 0.78.
           threshold: 0.25
-        agent:
-          result_interpretation: "GSMA leaderboard median ≈ 0.23; GPT-5 ≈ 0.78."
         parameters:
           full: true
           eval_type: soft
@@ -85,9 +80,8 @@ data:
           metric: pattern/accuracy
           lower_is_better: false
         pass_criteria:
+          # GSMA leaderboard median ≈ 0.43; GPT-5 ≈ 0.58.
           threshold: 0.45
-        agent:
-          result_interpretation: "GSMA leaderboard median ≈ 0.43; GPT-5 ≈ 0.58."
         parameters:
           full: true
           num_examples: 50

--- a/config/configmaps/evalhub/collection-open-telco-v1.yaml
+++ b/config/configmaps/evalhub/collection-open-telco-v1.yaml
@@ -27,9 +27,15 @@ data:
       - reasoning
       - inspect
       - vllm
+    agent:
+      result_interpretation:
+        - "Collection pass threshold is the equal-weight average of the four Open-Telco benchmarks: (0.50 + 0.70 + 0.25 + 0.45) / 4 = 0.475"
+        - "HIGHER is better -- all four benchmarks report accuracy"
+        - "telemath: GSMA leaderboard median ≈ 0.42; GPT-5 ≈ 0.79"
+        - "teleqna: GSMA leaderboard median ≈ 0.75; GPT-5 ≈ 0.84"
+        - "telelogs: GSMA leaderboard median ≈ 0.23; GPT-5 ≈ 0.78"
+        - "3gpp-tsg: GSMA leaderboard median ≈ 0.43; GPT-5 ≈ 0.58"
     pass_criteria:
-      # Equal-weight average across four Open-Telco benchmarks:
-      # (0.50 + 0.70 + 0.25 + 0.45) / 4 = 0.475
       threshold: 0.475
     benchmarks:
       - id: inspect/telemath
@@ -39,7 +45,6 @@ data:
           metric: telemath_scorer/accuracy
           lower_is_better: false
         pass_criteria:
-          # GSMA leaderboard median ≈ 0.42; GPT-5 ≈ 0.79.
           threshold: 0.50
         parameters:
           full: true
@@ -52,7 +57,6 @@ data:
           metric: choice/accuracy
           lower_is_better: false
         pass_criteria:
-          # GSMA leaderboard median ≈ 0.75; GPT-5 ≈ 0.84.
           threshold: 0.70
         parameters:
           full: true
@@ -66,7 +70,6 @@ data:
           metric: telelogs_scorer/accuracy
           lower_is_better: false
         pass_criteria:
-          # GSMA leaderboard median ≈ 0.23; GPT-5 ≈ 0.78.
           threshold: 0.25
         parameters:
           full: true
@@ -80,7 +83,6 @@ data:
           metric: pattern/accuracy
           lower_is_better: false
         pass_criteria:
-          # GSMA leaderboard median ≈ 0.43; GPT-5 ≈ 0.58.
           threshold: 0.45
         parameters:
           full: true

--- a/config/configmaps/evalhub/provider-inspect.yaml
+++ b/config/configmaps/evalhub/provider-inspect.yaml
@@ -111,7 +111,7 @@ data:
         name: Petri — Full Alignment Audit
         description: >
           Complete Petri audit across all 170+ built-in seeds from all 40 tag categories.
-          Expensive — strongly recommend setting max_samples for development runs.
+          Expensive — strongly recommend setting num_examples for development runs.
           Primary output: 38-dimension scoring profile across all alignment behaviors.
         category: alignment
         metrics: [concerning/mean, eval_awareness/mean, admirable/mean]
@@ -520,6 +520,84 @@ data:
         metrics: [accuracy/accuracy]
         tags: [reasoning, math, inspect-evals]
 
+      # Telecom (GSMA Open-Telco)
+      - id: inspect/telemath
+        name: TeleMath
+        description: >
+          Telecom-domain mathematical problem solving — 500 numerical Q&A pairs covering
+          signal processing, networking, electrical engineering, information theory, and
+          related topics (GSMA Open-Telco / Inspect AI). Set full=true for GSMA/ot-full
+          (500 items); full=false uses GSMA/ot-lite. Cap sample count with num_examples.
+        category: telecom
+        metrics:
+          - telemath_scorer/accuracy
+          - telemath_scorer/stderr
+        primary_score:
+          metric: telemath_scorer/accuracy
+          lower_is_better: false
+        pass_criteria:
+          # GSMA leaderboard (Mar 2026): median ≈ 0.42, GPT-5 ≈ 0.79, top ≈ 0.87.
+          threshold: 0.50
+        tags: [telecom, math, reasoning, open-telco, inspect-ai]
+
+      - id: inspect/teleqna
+        name: TeleQnA
+        description: >
+          Telecom domain knowledge — multiple-choice questions on standards, research,
+          and technical topics (GSMA Open-Telco / Inspect AI). Set full=true for
+          GSMA/ot-full; full=false uses GSMA/ot-lite. Optional subject filters by
+          TeleQnA subject (default full = all subjects). Cap with num_examples.
+        category: telecom
+        metrics:
+          - choice/accuracy
+          - choice/stderr
+        primary_score:
+          metric: choice/accuracy
+          lower_is_better: false
+        pass_criteria:
+          # GSMA leaderboard (Mar 2026): median ≈ 0.75, GPT-5 ≈ 0.84, top ≈ 0.91.
+          threshold: 0.70
+        tags: [telecom, knowledge, qa, open-telco, inspect-ai]
+
+      - id: inspect/telelogs
+        name: TeleLogs
+        description: >
+          Root-cause analysis on 5G network data — models identify which of several
+          predefined root causes explain throughput degradation (GSMA Open-Telco /
+          Inspect AI). Set full=true for GSMA/ot-full; eval_type soft (default) or hard.
+          Cap with num_examples.
+        category: telecom
+        metrics:
+          - telelogs_scorer/accuracy
+          - telelogs_scorer/stderr
+          - telelogs_scorer/maj_at_k
+        primary_score:
+          metric: telelogs_scorer/accuracy
+          lower_is_better: false
+        pass_criteria:
+          # GSMA leaderboard (Mar 2026): median ≈ 0.23, GPT-5 ≈ 0.78, top ≈ 0.96.
+          threshold: 0.25
+        tags: [telecom, operations, rca, troubleshooting, open-telco, inspect-ai]
+
+      - id: inspect/3gpp-tsg
+        name: 3GPP-TSG
+        description: >
+          3GPP technical specification group classification — models identify the
+          correct working group for excerpts from official 3GPP documents
+          (GSMA Open-Telco / Inspect AI). Set full=true for GSMA/ot-full; cap with
+          num_examples.
+        category: telecom
+        metrics:
+          - pattern/accuracy
+          - pattern/stderr
+        primary_score:
+          metric: pattern/accuracy
+          lower_is_better: false
+        pass_criteria:
+          # GSMA leaderboard (Mar 2026): median ≈ 0.43, GPT-5 ≈ 0.58, top ≈ 0.81.
+          threshold: 0.45
+        tags: [telecom, standards, 3gpp, knowledge, open-telco, inspect-ai]
+
       # Knowledge & reasoning
       - id: inspect/mmlu
         name: MMLU
@@ -884,21 +962,35 @@ data:
         default: 1
         description: Number of tasks to run concurrently.
 
-      - name: max_samples
-        type: integer
+      - name: full
+        type: boolean
         default: null
         description: >
-          Limit samples per task. Strongly recommended for Petri/Bloom development
-          runs to control cost. Full Petri audits (170+ seeds × 30 turns × 3 models)
-          can be expensive.
+          Open-Telco tasks (TeleMath, TeleQnA, …): when true, use GSMA/ot-full; when
+          false, use GSMA/ot-lite. Forwarded as Inspect -T full=….
+
+      - name: subject
+        type: string
+        default: null
+        description: >
+          TeleQnA only. Filter samples by subject metadata. Default in the task is
+          'full' (all subjects). Forwarded as Inspect -T subject=….
+
+      - name: eval_type
+        type: string
+        default: null
+        description: >
+          TeleLogs only. Scoring mode: 'soft' (default) or 'hard'. Forwarded as
+          Inspect -T eval_type=….
 
       - name: task_args
         type: object
         default: {}
         description: >
-          Pass-through task arguments forwarded as '-T key=value' flags.
-          Use for Dish (research preview): {"dish_scaffold": "claude-code"}.
-          See Petri docs for available task args.
+          Escape hatch for Inspect -T flags that are not first-class parameters
+          (e.g. Dish research preview: {"dish_scaffold": "claude-code"}).
+          Do not use for Open-Telco full/subject/eval_type — set those as flat
+          parameters instead.
 
       - name: log_level
         type: string
@@ -908,9 +1000,9 @@ data:
       - name: languages
         type: array
         default: [en]
-        description: ISO 639 language codes for EvalCard metadata.
+        description: ISO 639 language codes (optional, but when set used in evaluation card).
 
       - name: languages_count
         type: integer
         default: 1
-        description: Number of languages in the evaluation dataset.
+        description: Number of languages in the evaluation dataset (optional).

--- a/config/configmaps/evalhub/provider-inspect.yaml
+++ b/config/configmaps/evalhub/provider-inspect.yaml
@@ -536,9 +536,10 @@ data:
           metric: telemath_scorer/accuracy
           lower_is_better: false
         pass_criteria:
-          # GSMA leaderboard (Mar 2026): median ≈ 0.42, GPT-5 ≈ 0.79, top ≈ 0.87.
           threshold: 0.50
         tags: [telecom, math, reasoning, open-telco, inspect-ai]
+        agent:
+          result_interpretation: "Accuracy on telecom-domain numerical math; HIGHER is better. GSMA leaderboard (Mar 2026): median ≈ 0.42, GPT-5 ≈ 0.79, top ≈ 0.87."
 
       - id: inspect/teleqna
         name: TeleQnA
@@ -555,9 +556,10 @@ data:
           metric: choice/accuracy
           lower_is_better: false
         pass_criteria:
-          # GSMA leaderboard (Mar 2026): median ≈ 0.75, GPT-5 ≈ 0.84, top ≈ 0.91.
           threshold: 0.70
         tags: [telecom, knowledge, qa, open-telco, inspect-ai]
+        agent:
+          result_interpretation: "Accuracy on telecom domain MCQ; HIGHER is better. GSMA leaderboard (Mar 2026): median ≈ 0.75, GPT-5 ≈ 0.84, top ≈ 0.91."
 
       - id: inspect/telelogs
         name: TeleLogs
@@ -575,9 +577,10 @@ data:
           metric: telelogs_scorer/accuracy
           lower_is_better: false
         pass_criteria:
-          # GSMA leaderboard (Mar 2026): median ≈ 0.23, GPT-5 ≈ 0.78, top ≈ 0.96.
           threshold: 0.25
         tags: [telecom, operations, rca, troubleshooting, open-telco, inspect-ai]
+        agent:
+          result_interpretation: "Accuracy on 5G root-cause analysis; HIGHER is better. GSMA leaderboard (Mar 2026): median ≈ 0.23, GPT-5 ≈ 0.78, top ≈ 0.96."
 
       - id: inspect/3gpp-tsg
         name: 3GPP-TSG
@@ -594,9 +597,10 @@ data:
           metric: pattern/accuracy
           lower_is_better: false
         pass_criteria:
-          # GSMA leaderboard (Mar 2026): median ≈ 0.43, GPT-5 ≈ 0.58, top ≈ 0.81.
           threshold: 0.45
         tags: [telecom, standards, 3gpp, knowledge, open-telco, inspect-ai]
+        agent:
+          result_interpretation: "Accuracy on 3GPP working-group classification; HIGHER is better. GSMA leaderboard (Mar 2026): median ≈ 0.43, GPT-5 ≈ 0.58, top ≈ 0.81."
 
       # Knowledge & reasoning
       - id: inspect/mmlu

--- a/config/configmaps/evalhub/provider-lighteval.yaml
+++ b/config/configmaps/evalhub/provider-lighteval.yaml
@@ -271,13 +271,12 @@ data:
           lower_is_better: false
         pass_criteria:
           threshold: 0.25
-      - id: truthfulqa:generation
+      - id: truthfulqa:gen
         name: Misconception resistance (generative)
         description: Tests whether generated answers are truthful and non-misleading (817 questions).
         category: safety
         metrics:
-          - bleu
-          - rouge
+          - exact_match
         num_few_shot: 0
         dataset_size: 817
         tags:
@@ -285,10 +284,10 @@ data:
           - truthfulness
           - lighteval
         primary_score:
-          metric: bleu
+          metric: exact_match
           lower_is_better: false
         pass_criteria:
-          threshold: 0.1
+          threshold: 0.25
       - id: gsm8k
         name: Grade-school math word problems
         description: |-


### PR DESCRIPTION
Sync trustyai operator - eval-hub configs with https://github.com/eval-hub/eval-hub latest main
Changes from:
- https://github.com/eval-hub/eval-hub/pull/911
- https://github.com/eval-hub/eval-hub/pull/856
- https://github.com/eval-hub/eval-hub/pull/893
- https://github.com/eval-hub/eval-hub/pull/891

Generated with `uv run hack/sync-evalhub-providers.py` script

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Open-Telco evaluation benchmarks for TeleMath, TeleQnA, TeleLogs, and 3GPP-TSG.
  - Added options for selecting full datasets, filtering TeleQnA subjects, and choosing TeleLogs scoring modes.
  - Clarified language metadata descriptions.

- **Changes**
  - Updated development sample limits to use `num_examples`.
  - Replaced the TruthfulQA generation benchmark with updated exact-match scoring and thresholds.
  - Simplified result interpretation guidance by incorporating it into pass criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->