### PR TITLE
fix(trustyai): update RELATED_IMAGE for odh-trustyai-service-py

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -38,7 +38,7 @@ spec:
           env:
             - name: GOMEMLIMIT
               value: "630MiB"
-            - name: RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE
+            - name: RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_PY_IMAGE
               value: $(trustyaiServiceImage)
             - name: RELATED_IMAGE_ODH_EVAL_HUB_IMAGE
               value: $(evalHubImage)

--- a/controllers/images/resolver.go
+++ b/controllers/images/resolver.go
@@ -26,7 +26,7 @@ const (
 
 // Operand image env vars injected by the ODH platform operator at deploy time
 const (
-	RelatedImageTrustyAIService         = "RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE"
+	RelatedImageTrustyAIService         = "RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_PY_IMAGE"
 	RelatedImageEvalHub                 = "RELATED_IMAGE_ODH_EVAL_HUB_IMAGE"
 	RelatedImageKubeRBACProxy           = "RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE"
 	RelatedImageLMESJob                 = "RELATED_IMAGE_ODH_TA_LMES_JOB_IMAGE"

--- a/trustyai-operator-module/pkg/trustyaimodule/images.go
+++ b/trustyai-operator-module/pkg/trustyaimodule/images.go
@@ -4,7 +4,7 @@ package trustyaimodule
 // variable injected by the ODH platform into the module controller pod.
 var paramsEnvMap = map[string]string{
 	"TRUSTYAI_OPERATOR_IMAGE":                  "RELATED_IMAGE_ODH_TRUSTYAI_OPERATOR_IMAGE",
-	"TRUSTYAI_SERVICE_IMAGE":                   "RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE",
+	"TRUSTYAI_SERVICE_IMAGE":                   "RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_PY_IMAGE",
 	"EVAL_HUB_IMAGE":                           "RELATED_IMAGE_ODH_EVAL_HUB_IMAGE",
 	"KUBE_RBAC_PROXY_IMAGE":                    "RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE",
 	"TA_LMES_JOB_IMAGE":                        "RELATED_IMAGE_ODH_TA_LMES_JOB_IMAGE",


### PR DESCRIPTION
Rename `RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE` to `RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_PY_IMAGE`.
This is to align with migrating the TrustyAI-Service from Java to Python (see [RHAISTRAT-130](https://redhat.atlassian.net/browse/RHAISTRAT-130)).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the TrustyAI Service image configuration to use the corrected environment variable name.
  * Ensured image resolution and deployment settings consistently reference the updated configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->