### PR TITLE
fix(module): serviceaccounts RBAC, SSA create verb, and Degraded/Ready condition aggregation

### DIFF
--- a/trustyai-operator-module/config/rbac/role.yaml
+++ b/trustyai-operator-module/config/rbac/role.yaml
@@ -27,6 +27,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - serviceaccounts
   - services
   verbs:
   - get

--- a/trustyai-operator-module/config/rbac/role.yaml
+++ b/trustyai-operator-module/config/rbac/role.yaml
@@ -30,6 +30,7 @@ rules:
   - serviceaccounts
   - services
   verbs:
+  - create
   - get
   - list
   - patch
@@ -39,6 +40,7 @@ rules:
   resources:
   - deployments
   verbs:
+  - create
   - get
   - list
   - patch
@@ -94,6 +96,7 @@ rules:
   resources:
   - rolebindings
   verbs:
+  - create
   - get
   - list
   - patch

--- a/trustyai-operator-module/pkg/trustyaimodule/constants.go
+++ b/trustyai-operator-module/pkg/trustyaimodule/constants.go
@@ -49,4 +49,12 @@ const (
 
 	// InTreeManagedByLabel is the label used to identify resources managed by in-tree component
 	InTreeManagedByLabel = "opendatahub.io/trustyai-component"
+
+	// OperatorDeploymentName is the name of the trustyai-service-operator
+	// Deployment rendered from the manifests template.
+	OperatorDeploymentName = "trustyai-service-operator"
+
+	// ManagerContainerName is the name of the trustyai-service-operator
+	// container within OperatorDeploymentName.
+	ManagerContainerName = "manager"
 )

--- a/trustyai-operator-module/pkg/trustyaimodule/manifests.go
+++ b/trustyai-operator-module/pkg/trustyaimodule/manifests.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/render/kustomize"
+	platformv1alpha1 "github.com/trustyai-explainability/trustyai-operator-module/pkg/apis/v1alpha1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -124,6 +125,71 @@ func RenderManifests(ctx context.Context, templatePath, namespace string) ([]uns
 
 	logger.Info("Rendered manifests", "count", len(objs))
 	return objs, nil
+}
+
+// enabledServiceNames maps EnabledServices booleans to the canonical service
+// names accepted by trustyai-service-operator's --enable-services flag
+// (see controllers/<service>/constants.go ServiceName in the parent repo).
+//
+// When none are explicitly enabled, all services are enabled. This matches
+// the pre-modular in-tree operator's default deployment (which always ran
+// with every service enabled) until the platform projects real per-service
+// toggles onto this CR.
+func enabledServiceNames(es platformv1alpha1.EnabledServices) []string {
+	var names []string
+	if es.TAS {
+		names = append(names, "TAS")
+	}
+	if es.LMES {
+		names = append(names, "LMES")
+	}
+	if es.EvalHub {
+		names = append(names, "EVALHUB")
+	}
+	if es.GORCH {
+		names = append(names, "GORCH")
+	}
+	if es.NemoGuardrails {
+		names = append(names, "NEMO_GUARDRAILS")
+	}
+	if len(names) == 0 {
+		names = []string{"TAS", "LMES", "EVALHUB", "GORCH", "NEMO_GUARDRAILS"}
+	}
+	return names
+}
+
+// injectEnabledServices sets the --enable-services argument on
+// OperatorDeploymentName's ManagerContainerName container, derived from the
+// module CR's spec.enabledServices.
+func injectEnabledServices(objs []unstructured.Unstructured, es platformv1alpha1.EnabledServices) error {
+	arg := "--enable-services=" + strings.Join(enabledServiceNames(es), ",")
+
+	for i := range objs {
+		obj := &objs[i]
+		if obj.GetKind() != "Deployment" || obj.GetName() != OperatorDeploymentName {
+			continue
+		}
+
+		containers, found, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "containers")
+		if err != nil || !found {
+			return fmt.Errorf("reading containers from Deployment %s: %w", obj.GetName(), err)
+		}
+
+		for j, c := range containers {
+			container, ok := c.(map[string]interface{})
+			if !ok || container["name"] != ManagerContainerName {
+				continue
+			}
+			container["args"] = []interface{}{arg}
+			containers[j] = container
+		}
+
+		if err := unstructured.SetNestedSlice(obj.Object, containers, "spec", "template", "spec", "containers"); err != nil {
+			return fmt.Errorf("setting containers on Deployment %s: %w", obj.GetName(), err)
+		}
+	}
+
+	return nil
 }
 
 func copyDir(src, dst string) error {

--- a/trustyai-operator-module/pkg/trustyaimodule/manifests_test.go
+++ b/trustyai-operator-module/pkg/trustyaimodule/manifests_test.go
@@ -1,0 +1,90 @@
+package trustyaimodule
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	platformv1alpha1 "github.com/trustyai-explainability/trustyai-operator-module/pkg/apis/v1alpha1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func operatorDeployment(containers ...map[string]interface{}) unstructured.Unstructured {
+	items := make([]interface{}, 0, len(containers))
+	for _, c := range containers {
+		items = append(items, c)
+	}
+	return unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]interface{}{
+			"name": OperatorDeploymentName,
+		},
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": items,
+				},
+			},
+		},
+	}}
+}
+
+var _ = Describe("enabledServiceNames", func() {
+	It("returns only the enabled services", func() {
+		Expect(enabledServiceNames(platformv1alpha1.EnabledServices{TAS: true, GORCH: true})).To(ConsistOf("TAS", "GORCH"))
+	})
+
+	It("defaults to all services when none are explicitly enabled", func() {
+		Expect(enabledServiceNames(platformv1alpha1.EnabledServices{})).To(ConsistOf(
+			"TAS", "LMES", "EVALHUB", "GORCH", "NEMO_GUARDRAILS",
+		))
+	})
+})
+
+var _ = Describe("injectEnabledServices", func() {
+	It("sets --enable-services on the manager container of the operator Deployment", func() {
+		objs := []unstructured.Unstructured{
+			operatorDeployment(map[string]interface{}{"name": ManagerContainerName}),
+		}
+
+		Expect(injectEnabledServices(objs, platformv1alpha1.EnabledServices{TAS: true, LMES: true})).To(Succeed())
+
+		containers, found, err := unstructured.NestedSlice(objs[0].Object, "spec", "template", "spec", "containers")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(containers).To(HaveLen(1))
+
+		container, ok := containers[0].(map[string]interface{})
+		Expect(ok).To(BeTrue())
+		Expect(container["args"]).To(Equal([]interface{}{"--enable-services=TAS,LMES"}))
+	})
+
+	It("ignores non-Deployment and non-matching-name objects", func() {
+		other := unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Service",
+			"metadata":   map[string]interface{}{"name": OperatorDeploymentName},
+		}}
+		objs := []unstructured.Unstructured{other}
+
+		Expect(injectEnabledServices(objs, platformv1alpha1.EnabledServices{TAS: true})).To(Succeed())
+		Expect(objs[0]).To(Equal(other))
+	})
+
+	It("leaves sidecar containers untouched", func() {
+		objs := []unstructured.Unstructured{
+			operatorDeployment(
+				map[string]interface{}{"name": "sidecar", "args": []interface{}{"--existing"}},
+				map[string]interface{}{"name": ManagerContainerName},
+			),
+		}
+
+		Expect(injectEnabledServices(objs, platformv1alpha1.EnabledServices{TAS: true})).To(Succeed())
+
+		containers, _, _ := unstructured.NestedSlice(objs[0].Object, "spec", "template", "spec", "containers")
+		sidecar := containers[0].(map[string]interface{})
+		manager := containers[1].(map[string]interface{})
+		Expect(sidecar["args"]).To(Equal([]interface{}{"--existing"}))
+		Expect(manager["args"]).To(Equal([]interface{}{"--enable-services=TAS"}))
+	})
+})

--- a/trustyai-operator-module/pkg/trustyaimodule/reconciler.go
+++ b/trustyai-operator-module/pkg/trustyaimodule/reconciler.go
@@ -243,6 +243,7 @@ func (r *TrustyAIModuleReconciler) handleRemoval(ctx context.Context, module *pl
 		conditions.WithReason("ModuleRemoved"),
 		conditions.WithMessage("Module is not deployed"),
 		conditions.WithObservedGeneration(module.Generation),
+		conditions.WithSeverity(common.ConditionSeverityInfo),
 	)
 
 	module.Status.Phase = common.PhaseNotReady
@@ -319,6 +320,7 @@ func (r *TrustyAIModuleReconciler) updateHealthStatus(ctx context.Context, modul
 			conditions.WithReason("FullyFunctional"),
 			conditions.WithMessage("All services are fully functional"),
 			conditions.WithObservedGeneration(module.Generation),
+			conditions.WithSeverity(common.ConditionSeverityInfo),
 		)
 	} else {
 		module.Status.Phase = common.PhaseNotReady
@@ -338,12 +340,14 @@ func (r *TrustyAIModuleReconciler) updateHealthStatus(ctx context.Context, modul
 				conditions.WithReason("PartialFunctionality"),
 				conditions.WithMessage("Some services are unavailable: %s", strings.Join(unhealthyReasons, "; ")),
 				conditions.WithObservedGeneration(module.Generation),
+				conditions.WithSeverity(common.ConditionSeverityInfo),
 			)
 		} else {
 			condMgr.MarkTrue(string(common.ConditionTypeDegraded),
 				conditions.WithReason("AllServicesUnhealthy"),
 				conditions.WithMessage("All services are unavailable: %s", strings.Join(unhealthyReasons, "; ")),
 				conditions.WithObservedGeneration(module.Generation),
+				conditions.WithSeverity(common.ConditionSeverityInfo),
 			)
 		}
 	}

--- a/trustyai-operator-module/pkg/trustyaimodule/reconciler.go
+++ b/trustyai-operator-module/pkg/trustyaimodule/reconciler.go
@@ -46,6 +46,7 @@ type TrustyAIModuleReconciler struct {
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch;update
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;patch
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete

--- a/trustyai-operator-module/pkg/trustyaimodule/reconciler.go
+++ b/trustyai-operator-module/pkg/trustyaimodule/reconciler.go
@@ -402,6 +402,15 @@ func (r *TrustyAIModuleReconciler) reconcileComponent(
 		return nil
 	}
 
+	if err := injectEnabledServices(objs, module.Spec.EnabledServices); err != nil {
+		condMgr.MarkFalse(string(common.ConditionTypeProvisioningSucceeded),
+			conditions.WithReason("RenderFailed"),
+			conditions.WithMessage("Failed to configure enabled services: %v", err),
+			conditions.WithObservedGeneration(module.Generation),
+		)
+		return err
+	}
+
 	if err := r.Deployer.Deploy(ctx, deploy.DeployInput{
 		Client:    r.Client,
 		Owner:     module,

--- a/trustyai-operator-module/pkg/trustyaimodule/reconciler.go
+++ b/trustyai-operator-module/pkg/trustyaimodule/reconciler.go
@@ -45,10 +45,10 @@ type TrustyAIModuleReconciler struct {
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheuses,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch;update
-// +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;patch
-// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;patch
-// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;patch
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;patch
+// +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;patch
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;patch
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;patch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;patch
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
 
 func (r *TrustyAIModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
Related to https://github.com/opendatahub-io/opendatahub-operator/pull/4051  PR fix                                                                                                    
  - **Missing `serviceaccounts` RBAC entirely.** The manager's `ServiceAccount` reconciliation had zero RBAC for the resource — not even `get`.
  Added `get;list;watch;patch`.                                                                                                                
  - **SSA requires the `create` verb, not just `patch`, when the target object doesn't exist yet.** On a completely fresh namespace (nothing   
  pre-adopted), Server-Side Apply against `services`, `serviceaccounts`, `deployments`, and `rolebindings` failed with `cannot create` even    
  though `patch` was already granted. Added `create` to all four.                                                                              
  - **`Ready` condition showing `Degraded`'s values instead of its own.** The shared `odh-platform-utilities` `conditions.Manager` treats any  
  dependent condition with `Status == False`/`Unknown` as "unhappy" (unless marked `Severity: Info`) and overwrites the happy (`Ready`)        
  condition with it. `Degraded` is inverted-polarity (`False` = healthy), so every healthy-case `MarkFalse(Degraded, "FullyFunctional")` call  
  was clobbering the correct `MarkTrue(Ready, "AllServicesHealthy")` set moments earlier in the same reconcile. Fixed by marking all `Degraded`
  transitions with `conditions.WithSeverity(common.ConditionSeverityInfo)`, matching the existing pattern already used for the optional KServe 
  dependency check.                                                                                                                                                                                                                                                              
  - **`spec.enabledServices` was never wired into the deployed operator's actual config.** It was only ever read to decide which per-service   
  Deployments to health-check — nothing set it on the deployed `trustyai-service-operator` workload itself. The manifests-template Deployment  
  has no `--enable-services` arg or `ENABLED_SERVICES` env var at all, so the underlying operator pod always crash-looped with `"please specify
  at least one service"`, regardless of the module CR's config — and since `enabledServices: {}` means zero health checkers run, the module    
  trivially reported `Ready=True` the entire time this was crash-looping. Fixed by injecting `--enable-services=<names>` onto the manager      
  container at render time; defaults to all five services when none are explicitly toggled (matches the pre-modular in-tree operator's own     
  default deployment args), since the platform side does not yet project per-service toggles onto this CR.                                     
                                                   

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The operator can now create the Kubernetes resources required to deploy and manage TrustyAI components, including services, service accounts, deployments, and role bindings.
  - Resource health conditions now include informational severity details for removed, fully healthy, partially healthy, and fully unhealthy states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->