### PR TITLE
feat(nemo-guardrails): surface capability manifest URL as CR annotation

### DIFF
--- a/controllers/nemo_guardrails/constants.go
+++ b/controllers/nemo_guardrails/constants.go
@@ -5,4 +5,14 @@ const (
 	nemoGuardrailsImageKey         = "nemo-guardrails-image"
 	configMapKubeRBACProxyImageKey = "kube-rbac-proxy"
 	finalizerName                  = "trustyai.opendatahub.io/nemo-guardrails-finalizer"
+
+	// manifestAnnotationKey surfaces the capability manifest URL on the CR so
+	// in-cluster agents can discover it without hardcoded configuration
+	// (RHAI-518). manifestPath mirrors MANIFEST_PATH in
+	// nemoguardrails/server/manifest.py in the NeMo-Guardrails repo --
+	// provisional pending EvalHub team alignment on the platform Agent
+	// Discoverability contract (RHAI-517 AC); keep the two in sync until that
+	// lands.
+	manifestAnnotationKey = "trustyai.opendatahub.io/nemo-guardrails-manifest-url"
+	manifestPath          = "/.well-known/ai-plugin.json"
 )

--- a/controllers/nemo_guardrails/constants.go
+++ b/controllers/nemo_guardrails/constants.go
@@ -14,5 +14,5 @@ const (
 	// Discoverability contract (RHAI-517 AC); keep the two in sync until that
 	// lands.
 	manifestAnnotationKey = "trustyai.opendatahub.io/nemo-guardrails-manifest-url"
-	manifestPath          = "/.well-known/ai-plugin.json"
+	manifestPath          = "/info"
 )

--- a/controllers/nemo_guardrails/constants.go
+++ b/controllers/nemo_guardrails/constants.go
@@ -14,5 +14,5 @@ const (
 	// Discoverability contract (RHAI-517 AC); keep the two in sync until that
 	// lands.
 	manifestAnnotationKey = "trustyai.opendatahub.io/nemo-guardrails-manifest-url"
-	manifestPath          = "/info"
+	manifestPath          = "/admin/info"
 )

--- a/controllers/nemo_guardrails/manifest.go
+++ b/controllers/nemo_guardrails/manifest.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nemo_guardrails
+
+import (
+	"context"
+
+	nemoguardrailsv1alpha1 "github.com/trustyai-explainability/trustyai-service-operator/api/nemo_guardrails/v1alpha1"
+	"github.com/trustyai-explainability/trustyai-service-operator/controllers/utils"
+)
+
+// buildManifestURL returns the in-cluster URL of the NeMo-Guardrails fork's
+// capability manifest endpoint for the given CR, using the same scheme and
+// default port as the reconciled Service (see service.tmpl.yaml).
+func buildManifestURL(nemoGuardrails *nemoguardrailsv1alpha1.NemoGuardrails) string {
+	base := utils.GenerateNonTLSServiceURL(nemoGuardrails.Name, nemoGuardrails.Namespace)
+	if utils.RequiresAuth(nemoGuardrails) {
+		base = utils.GenerateTLSServiceURL(nemoGuardrails.Name, nemoGuardrails.Namespace)
+	}
+	return base + manifestPath
+}
+
+// ensureManifestAnnotation sets the manifest discoverability annotation on
+// the CR if it's missing or stale, so agents in the cluster can discover the
+// manifest endpoint from the CR rather than relying on hardcoded
+// configuration. This is best-effort metadata only: it does not require the
+// manifest endpoint to actually be served by the deployed image, so it stays
+// backwards-compatible with older NeMo-Guardrails deployments.
+func (r *NemoGuardrailsReconciler) ensureManifestAnnotation(ctx context.Context, nemoGuardrails *nemoguardrailsv1alpha1.NemoGuardrails) error {
+	url := buildManifestURL(nemoGuardrails)
+	if nemoGuardrails.Annotations[manifestAnnotationKey] == url {
+		return nil
+	}
+
+	if nemoGuardrails.Annotations == nil {
+		nemoGuardrails.Annotations = map[string]string{}
+	}
+	nemoGuardrails.Annotations[manifestAnnotationKey] = url
+	return r.Update(ctx, nemoGuardrails)
+}

--- a/controllers/nemo_guardrails/nemoguardrail_controller.go
+++ b/controllers/nemo_guardrails/nemoguardrail_controller.go
@@ -103,6 +103,12 @@ func (r *NemoGuardrailsReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, nil
 	}
 
+	// ====== Surface the capability manifest URL as a CR annotation ===================================================
+	if err := r.ensureManifestAnnotation(ctx, nemoGuardrails); err != nil {
+		utils.LogErrorUpdating(ctx, err, "manifest annotation", nemoGuardrails.Name, nemoGuardrails.Namespace)
+		return ctrl.Result{}, err
+	}
+
 	// ====== Deploy the CA bundle configmap ============================================================================
 	caBundleConfigMapName := nemoGuardrails.Name + "-ca-bundle"
 	_, _, err = utils.ReconcileConfigMap(ctx, r.Client, nemoGuardrails, caBundleConfigMapName, constants.Version, caBundleTemplate, templateParser.ParseResource)

--- a/controllers/nemo_guardrails/nemoguardrail_controller_test.go
+++ b/controllers/nemo_guardrails/nemoguardrail_controller_test.go
@@ -544,6 +544,64 @@ var _ = Describe("NemoGuardrails Controller", func() {
 		}, time.Second*10, time.Millisecond*100).Should(HaveKeyWithValue("node-type", "guardrails"))
 	})
 
+	It("should set the manifest discoverability annotation on the CR", func() {
+		controllerReconciler := &NemoGuardrailsReconciler{
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			Namespace: operatorNamespace,
+		}
+		_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Checking if the CR has the manifest URL annotation")
+		expectedURL := "https://" + resourceName + "." + namespace + ".svc" + manifestPath
+		Eventually(func() string {
+			nemo := &nemoguardrailsv1alpha1.NemoGuardrails{}
+			err := k8sClient.Get(ctx, typeNamespacedName, nemo)
+			if err != nil {
+				return ""
+			}
+			return nemo.Annotations[manifestAnnotationKey]
+		}, time.Second*10, time.Millisecond*100).Should(Equal(expectedURL))
+	})
+
+	It("should keep the manifest annotation stable across reconciles", func() {
+		controllerReconciler := &NemoGuardrailsReconciler{
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			Namespace: operatorNamespace,
+		}
+
+		By("Performing initial reconciliation")
+		_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		var initialURL string
+		Eventually(func() string {
+			nemo := &nemoguardrailsv1alpha1.NemoGuardrails{}
+			err := k8sClient.Get(ctx, typeNamespacedName, nemo)
+			if err != nil {
+				return ""
+			}
+			initialURL = nemo.Annotations[manifestAnnotationKey]
+			return initialURL
+		}, time.Second*10, time.Millisecond*100).ShouldNot(BeEmpty())
+
+		By("Reconciling again without any changes")
+		_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		nemo := &nemoguardrailsv1alpha1.NemoGuardrails{}
+		Expect(k8sClient.Get(ctx, typeNamespacedName, nemo)).To(Succeed())
+		Expect(nemo.Annotations[manifestAnnotationKey]).To(Equal(initialURL))
+	})
+
 	It("should create a ServiceAccount and ClusterRoleBinding and delete them when the instance is deleted", func() {
 		controllerReconciler := &NemoGuardrailsReconciler{
 			Client:    k8sClient,


### PR DESCRIPTION
Adds a trustyai.opendatahub.io/nemo-guardrails-manifest-url annotation to NemoGuardrails CR instances during reconciliation, so in-cluster agents can discover the [RHAI-517](https://redhat.atlassian.net/browse/RHAI-517) capability manifest endpoint without hardcoded configuration ([RHAI-518](https://redhat.atlassian.net/browse/RHAI-518)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic discovery of the NeMo-Guardrails capability manifest.
  - Custom resources now include a manifest URL annotation for clients and integrations.
  - Manifest URLs automatically use the appropriate secure or non-secure service endpoint.

- **Bug Fixes**
  - Prevented unnecessary updates when the manifest URL is already current.

- **Tests**
  - Added coverage for manifest annotation creation and stability across repeated reconciliations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->