### PR TITLE
fix(tas): self-heal on missing KServe CRD, recover from immutable Deployment selector

### DIFF
--- a/controllers/tas/constants.go
+++ b/controllers/tas/constants.go
@@ -76,6 +76,7 @@ const prometheusUserWorkloadNamespace = "openshift-user-workload-monitoring"
 // Event reasons
 const (
 	EventReasonPVCCreated                      = "PVCCreated"
+	EventReasonDeploymentCreated               = "DeploymentCreated"
 	EventReasonInferenceServiceConfigured      = "InferenceServiceConfigured"
 	EventReasonServiceMonitorCreated           = "ServiceMonitorCreated"
 	EventReasonMetricsReaderSACreated          = "MetricsReaderServiceAccountCreated"

--- a/controllers/tas/crd_checks_test.go
+++ b/controllers/tas/crd_checks_test.go
@@ -1,0 +1,45 @@
+package tas
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// Regression test for a bug where isVirtualServiceCRDPresent checked the
+// DestinationRule CRD name instead of its own, so the two checks could never
+// disagree even though they gate independent features.
+var _ = Describe("Optional CRD presence checks", func() {
+	It("checks each optional CRD by its own distinct name", func() {
+		crd := func(name string) *apiextensionsv1.CustomResourceDefinition {
+			return &apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: name}}
+		}
+
+		// Only the DestinationRule CRD exists.
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(
+			crd(destinationRuleCDRName),
+		).Build()
+		r := &TrustyAIServiceReconciler{
+			Client:        fakeClient,
+			Scheme:        scheme.Scheme,
+			EventRecorder: record.NewFakeRecorder(10),
+			Namespace:     operatorNamespace,
+		}
+
+		present, err := r.isDestinationRuleCRDPresent(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(present).To(BeTrue(), "DestinationRule CRD should be reported present")
+
+		present, err = r.isVirtualServiceCRDPresent(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(present).To(BeFalse(), "VirtualService CRD should be reported absent when only DestinationRule exists")
+
+		present, err = r.isInferenceServiceCRDPresent(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(present).To(BeFalse(), "InferenceService CRD should be reported absent when only DestinationRule exists")
+	})
+})

--- a/controllers/tas/deployment.go
+++ b/controllers/tas/deployment.go
@@ -163,6 +163,32 @@ func (r *TrustyAIServiceReconciler) updateDeployment(ctx context.Context, cr *tr
 		log.FromContext(ctx).Error(err, "Error setting TrustyAIService as owner of Deployment.")
 		return err
 	}
+
+	existing := &appsv1.Deployment{}
+	err = r.Get(ctx, types.NamespacedName{Name: deployment.Name, Namespace: deployment.Namespace}, existing)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			log.FromContext(ctx).Info("Deployment not found during update, creating it.")
+			return r.Create(ctx, deployment)
+		}
+		return err
+	}
+
+	if !reflect.DeepEqual(existing.Spec.Selector, deployment.Spec.Selector) {
+		// spec.selector is immutable — recover by deleting and recreating the Deployment
+		log.FromContext(ctx).Info("Deployment selector changed, deleting and recreating Deployment.", "Deployment", deployment.Name)
+		if err := r.Delete(ctx, existing); err != nil {
+			log.FromContext(ctx).Error(err, "Error deleting Deployment with stale selector.")
+			return err
+		}
+		if err := r.Create(ctx, deployment); err != nil {
+			log.FromContext(ctx).Error(err, "Error recreating Deployment after selector change.")
+			return err
+		}
+		return nil
+	}
+
+	deployment.ResourceVersion = existing.ResourceVersion
 	log.FromContext(ctx).Info("Updating Deployment.")
 	err = r.Update(ctx, deployment)
 	if err != nil {

--- a/controllers/tas/deployment.go
+++ b/controllers/tas/deployment.go
@@ -14,6 +14,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -132,6 +133,7 @@ func (r *TrustyAIServiceReconciler) createDeployment(ctx context.Context, cr *tr
 		log.FromContext(ctx).Error(err, "Error creating Deployment.")
 		return err
 	}
+	r.eventDeploymentCreated(cr, "Deployment created")
 	// Created successfully
 	return nil
 
@@ -169,8 +171,18 @@ func (r *TrustyAIServiceReconciler) updateDeployment(ctx context.Context, cr *tr
 	if err != nil {
 		if errors.IsNotFound(err) {
 			log.FromContext(ctx).Info("Deployment not found during update, creating it.")
-			return r.Create(ctx, deployment)
+			if err := r.Create(ctx, deployment); err != nil {
+				return err
+			}
+			r.eventDeploymentCreated(cr, "Deployment created")
+			return nil
 		}
+		return err
+	}
+
+	if !metav1.IsControlledBy(existing, cr) {
+		err := fmt.Errorf("existing Deployment %s/%s is not controlled by TrustyAIService %s, refusing to modify it", existing.Namespace, existing.Name, cr.Name)
+		log.FromContext(ctx).Error(err, "Deployment ownership conflict")
 		return err
 	}
 
@@ -185,6 +197,7 @@ func (r *TrustyAIServiceReconciler) updateDeployment(ctx context.Context, cr *tr
 			log.FromContext(ctx).Error(err, "Error recreating Deployment after selector change.")
 			return err
 		}
+		r.eventDeploymentCreated(cr, "Deployment recreated due to immutable selector change")
 		return nil
 	}
 

--- a/controllers/tas/deployment_test.go
+++ b/controllers/tas/deployment_test.go
@@ -17,7 +17,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -723,6 +725,66 @@ var _ = Describe("TrustyAI operator", func() {
 
 		})
 
+	})
+
+	Context("When the existing Deployment has a stale immutable selector", func() {
+		var instance *trustyaiopendatahubiov1.TrustyAIService
+		It("deletes and recreates the Deployment instead of failing to update it", func() {
+			namespace := "trusty-ns-a-5-stale-selector"
+			instance = createDefaultPVCCustomResource(namespace)
+
+			// Intercept Delete/Update calls for the Deployment to prove the code
+			// takes the delete+recreate path rather than attempting a plain Update
+			// (which a real API server would reject for an immutable field change).
+			var deploymentDeleted, deploymentUpdated bool
+			trackingClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithInterceptorFuncs(interceptor.Funcs{
+				Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+					if _, ok := obj.(*appsv1.Deployment); ok {
+						deploymentDeleted = true
+					}
+					return c.Delete(ctx, obj, opts...)
+				},
+				Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+					if _, ok := obj.(*appsv1.Deployment); ok {
+						deploymentUpdated = true
+					}
+					return c.Update(ctx, obj, opts...)
+				},
+			}).Build()
+			k8sClient = trackingClient
+			reconciler = &TrustyAIServiceReconciler{
+				Client:        trackingClient,
+				Scheme:        scheme.Scheme,
+				EventRecorder: recorder,
+				Namespace:     operatorNamespace,
+			}
+
+			Expect(createNamespace(ctx, k8sClient, namespace)).To(Succeed())
+			Expect(k8sClient.Create(ctx, createConfigMap(operatorNamespace, testKubeRBACProxyImage, testTrustAIServiceImage))).To(Succeed())
+			caBundle := reconciler.GetCustomCertificatesBundle(ctx, instance)
+
+			Expect(createTestPVC(ctx, k8sClient, instance)).To(Succeed())
+			Expect(reconciler.createServiceAccount(ctx, instance)).To(Succeed())
+
+			// Simulate a Deployment left over from an older operator version with a
+			// different (now stale) selector, as if the label convention changed
+			// across an upgrade.
+			desired, err := reconciler.createDeploymentObject(ctx, instance, testTrustAIServiceImage, caBundle)
+			Expect(err).ToNot(HaveOccurred())
+			stale := desired.DeepCopy()
+			stale.Spec.Selector.MatchLabels["app"] = "stale-value"
+			stale.Spec.Template.Labels["app"] = "stale-value"
+			Expect(k8sClient.Create(ctx, stale)).To(Succeed())
+
+			Expect(reconciler.updateDeployment(ctx, instance, testTrustAIServiceImage, caBundle)).To(Succeed())
+
+			deployment := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, deployment)).To(Succeed())
+
+			Expect(deployment.Spec.Selector.MatchLabels["app"]).To(Equal(instance.Name), "selector should match the current desired value, not the stale one")
+			Expect(deploymentDeleted).To(BeTrue(), "stale Deployment should have been deleted")
+			Expect(deploymentUpdated).To(BeFalse(), "Deployment should not be updated in place when the selector changed")
+		})
 	})
 
 	Context("When deploying with no custom CA bundle ConfigMap", func() {

--- a/controllers/tas/deployment_test.go
+++ b/controllers/tas/deployment_test.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -774,6 +775,7 @@ var _ = Describe("TrustyAI operator", func() {
 			stale := desired.DeepCopy()
 			stale.Spec.Selector.MatchLabels["app"] = "stale-value"
 			stale.Spec.Template.Labels["app"] = "stale-value"
+			Expect(ctrl.SetControllerReference(instance, stale, reconciler.Scheme)).To(Succeed())
 			Expect(k8sClient.Create(ctx, stale)).To(Succeed())
 
 			Expect(reconciler.updateDeployment(ctx, instance, testTrustAIServiceImage, caBundle)).To(Succeed())
@@ -784,6 +786,60 @@ var _ = Describe("TrustyAI operator", func() {
 			Expect(deployment.Spec.Selector.MatchLabels["app"]).To(Equal(instance.Name), "selector should match the current desired value, not the stale one")
 			Expect(deploymentDeleted).To(BeTrue(), "stale Deployment should have been deleted")
 			Expect(deploymentUpdated).To(BeFalse(), "Deployment should not be updated in place when the selector changed")
+		})
+	})
+
+	Context("When a same-named Deployment exists but is not owned by the CR", func() {
+		var instance *trustyaiopendatahubiov1.TrustyAIService
+		It("refuses to delete or update the foreign Deployment", func() {
+			namespace := "trusty-ns-a-6-foreign-deployment"
+			instance = createDefaultPVCCustomResource(namespace)
+
+			var deploymentDeleted, deploymentUpdated bool
+			trackingClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithInterceptorFuncs(interceptor.Funcs{
+				Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+					if _, ok := obj.(*appsv1.Deployment); ok {
+						deploymentDeleted = true
+					}
+					return c.Delete(ctx, obj, opts...)
+				},
+				Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+					if _, ok := obj.(*appsv1.Deployment); ok {
+						deploymentUpdated = true
+					}
+					return c.Update(ctx, obj, opts...)
+				},
+			}).Build()
+			k8sClient = trackingClient
+			reconciler = &TrustyAIServiceReconciler{
+				Client:        trackingClient,
+				Scheme:        scheme.Scheme,
+				EventRecorder: recorder,
+				Namespace:     operatorNamespace,
+			}
+
+			Expect(createNamespace(ctx, k8sClient, namespace)).To(Succeed())
+			Expect(k8sClient.Create(ctx, createConfigMap(operatorNamespace, testKubeRBACProxyImage, testTrustAIServiceImage))).To(Succeed())
+			caBundle := reconciler.GetCustomCertificatesBundle(ctx, instance)
+
+			Expect(createTestPVC(ctx, k8sClient, instance)).To(Succeed())
+			Expect(reconciler.createServiceAccount(ctx, instance)).To(Succeed())
+
+			// A Deployment with the same name/namespace the operator would use,
+			// but with no OwnerReference back to our CR (e.g. created by a user
+			// or another controller before this CR existed).
+			foreign, err := reconciler.createDeploymentObject(ctx, instance, testTrustAIServiceImage, caBundle)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(k8sClient.Create(ctx, foreign)).To(Succeed())
+
+			Expect(reconciler.updateDeployment(ctx, instance, testTrustAIServiceImage, caBundle)).To(HaveOccurred())
+
+			Expect(deploymentDeleted).To(BeFalse(), "foreign Deployment should not be deleted")
+			Expect(deploymentUpdated).To(BeFalse(), "foreign Deployment should not be updated")
+
+			deployment := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, deployment)).To(Succeed())
+			Expect(deployment.OwnerReferences).To(BeEmpty(), "foreign Deployment should remain unowned")
 		})
 	})
 

--- a/controllers/tas/destination_rule.go
+++ b/controllers/tas/destination_rule.go
@@ -31,7 +31,7 @@ type DestinationRuleConfig struct {
 func (r *TrustyAIServiceReconciler) isDestinationRuleCRDPresent(ctx context.Context) (bool, error) {
 	crd := &apiextensionsv1.CustomResourceDefinition{}
 
-	err := r.Get(ctx, types.NamespacedName{Name: destinationRuleCDRName}, crd)
+	err := r.crdReader().Get(ctx, types.NamespacedName{Name: destinationRuleCDRName}, crd)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return false, fmt.Errorf("error getting "+destinationRuleCDRName+" CRD: %v", err)

--- a/controllers/tas/events.go
+++ b/controllers/tas/events.go
@@ -17,6 +17,10 @@ func (r *TrustyAIServiceReconciler) eventPVCCreated(instance *trustyaiopendatahu
 	r.EventRecorder.Event(instance, corev1.EventTypeNormal, EventReasonPVCCreated, "PVC created")
 }
 
+func (r *TrustyAIServiceReconciler) eventDeploymentCreated(instance *trustyaiopendatahubiov1.TrustyAIService, message string) {
+	r.EventRecorder.Event(instance, corev1.EventTypeNormal, EventReasonDeploymentCreated, message)
+}
+
 func (r *TrustyAIServiceReconciler) eventLocalServiceMonitorCreated(instance *trustyaiopendatahubiov1.TrustyAIService) {
 	r.EventRecorder.Event(instance, corev1.EventTypeNormal, EventReasonServiceMonitorCreated, "Local ServiceMonitor created")
 }

--- a/controllers/tas/inference_services.go
+++ b/controllers/tas/inference_services.go
@@ -10,7 +10,10 @@ import (
 	"github.com/trustyai-explainability/trustyai-service-operator/controllers/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -21,7 +24,26 @@ const (
 	DEPLOYMENT_MODE_STANDARD   = "Standard"
 	DEPLOYMENT_MODE_SERVERLESS = "Serverless"
 	DEPLOYMENT_MODE_KNATIVE    = "Knative"
+
+	inferenceServiceCRDName = "inferenceservices.serving.kserve.io"
 )
+
+// isInferenceServiceCRDPresent returns true if the KServe InferenceService CRD is present, false otherwise
+func (r *TrustyAIServiceReconciler) isInferenceServiceCRDPresent(ctx context.Context) (bool, error) {
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+
+	err := r.crdReader().Get(ctx, types.NamespacedName{Name: inferenceServiceCRDName}, crd)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return false, fmt.Errorf("error getting "+inferenceServiceCRDName+" CRD: %v", err)
+		}
+		// Not found
+		return false, nil
+	}
+
+	// Found
+	return true, nil
+}
 
 // GetDeploymentsByLabel returns a list of Deployments that match a label key-value pair
 func (r *TrustyAIServiceReconciler) GetDeploymentsByLabel(ctx context.Context, namespace string, labelKey string, labelValue string) ([]appsv1.Deployment, error) {
@@ -214,6 +236,16 @@ func generateEnvVarValue(currentValue, newValue string, remove bool) string {
 }
 
 func (r *TrustyAIServiceReconciler) handleInferenceServices(ctx context.Context, instance *trustyaiopendatahubiov1.TrustyAIService, namespace string, labelKey, labelValue, envVarName, crName string, remove bool) (bool, error) {
+	crdPresent, err := r.isInferenceServiceCRDPresent(ctx)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "Error verifying InferenceService CRD is present")
+		return false, err
+	}
+	if !crdPresent {
+		log.FromContext(ctx).Info("InferenceService CRD not found, skipping InferenceService handling. Will retry on next reconcile.")
+		return true, nil
+	}
+
 	var inferenceServices kservev1beta1.InferenceServiceList
 
 	if err := r.List(ctx, &inferenceServices, client.InNamespace(namespace)); err != nil {
@@ -367,6 +399,14 @@ func (r *TrustyAIServiceReconciler) patchKServe(ctx context.Context, instance *t
 }
 
 func (r *TrustyAIServiceReconciler) checkInferenceServicesPresent(ctx context.Context, namespace string) (bool, error) {
+	crdPresent, err := r.isInferenceServiceCRDPresent(ctx)
+	if err != nil {
+		return false, err
+	}
+	if !crdPresent {
+		return false, nil
+	}
+
 	infServiceList := &kservev1beta1.InferenceServiceList{}
 	if err := r.List(ctx, infServiceList, client.InNamespace(namespace)); err != nil {
 		return false, err

--- a/controllers/tas/statuses_test.go
+++ b/controllers/tas/statuses_test.go
@@ -9,6 +9,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	trustyaiopendatahubiov1 "github.com/trustyai-explainability/trustyai-service-operator/api/tas/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -64,10 +65,13 @@ var _ = Describe("Status and condition tests", func() {
 
 	BeforeEach(func() {
 		operatorCM := createConfigMap(operatorNamespace, testKubeRBACProxyImage, testTrustAIServiceImage)
+		inferenceServiceCRD := &apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{Name: inferenceServiceCRDName},
+		}
 		k8sClient = fake.NewClientBuilder().WithScheme(scheme.Scheme).WithStatusSubresource(
 			&routev1.Route{},
 			&trustyaiopendatahubiov1.TrustyAIService{},
-		).WithObjects(operatorCM).Build()
+		).WithObjects(operatorCM, inferenceServiceCRD).Build()
 		recorder = record.NewFakeRecorder(10)
 		reconciler = &TrustyAIServiceReconciler{
 			Client:        k8sClient,

--- a/controllers/tas/suite_test.go
+++ b/controllers/tas/suite_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/trustyai-explainability/trustyai-service-operator/controllers/constants"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -523,6 +524,10 @@ var _ = BeforeSuite(func() {
 	err = routev1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
+	// Add CRDs (needed for isXCRDPresent checks, e.g. isInferenceServiceCRDPresent)
+	err = apiextensionsv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
 	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
@@ -542,6 +547,7 @@ var _ = BeforeSuite(func() {
 
 	err = (&TrustyAIServiceReconciler{
 		Client:        k8sManager.GetClient(),
+		APIReader:     k8sManager.GetAPIReader(),
 		Scheme:        k8sManager.GetScheme(),
 		EventRecorder: recorder,
 		Namespace:     operatorNamespace,

--- a/controllers/tas/trustyaiservice_controller.go
+++ b/controllers/tas/trustyaiservice_controller.go
@@ -39,9 +39,20 @@ import (
 
 var ErrPVCNotReady = goerrors.New("PVC is not ready")
 
+// crdReader returns an uncached reader for one-off CRD-existence checks, avoiding
+// the manager cache's informer-sync race on first access to a not-yet-watched GVK.
+// Falls back to Client if APIReader is unset (e.g. unit tests using a fake client).
+func (r *TrustyAIServiceReconciler) crdReader() client.Reader {
+	if r.APIReader != nil {
+		return r.APIReader
+	}
+	return r.Client
+}
+
 func ControllerSetUp(mgr manager.Manager, ns, configmap string, recorder record.EventRecorder) error {
 	return (&TrustyAIServiceReconciler{
 		Client:        mgr.GetClient(),
+		APIReader:     mgr.GetAPIReader(),
 		Scheme:        mgr.GetScheme(),
 		Namespace:     ns,
 		EventRecorder: recorder,
@@ -51,6 +62,11 @@ func ControllerSetUp(mgr manager.Manager, ns, configmap string, recorder record.
 // TrustyAIServiceReconciler reconciles a TrustyAIService object
 type TrustyAIServiceReconciler struct {
 	client.Client
+	// APIReader is an uncached client used for one-off existence checks (e.g. optional
+	// CRD presence) that must not be affected by the manager cache's informer-sync race
+	// on first access to a not-yet-watched GVK. Falls back to Client if unset (e.g. in
+	// tests that don't wire it up).
+	APIReader     client.Reader
 	Scheme        *runtime.Scheme
 	Namespace     string
 	EventRecorder record.EventRecorder

--- a/controllers/tas/virtual_service.go
+++ b/controllers/tas/virtual_service.go
@@ -31,7 +31,7 @@ type VirtualServiceConfig struct {
 func (r *TrustyAIServiceReconciler) isVirtualServiceCRDPresent(ctx context.Context) (bool, error) {
 	crd := &apiextensionsv1.CustomResourceDefinition{}
 
-	err := r.Get(ctx, types.NamespacedName{Name: virtualServiceCDRName}, crd)
+	err := r.crdReader().Get(ctx, types.NamespacedName{Name: virtualServiceCDRName}, crd)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return false, fmt.Errorf("error getting "+virtualServiceCDRName+" CRD: %v", err)

--- a/controllers/tas/virtual_service.go
+++ b/controllers/tas/virtual_service.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	virtualServiceTemplatePath = "service/virtual-service.tmpl.yaml"
-	virtualServiceCDRName      = "destinationrules.networking.istio.io"
+	virtualServiceCDRName      = "virtualservices.networking.istio.io"
 )
 
 // DestinationRuleConfig has the variables for the DestinationRule template


### PR DESCRIPTION

Two gaps identified while auditing TAS against the module-architecture testing responsibilities doc:

- KServe InferenceServices CRD: previously treated as a hard dependency via a plain List() call, so a missing/not-yet-installed CRD surfaced as a generic requeue-with-error loop. Adds isInferenceServiceCRDPresent, mirroring the existing isDestinationRuleCRDPresent/isVirtualServiceCRDPresent pattern, and gates both handleInferenceServices and checkInferenceServicesPresent on it so a missing CRD degrades gracefully instead of erroring every reconcile.

- Deployment spec.selector is immutable; updateDeployment previously called r.Update() unconditionally, which would fail forever against a real API server if the selector ever needed to change (e.g. a label convention change across an upgrade). Now fetches the existing Deployment first and deletes+recreates on a selector mismatch, mirroring the existing RoleRef delete/recreate pattern in monitor.go. Also fixes a latent bug this surfaced: r.Update() was being called without carrying over the existing object's ResourceVersion, which would have failed as a conflict against a real cluster.

Both isXCRDPresent helpers (destination_rule.go, virtual_service.go, and the new inference_services.go one) now read through a new crdReader() accessor backed by mgr.GetAPIReader() instead of the cached Client, to avoid a manager-cache informer-sync race on first access to a not-yet-watched GVK -- this exact race caused a real test failure while adding coverage here, and would have affected the two existing isXCRDPresent checks identically had they ever been exercised by a test (their only call site is gated behind an Istio-annotation branch no test currently sets).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deployments are now created when missing and recreated when immutable selectors change, preventing update failures.
  * Existing Deployments owned by another resource are preserved and reported as conflicts.
  * Reconciliation safely handles environments where optional service resources or CRDs are unavailable.
  * CRD availability checks now use reliable direct reads to avoid cache synchronization issues.
* **Events**
  * Deployment creation and recreation now generate Kubernetes events.
* **Tests**
  * Added coverage for deployment ownership, recreation, and CRD availability handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->