### PR TITLE
fix(tas): scrape TrustyAI metrics from the main API port, not the health-only port

### DIFF
--- a/controllers/tas/monitor_test.go
+++ b/controllers/tas/monitor_test.go
@@ -51,8 +51,10 @@ var _ = Describe("Service Monitor Reconciliation", func() {
 			Expect(endpoint.HonorLabels).To(BeTrue())
 
 			Expect(endpoint.Path).To(Equal("/q/metrics"))
-			Expect(endpoint.Port).To(Equal("http"))
-			Expect(endpoint.Scheme).To(Equal("http"))
+			Expect(endpoint.Port).To(Equal("direct-https"))
+			Expect(endpoint.Scheme).To(Equal("https"))
+			Expect(endpoint.TLSConfig).ToNot(BeNil())
+			Expect(endpoint.TLSConfig.InsecureSkipVerify).To(BeTrue())
 			Expect(endpoint.Params["match[]"]).To(ConsistOf("{__name__= \"trustyai_spd\"}", "{__name__= \"trustyai_dir\"}"))
 
 		})
@@ -91,8 +93,10 @@ var _ = Describe("Service Monitor Reconciliation", func() {
 			Expect(endpoint.HonorLabels).To(BeTrue())
 
 			Expect(endpoint.Path).To(Equal("/q/metrics"))
-			Expect(endpoint.Port).To(Equal("http"))
-			Expect(endpoint.Scheme).To(Equal("http"))
+			Expect(endpoint.Port).To(Equal("direct-https"))
+			Expect(endpoint.Scheme).To(Equal("https"))
+			Expect(endpoint.TLSConfig).ToNot(BeNil())
+			Expect(endpoint.TLSConfig.InsecureSkipVerify).To(BeTrue())
 			Expect(endpoint.Params["match[]"]).To(ConsistOf("{__name__= \"trustyai_spd\"}", "{__name__= \"trustyai_dir\"}"))
 
 		})

--- a/controllers/tas/templates/service/service-internal.tmpl.yaml
+++ b/controllers/tas/templates/service/service-internal.tmpl.yaml
@@ -20,7 +20,7 @@ spec:
           protocol: TCP
           port: 80
           targetPort: 8080
-        - name: https
+        - name: direct-https
           protocol: TCP
           port: 443
           targetPort: 4443

--- a/controllers/tas/templates/service/service-monitor-central.tmpl.yaml
+++ b/controllers/tas/templates/service/service-monitor-central.tmpl.yaml
@@ -21,8 +21,10 @@ spec:
                   - '{__name__= "trustyai_spd"}'
                   - '{__name__= "trustyai_dir"}'
           path: /q/metrics
-          port: http
-          scheme: http
+          port: direct-https
+          scheme: https
+          tlsConfig:
+              insecureSkipVerify: true
     namespaceSelector:
         any: true
     selector:

--- a/controllers/tas/templates/service/service-monitor-local.tmpl.yaml
+++ b/controllers/tas/templates/service/service-monitor-local.tmpl.yaml
@@ -21,8 +21,10 @@ spec:
                   - '{__name__= "trustyai_spd"}'
                   - '{__name__= "trustyai_dir"}'
           path: /q/metrics
-          port: http
-          scheme: http
+          port: direct-https
+          scheme: https
+          tlsConfig:
+              insecureSkipVerify: true
     namespaceSelector:
         matchNames:
             - {{ .Namespace }}


### PR DESCRIPTION
## Summary

Follow-up to #884 (kube-rbac-proxy upstream port fix). Same root cause, different consumer.

The `ServiceMonitor` the operator creates (both the local and central variants) scraped `/q/metrics` via the service's "http" port, which maps to container port 8080. As established in #884, port 8080 is the Python service's deliberately minimal health/liveness/readiness app — it doesn't register `/q/metrics`. The real metrics endpoint lives on the main API, reachable in-cluster via the service's other port (443 → container port 4443, the app's direct-TLS listener).

This meant Prometheus never successfully scraped any `trustyai_*` metric for any drift or fairness metric type — every scrape returned 404, regardless of which metric was being tested.

## Changes

- `service-internal.tmpl.yaml`: renamed the "https" port (443→4443) to `direct-https`. This was necessary, not cosmetic: the `-tls`/kube-rbac-proxy service already has a port named "https" (443→8443), and since the `ServiceMonitor`'s selector matches both services via a shared label, reusing the same port name across both would create two scrape targets instead of one.
- `service-monitor-local.tmpl.yaml` / `service-monitor-central.tmpl.yaml`: point at `direct-https` via `scheme: https` with `tlsConfig.insecureSkipVerify: true`. The cert is auto-issued by OpenShift's internal service-ca; the endpoint already had no bearer token / auth configured, so this keeps the same unauthenticated-scrape design, just fixed to hit a port that actually serves `/q/metrics`.
- `monitor_test.go`: updated the two existing assertions that encoded the old broken `port: http` / `scheme: http` values, and added assertions for the new TLS config.

## Test plan

- [x] `go build ./controllers/tas/...`
- [x] `go test ./controllers/tas/...` (envtest, 43/43 Ginkgo specs + unit tests) passes with the fix
- [x] Reproduced on-cluster: `curl http://127.0.0.1:8080/q/metrics` from inside the pod returns 404; `curl http://127.0.0.1:8081/q/metrics` (the main app, same port kube-rbac-proxy now correctly forwards to per #884) returns real `trustyai_*` metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated service monitoring to use HTTPS endpoints for improved secure communication.
  * Configured monitoring for the renamed `direct-https` service port.
  * Enabled monitoring of endpoints using certificates that cannot be verified by the monitor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->