### PR TITLE
chore(evalhub): sync provider and collection configs

### DIFF
--- a/config/configmaps/evalhub/collection-document-understanding-v1.yaml
+++ b/config/configmaps/evalhub/collection-document-understanding-v1.yaml
@@ -1,0 +1,154 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: evalhub-collection-document-understanding-v1
+  labels:
+    trustyai.opendatahub.io/evalhub-collection-type: system
+    trustyai.opendatahub.io/evalhub-collection-name: document-understanding-v1
+data:
+  document-understanding-v1.yaml: |
+    id: document-understanding-v1
+    name: Grounded Document Understanding v1
+    category: document_understanding
+    description: >
+      Evaluates long-context retrieval, comprehension, and reasoning over extended documents.
+      RULER tests 13 synthetic tasks (needle-in-a-haystack, variable tracking, aggregation,
+      QA) at configurable context lengths. LongBench v2 provides real-world long-document
+      questions requiring multi-step reasoning.
+      Part of the Curated Collections taxonomy (#916).
+    tags:
+      - long_context
+      - retrieval
+      - comprehension
+      - ruler
+      - curated
+    domains:
+      - grounded_document_understanding
+    pass_criteria:
+      threshold: 0.35
+    benchmarks:
+      - id: niah-single-noise
+        provider_id: ruler
+        weight: 1
+        primary_score:
+          metric: string_match_all
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.50
+
+      - id: niah-single-essay
+        provider_id: ruler
+        weight: 1
+        primary_score:
+          metric: string_match_all
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.50
+
+      - id: niah-single-uuid
+        provider_id: ruler
+        weight: 1
+        primary_score:
+          metric: string_match_all
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.50
+
+      - id: niah-multikey
+        provider_id: ruler
+        weight: 1
+        primary_score:
+          metric: string_match_all
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.50
+
+      - id: niah-needle-bg
+        provider_id: ruler
+        weight: 1
+        primary_score:
+          metric: string_match_all
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.50
+
+      - id: niah-multikey-uuid
+        provider_id: ruler
+        weight: 1
+        primary_score:
+          metric: string_match_all
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.50
+
+      - id: niah-multivalue
+        provider_id: ruler
+        weight: 1
+        primary_score:
+          metric: string_match_all
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.50
+
+      - id: niah-multiquery
+        provider_id: ruler
+        weight: 1
+        primary_score:
+          metric: string_match_all
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.50
+
+      - id: variable-tracking
+        provider_id: ruler
+        weight: 1
+        primary_score:
+          metric: string_match_all
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.10
+
+      - id: common-words-extraction
+        provider_id: ruler
+        weight: 1
+        primary_score:
+          metric: string_match_all
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.10
+
+      - id: frequency-words-extraction
+        provider_id: ruler
+        weight: 1
+        primary_score:
+          metric: string_match_all
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.10
+
+      - id: qa-squad
+        provider_id: ruler
+        weight: 1
+        primary_score:
+          metric: string_match_part
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.15
+
+      - id: qa-hotpotqa
+        provider_id: ruler
+        weight: 1
+        primary_score:
+          metric: string_match_part
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.15
+
+      - id: longbenchv2
+        provider_id: lm_evaluation_harness
+        weight: 1
+        primary_score:
+          metric: accuracy
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.30

--- a/config/configmaps/evalhub/collection-instruction-output-v1.yaml
+++ b/config/configmaps/evalhub/collection-instruction-output-v1.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: evalhub-collection-instruction-output-v1
+  labels:
+    trustyai.opendatahub.io/evalhub-collection-type: system
+    trustyai.opendatahub.io/evalhub-collection-name: instruction-output-v1
+data:
+  instruction-output-v1.yaml: |
+    id: instruction-output-v1
+    name: Instruction & Output Reliability v1
+    category: instruction_output
+    description: >
+      Evaluates whether models produce outputs that conform to structural constraints.
+      JSONSchemaBench tests JSON schema compliance across easy, medium, and hard splits.
+      Note: lm-eval runs LM-only (no constrained decoding); scores vary drastically by split.
+      Part of the Curated Collections taxonomy (#916).
+    tags:
+      - instruction-following
+      - structured-output
+      - json
+      - lm_eval
+      - curated
+    domains:
+      - instruction_and_output_reliability
+    pass_criteria:
+      threshold: 0.60
+    benchmarks:
+      - id: jsonschema_bench
+        provider_id: lm_evaluation_harness
+        weight: 1
+        primary_score:
+          metric: schema_compliance
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.60

--- a/config/configmaps/evalhub/collection-knowledge-reasoning-v1.yaml
+++ b/config/configmaps/evalhub/collection-knowledge-reasoning-v1.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: evalhub-collection-knowledge-reasoning-v1
+  labels:
+    trustyai.opendatahub.io/evalhub-collection-type: system
+    trustyai.opendatahub.io/evalhub-collection-name: knowledge-reasoning-v1
+data:
+  knowledge-reasoning-v1.yaml: |
+    id: knowledge-reasoning-v1
+    name: Knowledge & Reasoning v1
+    category: knowledge_reasoning
+    description: >
+      Evaluates broad academic knowledge and expert-level reasoning. GPQA-Diamond tests
+      graduate-level science questions that resist internet lookup. HLE (Humanity's Last Exam)
+      is a 2,500-question frontier benchmark across dozens of subjects, designed to remain
+      unsaturated by current models.
+      Part of the Curated Collections taxonomy (#916).
+    tags:
+      - knowledge
+      - reasoning
+      - science
+      - inspect-evals
+      - curated
+    domains:
+      - knowledge_and_reasoning
+    pass_criteria:
+      threshold: 0.235
+    benchmarks:
+      - id: gpqa:diamond
+        provider_id: lighteval
+        weight: 1
+        primary_score:
+          metric: gpqa_pass@1
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.35
+
+      - id: inspect/hle
+        provider_id: inspect
+        weight: 1
+        primary_score:
+          metric: accuracy/accuracy
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.12
+        parameters:
+          task_args:
+            include_multi_modal: false
+            graders: [grader]

--- a/config/configmaps/evalhub/collection-multimodal-v1.yaml
+++ b/config/configmaps/evalhub/collection-multimodal-v1.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: evalhub-collection-multimodal-v1
+  labels:
+    trustyai.opendatahub.io/evalhub-collection-type: system
+    trustyai.opendatahub.io/evalhub-collection-name: multimodal-v1
+data:
+  multimodal-v1.yaml: |
+    id: multimodal-v1
+    name: Multimodal v1
+    category: multimodal
+    description: >
+      Evaluates vision-language understanding. DocVQA tests document visual question
+      answering — reading and reasoning over scanned document images. Requires a
+      vision-capable model.
+      Part of the Curated Collections taxonomy (#916).
+    tags:
+      - multimodal
+      - vision
+      - document-understanding
+      - inspect-evals
+      - curated
+    domains:
+      - multimodal
+    pass_criteria:
+      threshold: 0.50
+    benchmarks:
+      - id: inspect/docvqa
+        provider_id: inspect
+        weight: 1
+        primary_score:
+          metric: anls
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.50

--- a/config/configmaps/evalhub/collection-software-v1.yaml
+++ b/config/configmaps/evalhub/collection-software-v1.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: evalhub-collection-software-v1
+  labels:
+    trustyai.opendatahub.io/evalhub-collection-type: system
+    trustyai.opendatahub.io/evalhub-collection-name: software-v1
+data:
+  software-v1.yaml: |
+    id: software-v1
+    name: Software v1
+    category: software
+    description: >
+      Evaluates code generation and program comprehension. LiveCodeBench uses post-cutoff
+      competitive programming problems (contamination-free). BigCodeBench tests practical
+      coding tasks. CRUXEval tests code output prediction.
+      Part of the Curated Collections taxonomy (#916).
+    tags:
+      - code
+      - software
+      - competitive-programming
+      - curated
+    domains:
+      - software
+    pass_criteria:
+      threshold: 0.20
+    benchmarks:
+      - id: lcb:codegeneration_v6
+        provider_id: lighteval
+        weight: 1
+        primary_score:
+          metric: codegen_pass@1
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.25
+        parameters:
+          num_fewshot: 0
+          apply_chat_template: true
+          pass_at_k: 1
+          num_samples: 3
+
+      - id: inspect/bigcodebench
+        provider_id: inspect
+        weight: 1
+        primary_score:
+          metric: accuracy/accuracy
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.20
+
+      - id: cruxeval_output
+        provider_id: lm_evaluation_harness
+        weight: 1
+        primary_score:
+          metric: pass@1
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.15

--- a/config/configmaps/evalhub/collection-tool-use-v1.yaml
+++ b/config/configmaps/evalhub/collection-tool-use-v1.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: evalhub-collection-tool-use-v1
+  labels:
+    trustyai.opendatahub.io/evalhub-collection-type: system
+    trustyai.opendatahub.io/evalhub-collection-name: tool-use-v1
+data:
+  tool-use-v1.yaml: |
+    id: tool-use-v1
+    name: Tool Use & Function Calling v1
+    category: tool_use
+    description: >
+      Evaluates LLM ability to correctly invoke APIs and tools. BFCL (Berkeley Function Calling
+      Leaderboard) tests simple, parallel, multiple, and executable API invocations.
+      Part of the Curated Collections taxonomy (#916).
+    tags:
+      - tool-use
+      - function-calling
+      - api
+      - inspect-evals
+      - curated
+    domains:
+      - tool_use_and_function_calling
+    pass_criteria:
+      threshold: 0.60
+    benchmarks:
+      - id: inspect/bfcl
+        provider_id: inspect
+        weight: 1
+        primary_score:
+          metric: accuracy/accuracy
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.60

--- a/config/configmaps/evalhub/collection-trustworthiness-v1.yaml
+++ b/config/configmaps/evalhub/collection-trustworthiness-v1.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: evalhub-collection-trustworthiness-v1
+  labels:
+    trustyai.opendatahub.io/evalhub-collection-type: system
+    trustyai.opendatahub.io/evalhub-collection-name: trustworthiness-v1
+data:
+  trustworthiness-v1.yaml: |
+    id: trustworthiness-v1
+    name: Trustworthiness v1
+    category: trustworthiness
+    description: >
+      Evaluates model safety and robustness. StrongREJECT measures jailbreak resistance
+      (lower score = safer). CyberSecEval-PI tests prompt injection resistance (lower
+      injection success = better).
+      Note: AbstentionBench descoped from v1 due to isolated environment requirements.
+      Part of the Curated Collections taxonomy (#916).
+    tags:
+      - safety
+      - trustworthiness
+      - jailbreak
+      - prompt-injection
+      - inspect-evals
+      - curated
+    domains:
+      - trustworthiness
+    pass_criteria:
+      threshold: 0.325
+    benchmarks:
+      - id: inspect/strong-reject
+        provider_id: inspect
+        weight: 1
+        primary_score:
+          metric: accuracy/accuracy
+          lower_is_better: true
+        pass_criteria:
+          threshold: 1.0
+
+      - id: inspect/cyberseceval-2-pi
+        provider_id: inspect
+        weight: 1
+        primary_score:
+          metric: injection_successful_percentage
+          lower_is_better: true
+        pass_criteria:
+          threshold: 0.35

--- a/config/configmaps/evalhub/kustomization.yaml
+++ b/config/configmaps/evalhub/kustomization.yaml
@@ -8,15 +8,23 @@ resources:
   - provider-lighteval.yaml
   - provider-lm-evaluation-harness.yaml
   - provider-ragas.yaml
+  - provider-ruler.yaml
   - collection-coding-v1.yaml
+  - collection-document-understanding-v1.yaml
   - collection-instruction-following-v1.yaml
+  - collection-instruction-output-v1.yaml
+  - collection-knowledge-reasoning-v1.yaml
   - collection-leaderboard-v2.yaml
   - collection-long-context-v1.yaml
   - collection-model-validation.yaml
+  - collection-multimodal-v1.yaml
   - collection-open-telco-v1.yaml
   - collection-reasoning-v1.yaml
   - collection-safety-and-fairness-v1.yaml
+  - collection-software-v1.yaml
   - collection-standard-llm-evals-v1.yaml
+  - collection-tool-use-v1.yaml
   - collection-toxicity-and-ethical-principles.yaml
+  - collection-trustworthiness-v1.yaml
 
 namespace: system

--- a/config/configmaps/evalhub/provider-inspect.yaml
+++ b/config/configmaps/evalhub/provider-inspect.yaml
@@ -30,6 +30,8 @@ data:
         memory_limit: 4Gi
       local:
         # used for local mode tests (FVT)
+        # To run real benchmarks locally, override with the actual adapter path:
+        #   command: python /path/to/eval-hub-contrib/adapters/inspect/main.py
         command: python tests/features/test_data/runtime/main.py
 
     benchmarks:
@@ -462,6 +464,20 @@ data:
         metrics: [accuracy/accuracy]
         tags: [cybersecurity, inspect-evals]
 
+      - id: inspect/cyberseceval-2-pi
+        name: CyberSecEval 2 — Prompt Injection
+        description: >
+          Prompt injection subset of Meta's CyberSecEval 2 suite. Measures the percentage
+          of successful injection attacks against the model.
+        category: cybersecurity
+        metrics: [injection_successful_percentage]
+        primary_score:
+          metric: injection_successful_percentage
+          lower_is_better: true
+        pass_criteria:
+          threshold: 0.35
+        tags: [cybersecurity, prompt-injection, safety, inspect-evals]
+
       # Coding
       - id: inspect/humaneval
         name: HumanEval
@@ -666,6 +682,28 @@ data:
         metrics: [accuracy/accuracy]
         tags: [knowledge, factuality, inspect-evals]
 
+      # HLE requires a grader model for scoring. Pass model_roles.grader
+      # at run time via collection override, e.g.:
+      #   "parameters": { "model_roles": { "grader": "openai/gpt-4o-mini" } }
+      - id: inspect/hle
+        name: "Humanity's Last Exam"
+        description: >
+          Multi-modal benchmark of 2,500 frontier-difficulty questions across dozens of academic
+          subjects. ~14% of questions require image understanding. Designed to measure capabilities
+          beyond existing saturated benchmarks.
+        category: knowledge
+        metrics: [accuracy/accuracy]
+        primary_score:
+          metric: accuracy/accuracy
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.12
+        parameters:
+          task_args:
+            include_multi_modal: false
+            graders: [grader]
+        tags: [knowledge, reasoning, multimodal, inspect-evals]
+
       # Agent capabilities
       - id: inspect/gaia
         name: GAIA
@@ -687,6 +725,34 @@ data:
         category: agent
         metrics: [accuracy/accuracy]
         tags: [agent, inspect-evals]
+
+      - id: inspect/bfcl
+        name: Berkeley Function Calling Leaderboard
+        description: >
+          Tests LLM function-calling accuracy across simple, parallel, multiple,
+          and executable API invocations. V4 includes agentic-heavy weighting.
+        category: agent
+        metrics: [accuracy/accuracy]
+        primary_score:
+          metric: accuracy/accuracy
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.60
+        tags: [agent, tool-use, function-calling, inspect-evals]
+
+      - id: inspect/docvqa
+        name: DocVQA
+        description: >
+          Document Visual Question Answering — requires reading and reasoning over
+          scanned document images to answer questions. Multimodal (vision) input required.
+        category: multimodal
+        metrics: [anls]
+        primary_score:
+          metric: anls
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.50
+        tags: [multimodal, document-understanding, vision, inspect-evals]
 
       # Custom
       - id: inspect/custom

--- a/config/configmaps/evalhub/provider-lm-evaluation-harness.yaml
+++ b/config/configmaps/evalhub/provider-lm-evaluation-harness.yaml
@@ -3765,3 +3765,58 @@ data:
           meaning: Random baseline
         - range: 0.35-1.0
           meaning: Meets default pass threshold (0.35 or above)
+
+    - id: longbenchv2
+      name: "LongBench v2"
+      description: |-
+        Real-world long-document questions requiring multi-step reasoning across extended contexts.
+        Tests comprehension beyond simple retrieval with 4-choice multiple-choice format.
+      category: long_context
+      metrics:
+      - accuracy
+      tags:
+      - long_context
+      - reasoning
+      - lm_eval
+      primary_score:
+        metric: accuracy
+        lower_is_better: false
+      pass_criteria:
+        threshold: 0.30
+
+    - id: jsonschema_bench
+      name: "JSONSchemaBench"
+      description: |-
+        Tests JSON schema compliance across easy, medium, and hard splits.
+        LM-only evaluation (no constrained decoding); scores vary drastically by split.
+      category: structured_output
+      metrics:
+      - schema_compliance
+      tags:
+      - instruction-following
+      - structured-output
+      - json
+      - lm_eval
+      primary_score:
+        metric: schema_compliance
+        lower_is_better: false
+      pass_criteria:
+        threshold: 0.60
+
+    - id: cruxeval_output
+      name: "CRUXEval (Output Prediction)"
+      description: |-
+        Tests code output prediction — given a Python function and input, predict the output.
+        Measures program comprehension without requiring code generation.
+      category: coding
+      metrics:
+      - pass@1
+      tags:
+      - code
+      - comprehension
+      - lm_eval
+      primary_score:
+        metric: pass@1
+        lower_is_better: false
+      pass_criteria:
+        threshold: 0.15

--- a/config/configmaps/evalhub/provider-ruler.yaml
+++ b/config/configmaps/evalhub/provider-ruler.yaml
@@ -1,0 +1,317 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: evalhub-provider-ruler
+  labels:
+    trustyai.opendatahub.io/evalhub-provider-type: system
+    trustyai.opendatahub.io/evalhub-provider-name: ruler
+data:
+  ruler.yaml: |
+    # RULER Provider Configuration
+    # RULER: What's the Real Context Size of Your LLM?
+    # Reference: https://github.com/NVIDIA/RULER
+
+    id: ruler
+    name: RULER
+    description: >
+      NVIDIA RULER long-context evaluation benchmark. Tests LLMs across 13 synthetic
+      tasks spanning needle-in-a-haystack retrieval, variable tracking, aggregation,
+      and question answering at multiple context lengths.
+    type: community
+
+    runtime:
+      k8s:
+        image: $(evalhub-provider-ruler-image)
+        entrypoint:
+          - python
+          - main.py
+        cpu_request: 500m
+        memory_request: 1Gi
+        cpu_limit: 4000m
+        memory_limit: 8Gi
+      local:
+        # used for local mode tests (FVT)
+        # To run real benchmarks locally, override with the actual adapter path:
+        #   command: python /path/to/eval-hub-contrib/adapters/ruler/main.py
+        command: python tests/features/test_data/runtime/main.py
+
+    benchmarks:
+      # Needle-in-a-Haystack — single needle variants
+      - id: niah-single-noise
+        name: NIAH Single (Noise Haystack)
+        description: Single needle/value pair hidden in random noise background
+        category: needle_in_a_haystack
+        metrics:
+          - string_match_all
+        primary_score:
+          metric: string_match_all
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.50
+        tags:
+          - ruler
+          - niah
+          - retrieval
+          - long_context
+
+      - id: niah-single-essay
+        name: NIAH Single (Essay Haystack)
+        description: Single needle/value pair hidden in Paul Graham essays
+        category: needle_in_a_haystack
+        metrics:
+          - string_match_all
+        primary_score:
+          metric: string_match_all
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.50
+        tags:
+          - ruler
+          - niah
+          - retrieval
+          - long_context
+
+      - id: niah-single-uuid
+        name: NIAH Single (UUID Values)
+        description: Single needle/UUID-value pair hidden in essay background
+        category: needle_in_a_haystack
+        metrics:
+          - string_match_all
+        primary_score:
+          metric: string_match_all
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.50
+        tags:
+          - ruler
+          - niah
+          - retrieval
+          - long_context
+
+      # Needle-in-a-Haystack — multi-key / multi-value / multi-query variants
+      - id: niah-multikey
+        name: NIAH Multi-Key
+        description: Multiple distinct needle keys hidden in essay background
+        category: needle_in_a_haystack
+        metrics:
+          - string_match_all
+        primary_score:
+          metric: string_match_all
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.50
+        tags:
+          - ruler
+          - niah
+          - retrieval
+          - long_context
+
+      - id: niah-needle-bg
+        name: NIAH Needle Background
+        description: Single needle with other needles used as background noise
+        category: needle_in_a_haystack
+        metrics:
+          - string_match_all
+        primary_score:
+          metric: string_match_all
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.50
+        tags:
+          - ruler
+          - niah
+          - retrieval
+          - long_context
+
+      - id: niah-multikey-uuid
+        name: NIAH Multi-Key UUID
+        description: UUID keys and UUID values — hardest retrieval variant
+        category: needle_in_a_haystack
+        metrics:
+          - string_match_all
+        primary_score:
+          metric: string_match_all
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.50
+        tags:
+          - ruler
+          - niah
+          - retrieval
+          - long_context
+
+      - id: niah-multivalue
+        name: NIAH Multi-Value
+        description: Single key associated with multiple values in essay background
+        category: needle_in_a_haystack
+        metrics:
+          - string_match_all
+        primary_score:
+          metric: string_match_all
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.50
+        tags:
+          - ruler
+          - niah
+          - retrieval
+          - long_context
+
+      - id: niah-multiquery
+        name: NIAH Multi-Query
+        description: Multiple queries each targeting a distinct needle/value pair
+        category: needle_in_a_haystack
+        metrics:
+          - string_match_all
+        primary_score:
+          metric: string_match_all
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.50
+        tags:
+          - ruler
+          - niah
+          - retrieval
+          - long_context
+
+      # Variable Tracking
+      - id: variable-tracking
+        name: Variable Tracking
+        description: Track chains of variable assignments and return the final value
+        category: variable_tracking
+        metrics:
+          - string_match_all
+        primary_score:
+          metric: string_match_all
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.10
+        tags:
+          - ruler
+          - tracking
+          - long_context
+
+      # Aggregation tasks
+      - id: common-words-extraction
+        name: Common Words Extraction
+        description: Identify the 10 most frequently appearing words in a long list
+        category: aggregation
+        metrics:
+          - string_match_all
+        primary_score:
+          metric: string_match_all
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.10
+        tags:
+          - ruler
+          - aggregation
+          - long_context
+
+      - id: frequency-words-extraction
+        name: Frequency Words Extraction
+        description: Find the three most frequent coded words in a Zipf-distributed list
+        category: aggregation
+        metrics:
+          - string_match_all
+        primary_score:
+          metric: string_match_all
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.10
+        tags:
+          - ruler
+          - aggregation
+          - long_context
+
+      # Question Answering
+      - id: qa-squad
+        name: QA — SQuAD
+        description: Long-context question answering with SQuAD passages as context
+        category: question_answering
+        metrics:
+          - string_match_part
+        primary_score:
+          metric: string_match_part
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.15
+        tags:
+          - ruler
+          - qa
+          - squad
+          - long_context
+
+      - id: qa-hotpotqa
+        name: QA — HotpotQA
+        description: Multi-hop long-context question answering with HotpotQA passages
+        category: question_answering
+        metrics:
+          - string_match_part
+        primary_score:
+          metric: string_match_part
+          lower_is_better: false
+        pass_criteria:
+          threshold: 0.15
+        tags:
+          - ruler
+          - qa
+          - hotpotqa
+          - long_context
+
+    parameters:
+      - name: benchmarks
+        type: array
+        default: null
+        description: >
+          Optional list of RULER benchmark IDs to run in a single job
+          (e.g. [niah-single-essay, variable-tracking]). When set, overrides benchmark_id.
+
+      - name: context_lengths
+        type: array
+        default:
+          - 4096
+          - 8192
+          - 16384
+        description: Context lengths (in tokens) at which each task is evaluated.
+
+      - name: num_samples
+        type: integer
+        default: 10
+        description: Number of examples to generate per (task, context_length) pair.
+
+      - name: tokenizer_path
+        type: string
+        default: null
+        description: >
+          HuggingFace model ID or tiktoken model name used for context-length-aware
+          dataset generation. Defaults to model.name from the JobSpec.
+
+      - name: tokenizer_type
+        type: string
+        default: hf
+        description: Tokenizer backend — "hf" (HuggingFace) or "openai" (tiktoken).
+
+      - name: model_template
+        type: string
+        default: base
+        description: >
+          Chat prompt template to wrap each task prompt. See scripts/data/template.py
+          for available keys (base, meta-llama3, meta-chat, Phi3, …).
+
+      - name: tokens_to_generate
+        type: integer
+        default: null
+        description: >
+          Maximum tokens the model may generate per sample. When null, the per-task
+          default from synthetic.yaml is used (128 for NIAH, 30 for VT, etc.).
+
+      - name: batch_size
+        type: integer
+        default: 1
+        description: Number of concurrent requests to send to the inference endpoint.
+
+      - name: random_seed
+        type: integer
+        default: 42
+        description: Random seed for reproducible dataset generation.


### PR DESCRIPTION
sync eval-hub config with main https://github.com/eval-hub/eval-hub 

This is causing ci check failures in eval-hub
<img width="647" height="64" alt="Screenshot 2026-09-08 at 6 35 55 PM" src="https://github.com/user-attachments/assets/f37a746d-7426-4dc6-b362-7cf786d68814" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added seven curated evaluation collections covering document understanding, instruction output, knowledge and reasoning, multimodal understanding, software, tool use, and trustworthiness.
  - Added benchmark support for long-context retrieval and reasoning, JSON schema compliance, code output prediction, prompt-injection resistance, function calling, visual question answering, and advanced knowledge evaluation.
  - Added the RULER long-context evaluation provider with configurable tasks, context lengths, sampling, tokenization, and generation settings.
  - Registered all new collections for EvalHub discovery and use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->