### PR TITLE
fix(evalhub): rename open-telco benchmark IDs to drop inspect/ prefix

### DIFF
--- a/config/configmaps/evalhub/collection-open-telco-v1.yaml
+++ b/config/configmaps/evalhub/collection-open-telco-v1.yaml
@@ -38,7 +38,7 @@ data:
     pass_criteria:
       threshold: 0.475
     benchmarks:
-      - id: inspect/telemath
+      - id: telemath
         provider_id: inspect
         weight: 1
         primary_score:
@@ -50,7 +50,7 @@ data:
           full: true
           num_examples: 50
 
-      - id: inspect/teleqna
+      - id: teleqna
         provider_id: inspect
         weight: 1
         primary_score:
@@ -63,7 +63,7 @@ data:
           subject: full
           num_examples: 50
 
-      - id: inspect/telelogs
+      - id: telelogs
         provider_id: inspect
         weight: 1
         primary_score:
@@ -76,7 +76,7 @@ data:
           eval_type: soft
           num_examples: 50
 
-      - id: inspect/3gpp-tsg
+      - id: 3gpp-tsg
         provider_id: inspect
         weight: 1
         primary_score:

--- a/config/configmaps/evalhub/provider-inspect.yaml
+++ b/config/configmaps/evalhub/provider-inspect.yaml
@@ -521,7 +521,7 @@ data:
         tags: [reasoning, math, inspect-evals]
 
       # Telecom (GSMA Open-Telco)
-      - id: inspect/telemath
+      - id: telemath
         name: TeleMath
         description: >
           Telecom-domain mathematical problem solving — 500 numerical Q&A pairs covering
@@ -541,7 +541,7 @@ data:
         agent:
           result_interpretation: "Accuracy on telecom-domain numerical math; HIGHER is better. GSMA leaderboard (Mar 2026): median ≈ 0.42, GPT-5 ≈ 0.79, top ≈ 0.87."
 
-      - id: inspect/teleqna
+      - id: teleqna
         name: TeleQnA
         description: >
           Telecom domain knowledge — multiple-choice questions on standards, research,
@@ -561,7 +561,7 @@ data:
         agent:
           result_interpretation: "Accuracy on telecom domain MCQ; HIGHER is better. GSMA leaderboard (Mar 2026): median ≈ 0.75, GPT-5 ≈ 0.84, top ≈ 0.91."
 
-      - id: inspect/telelogs
+      - id: telelogs
         name: TeleLogs
         description: >
           Root-cause analysis on 5G network data — models identify which of several
@@ -582,7 +582,7 @@ data:
         agent:
           result_interpretation: "Accuracy on 5G root-cause analysis; HIGHER is better. GSMA leaderboard (Mar 2026): median ≈ 0.23, GPT-5 ≈ 0.78, top ≈ 0.96."
 
-      - id: inspect/3gpp-tsg
+      - id: 3gpp-tsg
         name: 3GPP-TSG
         description: >
           3GPP technical specification group classification — models identify the

--- a/controllers/evalhub/open_telco_benchmark_ids_test.go
+++ b/controllers/evalhub/open_telco_benchmark_ids_test.go
@@ -1,0 +1,103 @@
+package evalhub
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/yaml"
+)
+
+var openTelcoBenchmarkIDs = []string{
+	"telemath",
+	"teleqna",
+	"telelogs",
+	"3gpp-tsg",
+}
+
+func moduleRoot(t *testing.T) string {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+}
+
+func readConfigMapData(t *testing.T, relPath string) map[string]string {
+	path := filepath.Join(moduleRoot(t), relPath)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	var cm corev1.ConfigMap
+	if err := yaml.Unmarshal(raw, &cm); err != nil {
+		t.Fatalf("unmarshal %s: %v", path, err)
+	}
+	return cm.Data
+}
+
+func TestOpenTelcoCollectionBenchmarkIDsAreK8sLabelSafe(t *testing.T) {
+	data := readConfigMapData(t, filepath.Join("config", "configmaps", "evalhub", "collection-open-telco-v1.yaml"))
+	raw, ok := data["open-telco-v1.yaml"]
+	if !ok {
+		t.Fatal("collection ConfigMap missing open-telco-v1.yaml key")
+	}
+
+	var collection struct {
+		Benchmarks []struct {
+			ID string `yaml:"id"`
+		} `yaml:"benchmarks"`
+	}
+	if err := yaml.Unmarshal([]byte(raw), &collection); err != nil {
+		t.Fatalf("unmarshal open-telco-v1 collection: %v", err)
+	}
+
+	got := make([]string, 0, len(collection.Benchmarks))
+	for _, b := range collection.Benchmarks {
+		got = append(got, b.ID)
+		if strings.Contains(b.ID, "/") {
+			t.Fatalf("benchmark id %q contains '/' and is unsafe for Kubernetes label values", b.ID)
+		}
+	}
+
+	if len(got) != len(openTelcoBenchmarkIDs) {
+		t.Fatalf("unexpected benchmark count: got=%v want=%v", got, openTelcoBenchmarkIDs)
+	}
+	for i, want := range openTelcoBenchmarkIDs {
+		if got[i] != want {
+			t.Fatalf("benchmark[%d]: got %q want %q", i, got[i], want)
+		}
+	}
+}
+
+func TestOpenTelcoProviderBenchmarkIDsMatchCollection(t *testing.T) {
+	data := readConfigMapData(t, filepath.Join("config", "configmaps", "evalhub", "provider-inspect.yaml"))
+	raw, ok := data["inspect.yaml"]
+	if !ok {
+		t.Fatal("provider ConfigMap missing inspect.yaml key")
+	}
+
+	var provider struct {
+		Benchmarks []struct {
+			ID string `yaml:"id"`
+		} `yaml:"benchmarks"`
+	}
+	if err := yaml.Unmarshal([]byte(raw), &provider); err != nil {
+		t.Fatalf("unmarshal provider-inspect provider.yaml: %v", err)
+	}
+
+	providerIDs := make(map[string]bool, len(provider.Benchmarks))
+	for _, b := range provider.Benchmarks {
+		providerIDs[b.ID] = true
+	}
+
+	for _, id := range openTelcoBenchmarkIDs {
+		if !providerIDs[id] {
+			t.Fatalf("provider-inspect missing benchmark id %q", id)
+		}
+	}
+}


### PR DESCRIPTION
Kubernetes label values cannot contain '/', so benchmark IDs like inspect/telemath were transformed when set on jobs and caused 404s when the failure reconciler posted events to EvalHub.

Renames telemath, teleqna, telelogs, and 3gpp-tsg in provider and collection configmaps to match eval-hub PR #957. Ref: [RHOAIENG-91579](https://redhat.atlassian.net/browse/RHOAIENG-91579)

For a summary of the manual tests done, please see [here](https://github.com/eval-hub/eval-hub/pull/957#:~:text=Tested%20manually-,Manual%20Test%20Summary,-%E2%9C%85%20Successfully%20deployed%20operator). There were errors while updating the operator image on the cluster, but all the changes in this PR were directly applied on the cluster for the tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Updated the identifiers for four Open Telco benchmarks to remove the `inspect/` prefix:
    - `telemath`
    - `teleqna`
    - `telelogs`
    - `3gpp-tsg`
  - Synchronized benchmark identifiers across the collection and provider configurations.
  - Benchmark metadata, evaluation settings, metrics, weights, and thresholds remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->