### PR TITLE
fix: support RULER and additional lm-eval dependencies

### DIFF
--- a/Dockerfile.lmes-job
+++ b/Dockerfile.lmes-job
@@ -4,7 +4,7 @@ USER root
 RUN sed -i.bak 's/include-system-site-packages = false/include-system-site-packages = true/' /opt/app-root/pyvenv.cfg
 
 # required dependency for oci.py in lmes-job; put here for the `needs-lmes-build`, but already incorporated here: https://github.com/opendatahub-io/lm-evaluation-harness/blob/3c4dec006a4a096b546d60c3364c78acbe33cd48/Dockerfile.lmes-job#L16
-RUN dnf install -y skopeo && dnf clean all
+RUN dnf install -y git skopeo && dnf clean all
 
 USER default
 WORKDIR /opt/app-root/src
@@ -26,8 +26,19 @@ RUN curl -L https://github.com/opendatahub-io/lm-evaluation-harness/archive/refs
 # incubation branch's requirements.txt:
 #   evaluate, bert-score  → careqa_open_perplexity (bert_score metric)
 #   tinyBenchmarks        → tinyTruthfulQA
-RUN pip install --no-cache-dir evaluate bert-score \
-    "tinyBenchmarks @ git+https://github.com/felipemaiapolo/tinyBenchmarks"
+RUN printf '%s\n' \
+    'evaluate==0.4.3 --hash=sha256:47d8770bdea76e2c2ed0d40189273027d1a41ccea861bcc7ba12d30ec5d1e517' \
+    > /tmp/evaluate-requirements.txt && \
+    pip install --no-cache-dir --require-hashes --no-deps -r /tmp/evaluate-requirements.txt && \
+    rm /tmp/evaluate-requirements.txt && \
+    pip install --no-cache-dir matplotlib==3.11.1 && \
+    printf '%s\n' \
+    'bert-score==0.3.13 --hash=sha256:bbbb4c7fcdaa46d7681aff49f37f96faa09ed74e1b150e659bdc6b58a66989b9' \
+    > /tmp/bert-score-requirements.txt && \
+    pip install --no-cache-dir --no-deps -r /tmp/bert-score-requirements.txt && \
+    rm /tmp/bert-score-requirements.txt && \
+    pip install --no-cache-dir \
+    "tinyBenchmarks @ git+https://github.com/felipemaiapolo/tinyBenchmarks@e9a8b1031b0340571beb6c9ca3a27891be09a8fd"
 
 RUN python -c 'from lm_eval.tasks.unitxt import task; import os.path; print("class: !function " + task.__file__.replace("task.py", "task.Unitxt"))' > ./my_tasks/unitxt
 

--- a/Dockerfile.lmes-job
+++ b/Dockerfile.lmes-job
@@ -22,6 +22,13 @@ RUN curl -L https://github.com/opendatahub-io/lm-evaluation-harness/archive/refs
     pip install --no-cache-dir -r requirements.txt && \
     pip install --no-cache-dir -e .
 
+# Extra packages required by specific lm-eval tasks but not in the
+# incubation branch's requirements.txt:
+#   evaluate, bert-score  → careqa_open_perplexity (bert_score metric)
+#   tinyBenchmarks        → tinyTruthfulQA
+RUN pip install --no-cache-dir evaluate bert-score \
+    "tinyBenchmarks @ git+https://github.com/felipemaiapolo/tinyBenchmarks"
+
 RUN python -c 'from lm_eval.tasks.unitxt import task; import os.path; print("class: !function " + task.__file__.replace("task.py", "task.Unitxt"))' > ./my_tasks/unitxt
 
 ENV PYTHONPATH=/opt/app-root/src/.local/lib/python3.11/site-packages:/opt/app-root/src:/opt/app-root/src/server

--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -107,6 +107,13 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.evalhub-provider-ragas-image
+  - name: evalhub-provider-ruler-image
+    objref:
+      kind: ConfigMap
+      name: config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.evalhub-provider-ruler-image
   - name: lmes-pod-image
     objref:
       kind: ConfigMap

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -24,4 +24,4 @@ evalhub-provider-ibm-clear-image=quay.io/evalhub/community-ibm-clear:latest
 evalhub-provider-deepeval-image=quay.io/evalhub/community-deepeval:latest
 evalhub-provider-ragas-image=quay.io/evalhub/community-ragas:latest
 evalhub-provider-inspect-image=quay.io/evalhub/community-inspect:latest
-evalhub-provider-ruler-image=quay.io/evalhub/community-ruler:latest
+evalhub-provider-ruler-image=quay.io/evalhub/community-ruler@sha256:242139e790a88e26a46bdd8357624b02b4db1b5fff31516fb8c9114344907

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -24,3 +24,4 @@ evalhub-provider-ibm-clear-image=quay.io/evalhub/community-ibm-clear:latest
 evalhub-provider-deepeval-image=quay.io/evalhub/community-deepeval:latest
 evalhub-provider-ragas-image=quay.io/evalhub/community-ragas:latest
 evalhub-provider-inspect-image=quay.io/evalhub/community-inspect:latest
+evalhub-provider-ruler-image=quay.io/evalhub/community-ruler:latest

--- a/config/overlays/odh-kueue/params.env
+++ b/config/overlays/odh-kueue/params.env
@@ -11,4 +11,4 @@ lmes-default-batch-size=8
 lmes-detect-device=true
 lmes-allow-online=true
 lmes-allow-code-execution=true
-evalhub-provider-ruler-image=quay.io/evalhub/community-ruler:latest
+evalhub-provider-ruler-image=quay.io/evalhub/community-ruler@sha256:242139e790a88e26a46bdd8357624b02b4db1b5fff31516fb8c9114344907

--- a/config/overlays/odh-kueue/params.env
+++ b/config/overlays/odh-kueue/params.env
@@ -11,3 +11,4 @@ lmes-default-batch-size=8
 lmes-detect-device=true
 lmes-allow-online=true
 lmes-allow-code-execution=true
+evalhub-provider-ruler-image=quay.io/evalhub/community-ruler:latest

--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -25,4 +25,4 @@ evalhub-provider-ibm-clear-image=quay.io/evalhub/community-ibm-clear:v0.5.0
 evalhub-provider-ragas-image=quay.io/evalhub/community-ragas:v0.5.0
 evalhub-provider-deepeval-image=quay.io/evalhub/community-deepeval:v0.5.0
 evalhub-provider-inspect-image=quay.io/evalhub/community-inspect:v0.5.2
-evalhub-provider-ruler-image=quay.io/evalhub/community-ruler:latest
+evalhub-provider-ruler-image=quay.io/evalhub/community-ruler@sha256:242139e790a88e26a46bdd8357624b02b4db1b5fff31516fb8c9114344907

--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -25,3 +25,4 @@ evalhub-provider-ibm-clear-image=quay.io/evalhub/community-ibm-clear:v0.5.0
 evalhub-provider-ragas-image=quay.io/evalhub/community-ragas:v0.5.0
 evalhub-provider-deepeval-image=quay.io/evalhub/community-deepeval:v0.5.0
 evalhub-provider-inspect-image=quay.io/evalhub/community-inspect:v0.5.2
+evalhub-provider-ruler-image=quay.io/evalhub/community-ruler:latest

--- a/config/overlays/rhoai/params.env
+++ b/config/overlays/rhoai/params.env
@@ -25,4 +25,4 @@ evalhub-provider-ibm-clear-image=quay.io/evalhub/community-ibm-clear:v0.5.0
 evalhub-provider-ragas-image=quay.io/evalhub/community-ragas:v0.5.0
 evalhub-provider-deepeval-image=quay.io/evalhub/community-deepeval:v0.5.0
 evalhub-provider-inspect-image=quay.io/evalhub/community-inspect:v0.5.2
-evalhub-provider-ruler-image=quay.io/evalhub/community-ruler:latest
+evalhub-provider-ruler-image=quay.io/evalhub/community-ruler@sha256:242139e790a88e26a46bdd8357624b02b4db1b5fff31516fb8c9114344907

--- a/config/overlays/rhoai/params.env
+++ b/config/overlays/rhoai/params.env
@@ -25,3 +25,4 @@ evalhub-provider-ibm-clear-image=quay.io/evalhub/community-ibm-clear:v0.5.0
 evalhub-provider-ragas-image=quay.io/evalhub/community-ragas:v0.5.0
 evalhub-provider-deepeval-image=quay.io/evalhub/community-deepeval:v0.5.0
 evalhub-provider-inspect-image=quay.io/evalhub/community-inspect:v0.5.2
+evalhub-provider-ruler-image=quay.io/evalhub/community-ruler:latest


### PR DESCRIPTION
## Summary

  - Add Kustomize image substitution for the EvalHub RULER provider.
  - Configure the RULER image across the base, ODH, RHOAI, and ODH-Kueue overlays.
  - Install additional Python dependencies required by selected lm-evaluation-harness tasks.

  ## Validation

  - `kustomize build config/overlays/odh`
  - `kustomize build config/overlays/rhoai`
  - `kustomize build config/overlays/odh-kueue`
  - Verified that the RULER image resolves to:
    `quay.io/evalhub/community-ruler:latest`
  - `git diff --check` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring and deploying a community ruler service image across supported environments.
  * Added required evaluation packages for additional language-model evaluation tasks.
* **Configuration**
  * Updated base and environment-specific settings to use the community ruler image by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->