### PR TITLE
fix(evalhub): query instance namespace for provider/collection ConfigMaps in single tenancy

### DIFF
--- a/controllers/evalhub/configmap.go
+++ b/controllers/evalhub/configmap.go
@@ -538,6 +538,11 @@ func (r *EvalHubReconciler) validateImageConfiguration(ctx context.Context, imag
 //   - trustyai.opendatahub.io/evalhub-provider-type=system
 //   - trustyai.opendatahub.io/evalhub-provider-name=<name>
 //
+// In single-tenancy mode, if a system provider is not found in the operator namespace,
+// the reconciler falls back to searching for a tenant-labeled provider in the instance
+// namespace. This keeps system providers sourced from the trusted operator namespace
+// while allowing single-tenancy users to define providers in their own namespace.
+//
 // Returns the list of created ConfigMap names (for building projected volumes).
 func (r *EvalHubReconciler) reconcileProviderConfigMaps(ctx context.Context, instance *evalhubv1.EvalHub) ([]string, error) {
 	if len(instance.Spec.Providers) == 0 {
@@ -549,7 +554,7 @@ func (r *EvalHubReconciler) reconcileProviderConfigMaps(ctx context.Context, ins
 
 	var cmNames []string
 	for _, providerName := range instance.Spec.Providers {
-		// Look up the source ConfigMap by both labels
+		// Look up the source ConfigMap by both labels in the operator namespace
 		var sourceList corev1.ConfigMapList
 		if err := r.List(ctx, &sourceList,
 			client.InNamespace(r.Namespace),
@@ -559,6 +564,18 @@ func (r *EvalHubReconciler) reconcileProviderConfigMaps(ctx context.Context, ins
 			}); err != nil {
 			return nil, fmt.Errorf("failed to list provider ConfigMaps for %q in namespace %s: %w", providerName, r.Namespace, err)
 		}
+
+		if len(sourceList.Items) == 0 && instance.Spec.IsSingleTenancy() {
+			if err := r.List(ctx, &sourceList,
+				client.InNamespace(instance.Namespace),
+				client.MatchingLabels{
+					providerLabel:     providerTenantValue,
+					providerNameLabel: providerName,
+				}); err != nil {
+				return nil, fmt.Errorf("failed to list tenant provider ConfigMaps for %q in namespace %s: %w", providerName, instance.Namespace, err)
+			}
+		}
+
 		if len(sourceList.Items) == 0 {
 			return nil, fmt.Errorf("provider %q not found: no ConfigMap with label %s=%s in namespace %s",
 				providerName, providerNameLabel, providerName, r.Namespace)
@@ -611,6 +628,10 @@ func (r *EvalHubReconciler) reconcileProviderConfigMaps(ctx context.Context, ins
 //   - trustyai.opendatahub.io/evalhub-collection-type=system
 //   - trustyai.opendatahub.io/evalhub-collection-name=<name>
 //
+// In single-tenancy mode, if a system collection is not found in the operator namespace,
+// the reconciler falls back to searching for a tenant-labeled collection in the instance
+// namespace.
+//
 // Returns the list of created ConfigMap names (for building projected volumes).
 func (r *EvalHubReconciler) reconcileCollectionConfigMaps(ctx context.Context, instance *evalhubv1.EvalHub) ([]string, error) {
 	if len(instance.Spec.Collections) == 0 {
@@ -622,7 +643,7 @@ func (r *EvalHubReconciler) reconcileCollectionConfigMaps(ctx context.Context, i
 
 	var cmNames []string
 	for _, collectionName := range instance.Spec.Collections {
-		// Look up the source ConfigMap by both labels
+		// Look up the source ConfigMap by both labels in the operator namespace
 		var sourceList corev1.ConfigMapList
 		if err := r.List(ctx, &sourceList,
 			client.InNamespace(r.Namespace),
@@ -632,6 +653,18 @@ func (r *EvalHubReconciler) reconcileCollectionConfigMaps(ctx context.Context, i
 			}); err != nil {
 			return nil, fmt.Errorf("failed to list collection ConfigMaps for %q in namespace %s: %w", collectionName, r.Namespace, err)
 		}
+
+		if len(sourceList.Items) == 0 && instance.Spec.IsSingleTenancy() {
+			if err := r.List(ctx, &sourceList,
+				client.InNamespace(instance.Namespace),
+				client.MatchingLabels{
+					collectionLabel:     collectionTenantValue,
+					collectionNameLabel: collectionName,
+				}); err != nil {
+				return nil, fmt.Errorf("failed to list tenant collection ConfigMaps for %q in namespace %s: %w", collectionName, instance.Namespace, err)
+			}
+		}
+
 		if len(sourceList.Items) == 0 {
 			return nil, fmt.Errorf("collection %q not found: no ConfigMap with label %s=%s in namespace %s",
 				collectionName, collectionNameLabel, collectionName, r.Namespace)

--- a/controllers/evalhub/configmap.go
+++ b/controllers/evalhub/configmap.go
@@ -574,6 +574,10 @@ func (r *EvalHubReconciler) reconcileProviderConfigMaps(ctx context.Context, ins
 				}); err != nil {
 				return nil, fmt.Errorf("failed to list tenant provider ConfigMaps for %q in namespace %s: %w", providerName, instance.Namespace, err)
 			}
+			if len(sourceList.Items) > 1 {
+				return nil, fmt.Errorf("provider %q is ambiguous: found %d tenant ConfigMaps in namespace %s, expected exactly 1",
+					providerName, len(sourceList.Items), instance.Namespace)
+			}
 		}
 
 		if len(sourceList.Items) == 0 {
@@ -662,6 +666,10 @@ func (r *EvalHubReconciler) reconcileCollectionConfigMaps(ctx context.Context, i
 					collectionNameLabel: collectionName,
 				}); err != nil {
 				return nil, fmt.Errorf("failed to list tenant collection ConfigMaps for %q in namespace %s: %w", collectionName, instance.Namespace, err)
+			}
+			if len(sourceList.Items) > 1 {
+				return nil, fmt.Errorf("collection %q is ambiguous: found %d tenant ConfigMaps in namespace %s, expected exactly 1",
+					collectionName, len(sourceList.Items), instance.Namespace)
 			}
 		}
 

--- a/controllers/evalhub/unit_test.go
+++ b/controllers/evalhub/unit_test.go
@@ -1916,6 +1916,308 @@ func TestEvalHubReconciler_reconcileProviderConfigMaps(t *testing.T) {
 	})
 }
 
+func TestEvalHubReconciler_reconcileProviderConfigMaps_singleTenancy(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, evalhubv1.AddToScheme(scheme))
+
+	ctx := context.Background()
+	operatorNamespace := "operator-ns"
+	instanceNamespace := "instance-ns"
+	evalHubName := "test-evalhub"
+
+	t.Run("should find tenant-labeled provider in instance namespace for single tenancy", func(t *testing.T) {
+		sourceProvider := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-provider-cm",
+				Namespace: instanceNamespace,
+				Labels: map[string]string{
+					providerLabel:     providerTenantValue,
+					providerNameLabel: "testprovider",
+				},
+			},
+			Data: map[string]string{
+				"testprovider.yaml": "id: testprovider\nname: Test Provider\n",
+			},
+		}
+
+		evalHub := &evalhubv1.EvalHub{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      evalHubName,
+				Namespace: instanceNamespace,
+			},
+			Spec: evalhubv1.EvalHubSpec{
+				Tenancy:   evalhubv1.TenancySingle,
+				Providers: []string{"testprovider"},
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(evalHub, sourceProvider).
+			Build()
+
+		reconciler := &EvalHubReconciler{
+			Client:        fakeClient,
+			Scheme:        scheme,
+			Namespace:     operatorNamespace,
+			EventRecorder: record.NewFakeRecorder(10),
+		}
+
+		cmNames, err := reconciler.reconcileProviderConfigMaps(ctx, evalHub)
+		require.NoError(t, err)
+		require.Len(t, cmNames, 1)
+		assert.Equal(t, evalHubName+"-provider-testprovider", cmNames[0])
+
+		copiedCM := &corev1.ConfigMap{}
+		err = fakeClient.Get(ctx, types.NamespacedName{
+			Name:      evalHubName + "-provider-testprovider",
+			Namespace: instanceNamespace,
+		}, copiedCM)
+		require.NoError(t, err)
+		assert.Equal(t, sourceProvider.Data["testprovider.yaml"], copiedCM.Data["testprovider.yaml"])
+	})
+
+	t.Run("should prefer system provider from operator namespace over tenant fallback", func(t *testing.T) {
+		systemProvider := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "trustyai-service-operator-evalhub-provider-testprovider",
+				Namespace: operatorNamespace,
+				Labels: map[string]string{
+					providerLabel:     "system",
+					providerNameLabel: "testprovider",
+				},
+			},
+			Data: map[string]string{
+				"testprovider.yaml": "id: testprovider\nname: System Provider\n",
+			},
+		}
+
+		evalHub := &evalhubv1.EvalHub{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      evalHubName,
+				Namespace: instanceNamespace,
+			},
+			Spec: evalhubv1.EvalHubSpec{
+				Tenancy:   evalhubv1.TenancySingle,
+				Providers: []string{"testprovider"},
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(evalHub, systemProvider).
+			Build()
+
+		reconciler := &EvalHubReconciler{
+			Client:        fakeClient,
+			Scheme:        scheme,
+			Namespace:     operatorNamespace,
+			EventRecorder: record.NewFakeRecorder(10),
+		}
+
+		cmNames, err := reconciler.reconcileProviderConfigMaps(ctx, evalHub)
+		require.NoError(t, err)
+		require.Len(t, cmNames, 1)
+		assert.Equal(t, evalHubName+"-provider-testprovider", cmNames[0])
+	})
+
+	t.Run("should not find system-labeled provider in instance namespace", func(t *testing.T) {
+		systemLabeledInTenant := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-provider-cm",
+				Namespace: instanceNamespace,
+				Labels: map[string]string{
+					providerLabel:     "system",
+					providerNameLabel: "testprovider",
+				},
+			},
+			Data: map[string]string{
+				"testprovider.yaml": "id: testprovider\n",
+			},
+		}
+
+		evalHub := &evalhubv1.EvalHub{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      evalHubName,
+				Namespace: instanceNamespace,
+			},
+			Spec: evalhubv1.EvalHubSpec{
+				Tenancy:   evalhubv1.TenancySingle,
+				Providers: []string{"testprovider"},
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(evalHub, systemLabeledInTenant).
+			Build()
+
+		reconciler := &EvalHubReconciler{
+			Client:        fakeClient,
+			Scheme:        scheme,
+			Namespace:     operatorNamespace,
+			EventRecorder: record.NewFakeRecorder(10),
+		}
+
+		_, err := reconciler.reconcileProviderConfigMaps(ctx, evalHub)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestEvalHubReconciler_reconcileCollectionConfigMaps_singleTenancy(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, evalhubv1.AddToScheme(scheme))
+
+	ctx := context.Background()
+	operatorNamespace := "operator-ns"
+	instanceNamespace := "instance-ns"
+	evalHubName := "test-evalhub"
+
+	t.Run("should find tenant-labeled collection in instance namespace for single tenancy", func(t *testing.T) {
+		sourceCollection := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-collection-cm",
+				Namespace: instanceNamespace,
+				Labels: map[string]string{
+					collectionLabel:     collectionTenantValue,
+					collectionNameLabel: "testcollection",
+				},
+			},
+			Data: map[string]string{
+				"testcollection.yaml": "id: testcollection\nname: Test Collection\n",
+			},
+		}
+
+		evalHub := &evalhubv1.EvalHub{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      evalHubName,
+				Namespace: instanceNamespace,
+			},
+			Spec: evalhubv1.EvalHubSpec{
+				Tenancy:     evalhubv1.TenancySingle,
+				Collections: []string{"testcollection"},
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(evalHub, sourceCollection).
+			Build()
+
+		reconciler := &EvalHubReconciler{
+			Client:        fakeClient,
+			Scheme:        scheme,
+			Namespace:     operatorNamespace,
+			EventRecorder: record.NewFakeRecorder(10),
+		}
+
+		cmNames, err := reconciler.reconcileCollectionConfigMaps(ctx, evalHub)
+		require.NoError(t, err)
+		require.Len(t, cmNames, 1)
+		assert.Equal(t, evalHubName+"-collection-testcollection", cmNames[0])
+
+		copiedCM := &corev1.ConfigMap{}
+		err = fakeClient.Get(ctx, types.NamespacedName{
+			Name:      evalHubName + "-collection-testcollection",
+			Namespace: instanceNamespace,
+		}, copiedCM)
+		require.NoError(t, err)
+		assert.Equal(t, sourceCollection.Data["testcollection.yaml"], copiedCM.Data["testcollection.yaml"])
+	})
+
+	t.Run("should prefer system collection from operator namespace over tenant fallback", func(t *testing.T) {
+		systemCollection := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "trustyai-service-operator-evalhub-collection-testcollection",
+				Namespace: operatorNamespace,
+				Labels: map[string]string{
+					collectionLabel:     "system",
+					collectionNameLabel: "testcollection",
+				},
+			},
+			Data: map[string]string{
+				"testcollection.yaml": "id: testcollection\nname: System Collection\n",
+			},
+		}
+
+		evalHub := &evalhubv1.EvalHub{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      evalHubName,
+				Namespace: instanceNamespace,
+			},
+			Spec: evalhubv1.EvalHubSpec{
+				Tenancy:     evalhubv1.TenancySingle,
+				Collections: []string{"testcollection"},
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(evalHub, systemCollection).
+			Build()
+
+		reconciler := &EvalHubReconciler{
+			Client:        fakeClient,
+			Scheme:        scheme,
+			Namespace:     operatorNamespace,
+			EventRecorder: record.NewFakeRecorder(10),
+		}
+
+		cmNames, err := reconciler.reconcileCollectionConfigMaps(ctx, evalHub)
+		require.NoError(t, err)
+		require.Len(t, cmNames, 1)
+		assert.Equal(t, evalHubName+"-collection-testcollection", cmNames[0])
+	})
+
+	t.Run("should not find system-labeled collection in instance namespace", func(t *testing.T) {
+		systemLabeledInTenant := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-collection-cm",
+				Namespace: instanceNamespace,
+				Labels: map[string]string{
+					collectionLabel:     "system",
+					collectionNameLabel: "testcollection",
+				},
+			},
+			Data: map[string]string{
+				"testcollection.yaml": "id: testcollection\n",
+			},
+		}
+
+		evalHub := &evalhubv1.EvalHub{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      evalHubName,
+				Namespace: instanceNamespace,
+			},
+			Spec: evalhubv1.EvalHubSpec{
+				Tenancy:     evalhubv1.TenancySingle,
+				Collections: []string{"testcollection"},
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(evalHub, systemLabeledInTenant).
+			Build()
+
+		reconciler := &EvalHubReconciler{
+			Client:        fakeClient,
+			Scheme:        scheme,
+			Namespace:     operatorNamespace,
+			EventRecorder: record.NewFakeRecorder(10),
+		}
+
+		_, err := reconciler.reconcileCollectionConfigMaps(ctx, evalHub)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
 // TestEvalHubReconciler_createTenantServiceCAConfigMap verifies that the service CA
 // ConfigMap is created in tenant namespaces with the inject-cabundle annotation
 // and job resource labels for cleanup.

--- a/controllers/evalhub/unit_test.go
+++ b/controllers/evalhub/unit_test.go
@@ -1994,6 +1994,20 @@ func TestEvalHubReconciler_reconcileProviderConfigMaps_singleTenancy(t *testing.
 			},
 		}
 
+		tenantProvider := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-tenant-provider",
+				Namespace: instanceNamespace,
+				Labels: map[string]string{
+					providerLabel:     providerTenantValue,
+					providerNameLabel: "testprovider",
+				},
+			},
+			Data: map[string]string{
+				"testprovider.yaml": "id: testprovider\nname: Tenant Provider\n",
+			},
+		}
+
 		evalHub := &evalhubv1.EvalHub{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      evalHubName,
@@ -2007,7 +2021,7 @@ func TestEvalHubReconciler_reconcileProviderConfigMaps_singleTenancy(t *testing.
 
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(scheme).
-			WithObjects(evalHub, systemProvider).
+			WithObjects(evalHub, systemProvider, tenantProvider).
 			Build()
 
 		reconciler := &EvalHubReconciler{
@@ -2021,6 +2035,14 @@ func TestEvalHubReconciler_reconcileProviderConfigMaps_singleTenancy(t *testing.
 		require.NoError(t, err)
 		require.Len(t, cmNames, 1)
 		assert.Equal(t, evalHubName+"-provider-testprovider", cmNames[0])
+
+		copiedCM := &corev1.ConfigMap{}
+		err = fakeClient.Get(ctx, types.NamespacedName{
+			Name:      evalHubName + "-provider-testprovider",
+			Namespace: instanceNamespace,
+		}, copiedCM)
+		require.NoError(t, err)
+		assert.Equal(t, "id: testprovider\nname: System Provider\n", copiedCM.Data["testprovider.yaml"])
 	})
 
 	t.Run("should not find system-labeled provider in instance namespace", func(t *testing.T) {
@@ -2145,6 +2167,20 @@ func TestEvalHubReconciler_reconcileCollectionConfigMaps_singleTenancy(t *testin
 			},
 		}
 
+		tenantCollection := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-tenant-collection",
+				Namespace: instanceNamespace,
+				Labels: map[string]string{
+					collectionLabel:     collectionTenantValue,
+					collectionNameLabel: "testcollection",
+				},
+			},
+			Data: map[string]string{
+				"testcollection.yaml": "id: testcollection\nname: Tenant Collection\n",
+			},
+		}
+
 		evalHub := &evalhubv1.EvalHub{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      evalHubName,
@@ -2158,7 +2194,7 @@ func TestEvalHubReconciler_reconcileCollectionConfigMaps_singleTenancy(t *testin
 
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(scheme).
-			WithObjects(evalHub, systemCollection).
+			WithObjects(evalHub, systemCollection, tenantCollection).
 			Build()
 
 		reconciler := &EvalHubReconciler{
@@ -2172,6 +2208,14 @@ func TestEvalHubReconciler_reconcileCollectionConfigMaps_singleTenancy(t *testin
 		require.NoError(t, err)
 		require.Len(t, cmNames, 1)
 		assert.Equal(t, evalHubName+"-collection-testcollection", cmNames[0])
+
+		copiedCM := &corev1.ConfigMap{}
+		err = fakeClient.Get(ctx, types.NamespacedName{
+			Name:      evalHubName + "-collection-testcollection",
+			Namespace: instanceNamespace,
+		}, copiedCM)
+		require.NoError(t, err)
+		assert.Equal(t, "id: testcollection\nname: System Collection\n", copiedCM.Data["testcollection.yaml"])
 	})
 
 	t.Run("should not find system-labeled collection in instance namespace", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes [RHAI-950](https://redhat.atlassian.net/browse/RHAI-950): In single-tenancy mode, EvalHub failed to reconcile when provider/collection ConfigMaps were defined in the instance namespace because the reconciler always searched the operator namespace.

Re-targets the fix from closed downstream [PR opendatahub-io#193 that was created by the Jira autofix](https://github.com/opendatahub-io/trustyai-service-operator/pull/193) to this upstream repository.

### Changes

- **System providers always sourced from operator namespace** (`r.Namespace`): Prevents tenants from injecting arbitrary `runtime.k8s.image` and `entrypoint` values via `system`-labeled ConfigMaps in their own namespace (CWE-668).
- **Tenant fallback in single tenancy**: When a system provider is not found in the operator namespace and the instance uses single-tenancy mode, the reconciler falls back to searching for `tenant`-labeled ConfigMaps in the instance namespace.
- **Same pattern for collections**: Both `reconcileProviderConfigMaps` and `reconcileCollectionConfigMaps` follow the same system-first, tenant-fallback approach.
- **Unit tests**: Six new test cases covering the single-tenancy provider/collection lookup: tenant-labeled discovery, system provider preference, and rejection of system-labeled ConfigMaps in the tenant namespace.

### Security

Addresses CWE-668 (Exposure of Resource to Wrong Sphere). System providers are always sourced from the trusted operator namespace. Only `tenant`-labeled ConfigMaps are discovered in the instance namespace during single-tenancy fallback.

### Files changed

- `controllers/evalhub/configmap.go` — Updated namespace lookup logic
- `controllers/evalhub/unit_test.go` — Added single-tenancy test cases


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * In single-tenant deployments, provider and collection configuration can now fall back to tenant-labeled ConfigMaps in the instance namespace when system-level configuration is unavailable.
  * System-level configuration remains preferred when both system and tenant configurations are present.

* **Tests**
  * Added coverage for provider and collection configuration fallback, precedence, and label matching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->