### PR TITLE
fix(module): add missing watch verb on services and prometheuses RBAC

### DIFF
--- a/policy/clusterrole.rego
+++ b/policy/clusterrole.rego
@@ -61,6 +61,7 @@ allowed_api_resources := {
 
 	# --- monitoring ---
 	["monitoring.coreos.com", "servicemonitors"],
+	["monitoring.coreos.com", "prometheuses"],
 
 	# --- kserve ---
 	["serving.kserve.io", "inferenceservices"],
@@ -250,4 +251,34 @@ deny contains msg if {
 		"RBAC VIOLATION: ClusterRole '%s' uses escalation verb '%s'.",
 		[input.metadata.name, verb],
 	)
+}
+
+# Layer 3: module-specific watch requirements.
+#
+# The manager's cached client establishes an informer for any GVK it Lists
+# or Gets, which requires the watch verb in addition to get/list. These
+# guard against regressing the bugs fixed in #908/#913.
+
+deny contains msg if {
+	input.kind == "ClusterRole"
+	input.metadata.name == "trustyai-operator-module-manager-role"
+
+	rule := input.rules[_]
+	"" in rule.apiGroups
+	"services" in rule.resources
+	not "watch" in rule.verbs
+
+	msg := "RBAC VIOLATION: TrustyAI module services permission must include watch."
+}
+
+deny contains msg if {
+	input.kind == "ClusterRole"
+	input.metadata.name == "trustyai-operator-module-manager-role"
+
+	rule := input.rules[_]
+	"monitoring.coreos.com" in rule.apiGroups
+	"prometheuses" in rule.resources
+	not "watch" in rule.verbs
+
+	msg := "RBAC VIOLATION: TrustyAI module prometheuses permission must include watch."
 }

--- a/policy/clusterrole_test.rego
+++ b/policy/clusterrole_test.rego
@@ -221,6 +221,68 @@ test_impersonate_verb_denied if {
 	}
 }
 
+# --- Layer 3: module-specific watch requirements ---
+
+test_module_services_watch_required if {
+	count(deny) > 0 with input as {
+		"kind": "ClusterRole",
+		"metadata": {"name": "trustyai-operator-module-manager-role"},
+		"rules": [{
+			"apiGroups": [""],
+			"resources": ["services"],
+			"verbs": ["get", "list", "patch"],
+		}],
+	}
+}
+
+test_module_services_watch_present_allowed if {
+	count(deny) == 0 with input as {
+		"kind": "ClusterRole",
+		"metadata": {"name": "trustyai-operator-module-manager-role"},
+		"rules": [{
+			"apiGroups": [""],
+			"resources": ["services"],
+			"verbs": ["get", "list", "watch", "patch"],
+		}],
+	}
+}
+
+test_module_prometheuses_watch_required if {
+	count(deny) > 0 with input as {
+		"kind": "ClusterRole",
+		"metadata": {"name": "trustyai-operator-module-manager-role"},
+		"rules": [{
+			"apiGroups": ["monitoring.coreos.com"],
+			"resources": ["prometheuses"],
+			"verbs": ["get", "list"],
+		}],
+	}
+}
+
+test_module_prometheuses_watch_present_allowed if {
+	count(deny) == 0 with input as {
+		"kind": "ClusterRole",
+		"metadata": {"name": "trustyai-operator-module-manager-role"},
+		"rules": [{
+			"apiGroups": ["monitoring.coreos.com"],
+			"resources": ["prometheuses"],
+			"verbs": ["get", "list", "watch"],
+		}],
+	}
+}
+
+test_module_services_watch_other_role_not_checked if {
+	count(deny) == 0 with input as {
+		"kind": "ClusterRole",
+		"metadata": {"name": "trustyai-service-operator-tas-manager-role"},
+		"rules": [{
+			"apiGroups": [""],
+			"resources": ["services"],
+			"verbs": ["get", "list", "patch"],
+		}],
+	}
+}
+
 # --- Non-ClusterRole input ---
 
 test_non_clusterrole_ignored if {

--- a/trustyai-operator-module/config/rbac/role.yaml
+++ b/trustyai-operator-module/config/rbac/role.yaml
@@ -32,6 +32,7 @@ rules:
   - get
   - list
   - patch
+  - watch
 - apiGroups:
   - apps
   resources:
@@ -86,6 +87,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/trustyai-operator-module/pkg/trustyaimodule/reconciler.go
+++ b/trustyai-operator-module/pkg/trustyaimodule/reconciler.go
@@ -42,10 +42,10 @@ type TrustyAIModuleReconciler struct {
 // +kubebuilder:rbac:groups=components.platform.opendatahub.io,resources=trustyais/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=components.platform.opendatahub.io,resources=trustyais/finalizers,verbs=update
 // +kubebuilder:rbac:groups=serving.kserve.io,resources=inferenceservices,verbs=get;list
-// +kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheuses,verbs=get;list
+// +kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheuses,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch;update
-// +kubebuilder:rbac:groups="",resources=services,verbs=get;list;patch
+// +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
Same root cause as #908 (deployments, rolebindings): the manager's cached client establishes an informer/watch for any GVK it Lists or Gets, requiring the watch verb in addition to get/list. Two more call sites hit this that weren't covered by #908:

- migration.go's adoptServices lists Services for in-tree adoption
- dependencies.go's checkPrometheus lists Prometheus via the cached client (the InferenceService check uses RESTMapper discovery instead, so it doesn't need watch)

Found by proactively auditing every List/Get call site in the package after Steven Tobin reported the Services watch failure, to catch the remaining latent gap before it surfaced separately.

Related to opendatahub-io/opendatahub-operator#4051 — Steven is testing                                                                      
  the TrustyAI module end-to-end via that PR, and this fixes one of the                                                                        
  errors he's hit there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved monitoring and service resource tracking for more timely operator updates.
  * Updated permissions to support watching Prometheus and service resources alongside existing access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->