### PR TITLE
Feat: module e2e kind

### DIFF
--- a/.github/workflows/trustyai-module-e2e-test.yaml
+++ b/.github/workflows/trustyai-module-e2e-test.yaml
@@ -1,0 +1,90 @@
+name: Module E2E test
+
+on:
+  pull_request:
+    paths:
+      - 'trustyai-operator-module/**'
+      - 'tests/crds/**'
+      - 'Makefile.trustyai-operator-module.mk'
+      - 'Makefile'
+      - '.github/workflows/trustyai-module-e2e-test.yaml'
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    env:
+      TRUSTYAI_MODULE_IMG: trustyai-operator-module-controller
+      MODULE_TAG: pr-${{ github.event.pull_request.number || 'default-pr-number' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: trustyai-operator-module/go.mod
+          cache-dependency-path: trustyai-operator-module/go.sum
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push module operator image
+        uses: docker/build-push-action@v6
+        with:
+          context: trustyai-operator-module
+          file: trustyai-operator-module/Dockerfile
+          load: true
+          tags: ${{ env.TRUSTYAI_MODULE_IMG }}:${{ env.MODULE_TAG }}
+          build-args: |
+            VERSION=${{ env.MODULE_TAG }}
+
+      - name: Create k8s Kind Cluster
+        uses: helm/kind-action@v1
+        with:
+          node_image: kindest/node:v1.29.0
+          cluster_name: kind
+
+      - name: Load the module operator image into Kind
+        run: kind load docker-image ${{ env.TRUSTYAI_MODULE_IMG }}:${{ env.MODULE_TAG }}
+
+      - name: Apply external CRDs required by dependency preconditions
+        run: kubectl apply -f tests/crds/monitoring.coreos.com_prometheuses.yaml
+
+      - name: Deploy the module operator
+        run: |
+          kubectl create namespace system
+          make deploy-tom TRUSTYAI_MODULE_IMG=${{ env.TRUSTYAI_MODULE_IMG }} MODULE_TAG=${{ env.MODULE_TAG }}
+
+      - name: Wait for module operator to be ready
+        run: |
+          if ! kubectl wait --for=condition=available --timeout=120s \
+            deployment/trustyai-operator-module-controller-manager -n system; then
+            echo "::group::Module operator diagnostics"
+            kubectl get pods -n system -o wide
+            kubectl describe pod -l control-plane=controller-manager -n system
+            echo "--- Module operator logs ---"
+            kubectl logs -l control-plane=controller-manager -n system --tail=200 || true
+            echo "--- Events ---"
+            kubectl get events -n system --sort-by='.lastTimestamp' || true
+            echo "::endgroup::"
+            exit 1
+          fi
+          echo "Module operator deployment is ready"
+
+      - name: Run module e2e tests
+        run: make test-tom-e2e
+
+      - name: Collect diagnostics
+        if: always()
+        run: |
+          echo "::group::TrustyAI module CR"
+          kubectl get trustyai.components.platform.opendatahub.io -o yaml || true
+          echo "::endgroup::"
+          echo "::group::system namespace resources"
+          kubectl get all -n system || true
+          echo "::endgroup::"
+          echo "::group::Module operator logs"
+          kubectl logs -l control-plane=controller-manager -n system --tail=500 || true
+          echo "::endgroup::"
+
+env:
+  KUBECONFIG: "${HOME}/.kube/config"

--- a/Makefile.trustyai-operator-module.mk
+++ b/Makefile.trustyai-operator-module.mk
@@ -19,7 +19,7 @@ docker-push-tom: docker-build-tom ## Build and push the trustyai-operator-module
 	$(ENGINE) push $(TRUSTYAI_MODULE_IMG):$(MODULE_TAG)
 
 .PHONY: deploy-tom
-deploy-tom: ## Deploy the trustyai-operator-module-controller to the cluster
+deploy-tom: kustomize ## Deploy the trustyai-operator-module-controller to the cluster
 	cd $(MODULE_DIR)/config/default && \
 		$(KUSTOMIZE) edit set image trustyai-operator-module-controller=$(TRUSTYAI_MODULE_IMG):$(MODULE_TAG)
 	kubectl apply -k $(MODULE_DIR)/config/default --server-side=true
@@ -48,3 +48,7 @@ precommit-tom: ## Run pre-commit checks for trustyai-operator-module
 .PHONY: test-tom
 test-tom: envtest ## Run tests for trustyai-operator-module
 	cd $(MODULE_DIR) && KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -v
+
+.PHONY: test-tom-e2e
+test-tom-e2e: ## Run e2e tests for trustyai-operator-module against a live cluster (requires KUBECONFIG)
+	cd $(MODULE_DIR) && go test -tags e2e -count=1 -v ./tests/e2e/... -run ^TestE2E -timeout 10m

--- a/trustyai-operator-module/tests/e2e/e2e_test.go
+++ b/trustyai-operator-module/tests/e2e/e2e_test.go
@@ -1,0 +1,15 @@
+//go:build e2e
+
+//nolint:testpackage
+package e2e
+
+import "testing"
+
+// TestE2E is the single entrypoint the CI workflow runs (make test-tom-e2e).
+// Subtests share the one cluster/module-operator deployment set up by CI, so
+// they run in a fixed order: validation first (does not mutate the singleton
+// CR), then the lifecycle test which creates and tears down the CR.
+func TestE2E(t *testing.T) {
+	t.Run("validation", TestValidation)
+	t.Run("lifecycle", TestLifecycle)
+}

--- a/trustyai-operator-module/tests/e2e/lifecycle_test.go
+++ b/trustyai-operator-module/tests/e2e/lifecycle_test.go
@@ -1,0 +1,90 @@
+//go:build e2e
+
+//nolint:testpackage
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/onsi/gomega"
+	common "github.com/opendatahub-io/odh-platform-utilities/api/common"
+	"github.com/trustyai-explainability/trustyai-operator-module/pkg/trustyaimodule"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// TestLifecycle drives the singleton TrustyAI CR through creation, the
+// Removed management-state cleanup path, and deletion against a real
+// cluster - the parts of the reconciler that are stable regardless of #872's
+// in-flight health/GC rewrite. It seeds a Prometheus instance first so the
+// required-dependency precondition gate doesn't block reconciliation before
+// it ever reaches the DSC ConfigMap this test exercises.
+func TestLifecycle(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ctx := context.Background()
+
+	g.Expect(createPrometheusInstance(ctx, OperatorNamespace, "e2e-prometheus")).To(gomega.Succeed())
+	t.Cleanup(func() {
+		_ = deletePrometheusInstance(ctx, OperatorNamespace, "e2e-prometheus")
+	})
+
+	t.Run("creates the singleton CR and adds a finalizer", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		module := newManagedTrustyAI(InstanceName)
+		g.Expect(k8sClient.Create(ctx, module)).To(gomega.Succeed())
+
+		g.Eventually(func() []string {
+			m, err := getModule(ctx)
+			if err != nil {
+				return nil
+			}
+			return m.Finalizers
+		}, pollTimeout, pollInterval).Should(gomega.ContainElement(trustyaimodule.FinalizerName))
+	})
+
+	t.Run("reconciles past the dependency gate and creates the DSC ConfigMap", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		g.Eventually(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{
+				Name:      trustyaimodule.DSCConfigMapName,
+				Namespace: OperatorNamespace,
+			}, &corev1.ConfigMap{})
+		}, pollTimeout, pollInterval).Should(gomega.Succeed())
+	})
+
+	t.Run("Removed management state deletes the DSC ConfigMap and clears observedGeneration lag", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		module, err := getModule(ctx)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		module.Spec.ManagementState = common.Removed
+		g.Expect(k8sClient.Update(ctx, module)).To(gomega.Succeed())
+
+		g.Eventually(func() bool {
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      trustyaimodule.DSCConfigMapName,
+				Namespace: OperatorNamespace,
+			}, &corev1.ConfigMap{})
+			return errors.IsNotFound(err)
+		}, pollTimeout, pollInterval).Should(gomega.BeTrue())
+
+		g.Eventually(func() common.Phase {
+			m, err := getModule(ctx)
+			if err != nil {
+				return ""
+			}
+			return m.Status.Phase
+		}, pollTimeout, pollInterval).Should(gomega.Equal(common.PhaseNotReady))
+	})
+
+	t.Run("deleting the CR removes it and the finalizer completes cleanup", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		module, err := getModule(ctx)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		g.Expect(k8sClient.Delete(ctx, module)).To(gomega.Succeed())
+		g.Expect(waitForModuleGone(ctx)).To(gomega.Succeed())
+	})
+}

--- a/trustyai-operator-module/tests/e2e/setup_test.go
+++ b/trustyai-operator-module/tests/e2e/setup_test.go
@@ -1,0 +1,19 @@
+//go:build e2e
+
+//nolint:testpackage
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	if err := SetupTestEnv(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to set up e2e test environment: %v\n", err)
+		os.Exit(1)
+	}
+
+	os.Exit(m.Run())
+}

--- a/trustyai-operator-module/tests/e2e/test_utils.go
+++ b/trustyai-operator-module/tests/e2e/test_utils.go
@@ -33,7 +33,7 @@ const (
 	DeploymentName = "trustyai-operator-module-controller-manager"
 
 	// InstanceName is the only name the singleton CRD's CEL rule accepts.
-	InstanceName = "default"
+	InstanceName = "default-trustyai"
 
 	pollInterval = 2 * time.Second
 	pollTimeout  = 2 * time.Minute

--- a/trustyai-operator-module/tests/e2e/test_utils.go
+++ b/trustyai-operator-module/tests/e2e/test_utils.go
@@ -1,0 +1,136 @@
+//go:build e2e
+
+//nolint:testpackage
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	platformv1alpha1 "github.com/trustyai-explainability/trustyai-operator-module/pkg/apis/v1alpha1"
+)
+
+const (
+	// OperatorNamespace is the namespace the module operator is deployed into
+	// by config/default (namePrefix "trustyai-operator-module-" is applied to
+	// resource names, not the "system" namespace itself).
+	OperatorNamespace = "system"
+
+	// DeploymentName is the module operator's own Deployment name.
+	DeploymentName = "trustyai-operator-module-controller-manager"
+
+	// InstanceName is the only name the singleton CRD's CEL rule accepts.
+	InstanceName = "default"
+
+	pollInterval = 2 * time.Second
+	pollTimeout  = 2 * time.Minute
+)
+
+// prometheusGVK matches dependencies.go's required-dependency check. The live
+// cluster has no Prometheus operator, so the lifecycle test seeds a bare
+// instance via the same minimal CRD fixture used by the envtest suite
+// (tests/crds/monitoring.coreos.com_prometheuses.yaml) to clear that gate -
+// otherwise reconciliation never proceeds far enough to create/delete the
+// DSC ConfigMap this test exercises.
+var prometheusGVK = schema.GroupVersionKind{
+	Group:   "monitoring.coreos.com",
+	Version: "v1",
+	Kind:    "Prometheus",
+}
+
+func createPrometheusInstance(ctx context.Context, namespace, name string) error {
+	prom := &unstructured.Unstructured{}
+	prom.SetGroupVersionKind(prometheusGVK)
+	prom.SetName(name)
+	prom.SetNamespace(namespace)
+	return k8sClient.Create(ctx, prom)
+}
+
+func deletePrometheusInstance(ctx context.Context, namespace, name string) error {
+	prom := &unstructured.Unstructured{}
+	prom.SetGroupVersionKind(prometheusGVK)
+	prom.SetName(name)
+	prom.SetNamespace(namespace)
+	err := k8sClient.Delete(ctx, prom)
+	if errors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}
+
+// k8sClient is the real cluster client shared by every e2e test in this package.
+var k8sClient client.Client
+
+// SetupTestEnv builds a real client.Client against the cluster pointed to by
+// the ambient kubeconfig (KUBECONFIG env var or in-cluster config). Unlike the
+// envtest-based suite in pkg/trustyaimodule, this drives an actual Kind (or
+// any real) cluster, so Deployments/Pods genuinely run.
+func SetupTestEnv() error {
+	scheme := clientgoscheme.Scheme
+	utilruntime.Must(platformv1alpha1.AddToScheme(scheme))
+
+	cfg, err := ctrl.GetConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load kubeconfig: %w", err)
+	}
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+
+	return nil
+}
+
+func newManagedTrustyAI(name string) *platformv1alpha1.TrustyAI {
+	return &platformv1alpha1.TrustyAI{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+}
+
+// requireDeploymentReady polls until the named Deployment has at least one
+// available replica, or the timeout elapses.
+func requireDeploymentReady(ctx context.Context, namespace, name string) error {
+	key := types.NamespacedName{Name: name, Namespace: namespace}
+	return wait.PollUntilContextTimeout(ctx, pollInterval, pollTimeout, true, func(ctx context.Context) (bool, error) {
+		dep := &appsv1.Deployment{}
+		if err := k8sClient.Get(ctx, key, dep); err != nil {
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		return dep.Status.AvailableReplicas > 0, nil
+	})
+}
+
+// getModule fetches the singleton TrustyAI CR.
+func getModule(ctx context.Context) (*platformv1alpha1.TrustyAI, error) {
+	module := &platformv1alpha1.TrustyAI{}
+	err := k8sClient.Get(ctx, types.NamespacedName{Name: InstanceName}, module)
+	return module, err
+}
+
+// waitForModuleGone polls until the singleton TrustyAI CR no longer exists.
+func waitForModuleGone(ctx context.Context) error {
+	return wait.PollUntilContextTimeout(ctx, pollInterval, pollTimeout, true, func(ctx context.Context) (bool, error) {
+		_, err := getModule(ctx)
+		if errors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	})
+}

--- a/trustyai-operator-module/tests/e2e/validation_test.go
+++ b/trustyai-operator-module/tests/e2e/validation_test.go
@@ -1,0 +1,40 @@
+//go:build e2e
+
+//nolint:testpackage
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+)
+
+// TestValidation checks cluster-level preconditions that must hold before the
+// lifecycle test runs: the module operator itself is up, and the CRD's
+// singleton-name admission rule is enforced by the live API server (not just
+// asserted in a unit test against the Go struct/string constant).
+func TestValidation(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("module operator deployment is ready", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		g.Expect(requireDeploymentReady(ctx, OperatorNamespace, DeploymentName)).To(gomega.Succeed())
+	})
+
+	t.Run("rejects a TrustyAI resource not named 'default'", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		invalid := newManagedTrustyAI("not-" + InstanceName)
+		err := k8sClient.Create(ctx, invalid)
+		g.Expect(err).To(gomega.HaveOccurred())
+		g.Expect(err.Error()).To(gomega.ContainSubstring("must be named 'default'"))
+	})
+
+	t.Run("no stale singleton CR left over from a previous run", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		_, err := getModule(ctx)
+		g.Expect(errors.IsNotFound(err)).To(gomega.BeTrue(),
+			"expected no TrustyAI/%s CR to exist yet; got: %v", InstanceName, err)
+	})
+}

--- a/trustyai-operator-module/tests/e2e/validation_test.go
+++ b/trustyai-operator-module/tests/e2e/validation_test.go
@@ -23,12 +23,12 @@ func TestValidation(t *testing.T) {
 		g.Expect(requireDeploymentReady(ctx, OperatorNamespace, DeploymentName)).To(gomega.Succeed())
 	})
 
-	t.Run("rejects a TrustyAI resource not named 'default'", func(t *testing.T) {
+	t.Run("rejects a TrustyAI resource not named 'default-trustyai'", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 		invalid := newManagedTrustyAI("not-" + InstanceName)
 		err := k8sClient.Create(ctx, invalid)
 		g.Expect(err).To(gomega.HaveOccurred())
-		g.Expect(err.Error()).To(gomega.ContainSubstring("must be named 'default'"))
+		g.Expect(err.Error()).To(gomega.ContainSubstring("must be named 'default-trustyai'"))
 	})
 
 	t.Run("no stale singleton CR left over from a previous run", func(t *testing.T) {


### PR DESCRIPTION
Adds a real-cluster (Kind) e2e test suite for trustyai-operator-module, closing part of the "operand health / lifecycle" gap from the module E2E testing sign-off. Complements
  the envtest-based reconciler tests in #893 — envtest runs a real API server but no kubelet/scheduler, so it structurally cannot verify things like a real Deployment becoming 
  Available or live singleton-CR admission end-to-end.                                                                                                                          
                                                                                                                                                                                
  What's included                                                                                                                                                               
                                                                                                                                                                                
  .github/workflows/trustyai-module-e2e-test.yaml — mirrors this repo's existing smoke.yaml conventions: Docker buildx build → Kind cluster → kind load docker-image (no        
  registry needed) → deploy via make deploy-tom → kubectl wait --for=condition=available → run e2e tests → diagnostics collection on failure.                                   
                                                                                                                                                                                
  trustyai-operator-module/tests/e2e/ — a real-kubeconfig e2e suite (TestE2E) covering the parts of the reconciler that are stable regardless of #872's in-flight rewrite:      
  - TestValidation: module operator deployment reaches Available; singleton CEL rejection enforced by a live API server (not just a unit assertion on the Go constant); no stale
    CR left over from a prior run.                                                                                                                                              
  - TestLifecycle: creates the singleton CR → finalizer added → reconciles past the required-Prometheus dependency gate → DSC ConfigMap created → ManagementState: Removed      
    deletes the ConfigMap and sets phase NotReady → deleting the CR completes finalizer cleanup.                                                                                
                                                                                                                                                                                
  Test files are gated behind a //go:build e2e tag so make test-tom's plain go test ./... doesn't try to dial a real cluster (TestMain calls SetupTestEnv() unconditionally).   
                                                                                                                                                                                
  Fixture: adds tests/crds/monitoring.coreos.com_prometheuses.yaml (minimal test-only CRD, same convention as the existing route_crd.yaml) since checkPrometheus gates          
  reconciliation and no Prometheus CRD fixture existed in the repo.                                                                                                             
                                                                                                                                                                                
  Also included: the stale CRD/RBAC regeneration fix from #893 (cherry-picked — this branch is based on plain main, which doesn't have it yet). Without it,                     
  precondition.RunAll's success path writes conditions with an empty reason, which 422s against the old CRD schema — this would make the "creates the DSC ConfigMap" assertion  
  fail every run for a reason unrelated to the module's actual behavior. deploy-tom also gets a missing kustomize Make prerequisite it needs to actually run in CI.
  
  Deliberately out of scope                                                                                                                                                     
                                                                                                                                                                                
  Operand-health/Ready-condition assertions against the deployed workload manifests — buildHealthCheckers() is being rewritten in #872, so any such assertion now would need    
  rework anyway.