### PR TITLE
fix(tas): point kube-rbac-proxy upstream at the main API port, not the health-only port

### DIFF
--- a/controllers/tas/kube_rbac_proxy_config_test.go
+++ b/controllers/tas/kube_rbac_proxy_config_test.go
@@ -85,7 +85,7 @@ func TestCreateKubeRBACProxyConfigMapObject(t *testing.T) {
 		"resourceName: \"test-service\"",
 		"verb: \"get\"",
 		"upstreamConfig:",
-		"url: \"http://127.0.0.1:8080\"",
+		"url: \"http://127.0.0.1:8081\"",
 		"tlsConfig:",
 		"minVersion: \"VersionTLS12\"",
 	}

--- a/controllers/tas/templates/kube-rbac-proxy/config.tmpl.yaml
+++ b/controllers/tas/templates/kube-rbac-proxy/config.tmpl.yaml
@@ -20,7 +20,7 @@ data:
         verb: "get"
         apiGroup: ""
     upstreamConfig:
-      url: "http://127.0.0.1:8080"
+      url: "http://127.0.0.1:8081"
       proxyTimeout: "30s"
     tlsConfig:
       minVersion: "VersionTLS12"

--- a/controllers/tas/templates/service/deployment.tmpl.yaml
+++ b/controllers/tas/templates/service/deployment.tmpl.yaml
@@ -154,7 +154,7 @@ spec:
           image: {{ .KubeRBACProxyImage }}
           args:
             - --secure-listen-address=0.0.0.0:8443
-            - --upstream=http://127.0.0.1:8080/
+            - --upstream=http://127.0.0.1:8081/
             - --config-file=/etc/kube-rbac-proxy/config.yaml
             - --tls-cert-file=/etc/tls/private/tls.crt
             - --tls-private-key-file=/etc/tls/private/tls.key


### PR DESCRIPTION
## Summary

The TrustyAI Service (Python) splits its FastAPI app into two servers: the main API (port 8081 internally, 4443 for direct TLS) and a deliberately minimal health/liveness/readiness app (port 8080), kept separate so the operator's Quarkus-era health-check paths and ports keep working unmodified. For more details, see https://github.com/trustyai-explainability/trustyai-service/pull/164.

The `kube-rbac-proxy` sidecar (and its `config.yaml`) still forwarded to `127.0.0.1:8080` — a holdover from the old Java/Quarkus service, where a single port served the full API, health checks, and metrics together. Since 8080 is now the health-only app, every external request routed through `kube-rbac-proxy` (i.e. every request through the Route, which targets the `-tls`/kube-rbac-proxy service) landed on the health app instead of the real API and got a 404, even though the pod itself was healthy and the API worked fine when reached directly in-cluster.

## Changes

- `controllers/tas/templates/service/deployment.tmpl.yaml`: kube-rbac-proxy `--upstream` → `127.0.0.1:8081`
- `controllers/tas/templates/kube-rbac-proxy/config.tmpl.yaml`: `upstreamConfig.url` → `127.0.0.1:8081`
- `controllers/tas/kube_rbac_proxy_config_test.go`: updated to assert the corrected value

## Test plan

- [x] `go build ./controllers/tas/...`
- [x] `go test ./controllers/tas/...` (envtest, 43/43 Ginkgo specs + unit tests) passes with the fix
- [x] Reproduced on-cluster: external API calls via the Route returned `{"detail":"Not Found"}` before this fix, while internal (in-cluster) calls to the same service worked — confirming the mismatch was specifically in the external/proxied path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated kube-rbac-proxy routing to use port 8081.
  - Corrected service and deployment configuration to ensure traffic reaches the intended upstream endpoint.
  - Updated configuration validation to reflect the new port.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->