### PR TITLE
fix(evalhub): pin RULER provider image digest

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -107,6 +107,13 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.evalhub-provider-ragas-image
+  - name: evalhub-provider-ruler-image
+    objref:
+      kind: ConfigMap
+      name: config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.evalhub-provider-ruler-image
   - name: lmes-pod-image
     objref:
       kind: ConfigMap

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -24,3 +24,4 @@ evalhub-provider-ibm-clear-image=quay.io/evalhub/community-ibm-clear:latest
 evalhub-provider-deepeval-image=quay.io/evalhub/community-deepeval:latest
 evalhub-provider-ragas-image=quay.io/evalhub/community-ragas:latest
 evalhub-provider-inspect-image=quay.io/evalhub/community-inspect:latest
+evalhub-provider-ruler-image=quay.io/evalhub/community-ruler@sha256:65459b3792cef0fd9d8fd42261dd2a60a0c68ecd67d1950885c32ecd33973bd2

--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -25,3 +25,4 @@ evalhub-provider-ibm-clear-image=quay.io/evalhub/community-ibm-clear:v0.5.0
 evalhub-provider-ragas-image=quay.io/evalhub/community-ragas:v0.5.0
 evalhub-provider-deepeval-image=quay.io/evalhub/community-deepeval:v0.5.0
 evalhub-provider-inspect-image=quay.io/evalhub/community-inspect:v0.5.2
+evalhub-provider-ruler-image=quay.io/evalhub/community-ruler@sha256:65459b3792cef0fd9d8fd42261dd2a60a0c68ecd67d1950885c32ecd33973bd2

--- a/config/overlays/rhoai/params.env
+++ b/config/overlays/rhoai/params.env
@@ -25,3 +25,4 @@ evalhub-provider-ibm-clear-image=quay.io/evalhub/community-ibm-clear:v0.5.0
 evalhub-provider-ragas-image=quay.io/evalhub/community-ragas:v0.5.0
 evalhub-provider-deepeval-image=quay.io/evalhub/community-deepeval:v0.5.0
 evalhub-provider-inspect-image=quay.io/evalhub/community-inspect:v0.5.2
+evalhub-provider-ruler-image=quay.io/evalhub/community-ruler@sha256:65459b3792cef0fd9d8fd42261dd2a60a0c68ecd67d1950885c32ecd33973bd2


### PR DESCRIPTION
## What and why

  Wire the RULER provider image into the TrustyAI Operator Kustomize
  configuration and pin it to the published image containing the runtime essay
  haystack download fix.

  This ensures RULER essay-based benchmarks can run through the TrustyAI
  deployment without requiring `PaulGrahamEssays.json` to be pre-bundled in the
  image.

  Image:

  `quay.io/evalhub/community-ruler@sha256:65459b3792cef0fd9d8fd42261dd2a60a0c68ecd67d1950885c32ecd33973bd2`

  Companion PR:

  - eval-hub-contrib#151:
    https://github.com/eval-hub/eval-hub-contrib/pull/151

  Refs: https://github.com/eval-hub/eval-hub/issues/941

  ## Type

  - [ ] feat
  - [x] fix
  - [ ] docs
  - [ ] refactor / chore
  - [ ] test / ci

  ## Testing

  - [ ] Tests added or updated
  - [x] Tested manually

  - Rendered the `odh` overlay successfully
  - Rendered the `rhoai` overlay successfully
  - Rendered the `odh-kueue` overlay successfully
  - Verified that `evalhub-provider-ruler-image` resolves to the pinned digest
  - Verified with `git diff --check`

  ## Breaking changes

  None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable container images for the EvalHub Inspect and Ruler providers.
  - Added support for deploying the Ruler provider in supported environments.
  - Provider images are pinned to specific versions or digests for consistent deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->